### PR TITLE
Add paragraph focus dimming to editor

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -4,6 +4,7 @@ import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import Link from '@tiptap/extension-link'
 import { Markdown } from 'tiptap-markdown'
+import { FocusMode } from '../../lib/focusMode'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
@@ -40,7 +41,8 @@ export function Editor() {
         bulletListMarker: '-',
         transformPastedText: true,
         transformCopiedText: true
-      })
+      }),
+      FocusMode
     ],
     content: document.content,
     editorProps: {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -237,6 +237,17 @@
   outline-offset: 2px;
 }
 
+/* Focus mode - paragraph dimming */
+.prose-editor .focus-dimmed {
+  opacity: 0.4;
+  transition: opacity 0.15s ease-out;
+}
+
+.prose-editor .focus-active {
+  opacity: 1;
+  transition: opacity 0.15s ease-out;
+}
+
 /* Selection */
 ::selection {
   background: hsl(var(--primary) / 0.2);

--- a/src/renderer/lib/focusMode.ts
+++ b/src/renderer/lib/focusMode.ts
@@ -1,0 +1,50 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+const focusModePluginKey = new PluginKey('focusMode')
+
+export const FocusMode = Extension.create({
+  name: 'focusMode',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: focusModePluginKey,
+        props: {
+          decorations: (state) => {
+            const { doc, selection } = state
+            const decorations: Decoration[] = []
+
+            // Find the paragraph containing the cursor
+            const $pos = selection.$head
+            let activeNodePos: number | null = null
+
+            // Walk up to find the nearest block node (paragraph, heading, etc.)
+            for (let depth = $pos.depth; depth >= 0; depth--) {
+              const node = $pos.node(depth)
+              if (node.isBlock && (node.type.name === 'paragraph' || node.type.name === 'heading' || node.type.name === 'blockquote' || node.type.name === 'listItem')) {
+                activeNodePos = $pos.before(depth)
+                break
+              }
+            }
+
+            // Add decorations to all block nodes
+            doc.descendants((node, pos) => {
+              if (node.isBlock && (node.type.name === 'paragraph' || node.type.name === 'heading' || node.type.name === 'blockquote' || node.type.name === 'listItem')) {
+                const isActive = pos === activeNodePos
+                decorations.push(
+                  Decoration.node(pos, pos + node.nodeSize, {
+                    class: isActive ? 'focus-active' : 'focus-dimmed'
+                  })
+                )
+              }
+            })
+
+            return DecorationSet.create(doc, decorations)
+          }
+        }
+      })
+    ]
+  }
+})


### PR DESCRIPTION
## Summary
- Adds always-on focus mode that dims non-active paragraphs
- Uses ProseMirror decorations via custom TipTap extension
- Applies to paragraphs, headings, blockquotes, and list items

## Test plan
- [ ] Open the editor with some multi-paragraph content
- [ ] Click/cursor into different paragraphs
- [ ] Verify the current paragraph stays at full opacity (1.0)
- [ ] Verify other paragraphs are dimmed (0.4 opacity)
- [ ] Verify smooth transition when moving between paragraphs
- [ ] Test with headings, blockquotes, and list items

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)