### PR TITLE
Fix numbered list and bullet point rendering

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -25,7 +25,9 @@ export function Editor() {
         placeholder: 'Start writing...'
       }),
       Markdown.configure({
-        html: false,
+        html: true,
+        tightLists: true,
+        bulletListMarker: '-',
         transformPastedText: true,
         transformCopiedText: true
       })

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -163,10 +163,21 @@
 
 .prose-editor li {
   margin-bottom: 0.25em;
+  display: list-item;
 }
 
 .prose-editor li p {
-  margin-bottom: 0.25em;
+  margin-bottom: 0;
+}
+
+.prose-editor li > p:only-child {
+  margin: 0;
+}
+
+/* Tight lists (no p tags or minimal margins) */
+.prose-editor ul.tight li p,
+.prose-editor ol.tight li p {
+  margin: 0;
 }
 
 .prose-editor blockquote {


### PR DESCRIPTION
## Summary
Fixes list rendering issues where markdown syntax was showing alongside styled list markers.

## Changes
- Enable `html: true` in tiptap-markdown config (was `false`)
- Add `tightLists: true` for proper list formatting
- Fix list item CSS to prevent duplicate markers
- Remove paragraph margins inside list items

## Testing
1. Create a numbered list: `1. First` `2. Second`
2. Create a bullet list: `- One` `- Two`
3. Verify no duplicate numbers or dashes appear

Closes #2
Closes #3

🤖 Generated with [Claude Code](https://claude.ai/claude-code)