### PR TITLE
Add aria-labels to icon buttons for accessibility

### DIFF
--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -57,6 +57,7 @@ export function ChatInput({ onSend, isLoading }: ChatInputProps) {
               size="icon"
               className="h-6 w-6 shrink-0"
               onClick={() => setContext(null)}
+              aria-label="Clear context"
             >
               <X className="h-3 w-3" />
             </Button>
@@ -79,6 +80,7 @@ export function ChatInput({ onSend, isLoading }: ChatInputProps) {
           onClick={handleSubmit}
           disabled={!message.trim() || isLoading}
           className="shrink-0"
+          aria-label="Send message"
         >
           <Send className="h-4 w-4" />
         </Button>

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -31,7 +31,7 @@ export function ChatPanel() {
             size="icon"
             className="h-8 w-8"
             onClick={clearMessages}
-            title="Clear chat"
+            aria-label="Clear chat"
           >
             <Trash2 className="h-4 w-4" />
           </Button>

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -55,7 +55,7 @@ export function Toolbar() {
       <div className="flex items-center gap-1 app-region-no-drag">
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={toggleTheme}>
+            <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
               {settings.theme === 'dark' ? (
                 <Sun className="h-4 w-4" />
               ) : (
@@ -68,7 +68,7 @@ export function Toolbar() {
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={togglePanel}>
+            <Button variant="ghost" size="icon" onClick={togglePanel} aria-label={isPanelOpen ? 'Hide chat' : 'Show chat'}>
               {isPanelOpen ? (
                 <PanelRightClose className="h-4 w-4" />
               ) : (
@@ -83,7 +83,7 @@ export function Toolbar() {
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" aria-label="More options">
               <MoreHorizontal className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
- Adds aria-label attributes to all icon-only buttons for screen reader accessibility
- Toolbar: theme toggle, chat panel toggle, more options menu
- ChatPanel: clear chat button  
- ChatInput: clear context button, send message button

## Test plan
- [ ] Inspect buttons in browser dev tools to verify aria-label attributes are present
- [ ] Test with screen reader (VoiceOver on Mac) to verify labels are announced

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)