### PR TITLE
Fix ResizablePanelGroup layout warnings

### DIFF
--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -54,20 +54,19 @@ export function App() {
         <Toolbar />
 
         <div className="flex-1 overflow-hidden">
-          <ResizablePanelGroup direction="horizontal">
-            <ResizablePanel defaultSize={70} minSize={40}>
-              <Editor />
-            </ResizablePanel>
-
-            {isPanelOpen && (
-              <>
-                <ResizableHandle />
-                <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
-                  <ChatPanel />
-                </ResizablePanel>
-              </>
-            )}
-          </ResizablePanelGroup>
+          {isPanelOpen ? (
+            <ResizablePanelGroup direction="horizontal">
+              <ResizablePanel defaultSize={70} minSize={40}>
+                <Editor />
+              </ResizablePanel>
+              <ResizableHandle />
+              <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
+                <ChatPanel />
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          ) : (
+            <Editor />
+          )}
         </div>
 
         <StatusBar />


### PR DESCRIPTION
## Summary
- Renders Editor directly when chat panel is closed instead of using ResizablePanelGroup with a single panel
- Avoids console warnings about panel sizes not summing to 100%

## Test plan
- [ ] Open browser console and toggle chat panel on/off
- [ ] Verify no console warnings about panel layout or sizes
- [ ] Verify editor takes full width when chat is closed
- [ ] Verify resizable behavior works correctly when chat is open

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)