### PR TITLE
fix(chat): remove double response UI during loading (#15)

### DIFF
--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -70,15 +70,6 @@ export function useChat() {
         timestamp: new Date()
       })
 
-      // Create assistant message placeholder
-      const assistantMsgId = createMessageId()
-      addMessage({
-        id: assistantMsgId,
-        role: 'assistant',
-        content: '',
-        timestamp: new Date()
-      })
-
       setLoading(true)
 
       try {
@@ -102,13 +93,25 @@ export function useChat() {
           system: buildSystemPrompt(includeDocument, document.content)
         })
 
-        updateMessage(assistantMsgId, { content: response.content })
+        // Add assistant message with the response
+        const assistantMsgId = createMessageId()
+        addMessage({
+          id: assistantMsgId,
+          role: 'assistant',
+          content: response.content,
+          timestamp: new Date()
+        })
       } catch (error) {
         console.error('[Chat] Error:', error)
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error'
-        updateMessage(assistantMsgId, {
-          content: `Error: ${errorMessage}. Please check your API key in Settings (Cmd+,).`
+        // Add error message as assistant response
+        const errorMsgId = createMessageId()
+        addMessage({
+          id: errorMsgId,
+          role: 'assistant',
+          content: `Error: ${errorMessage}. Please check your API key in Settings (Cmd+,).`,
+          timestamp: new Date()
         })
       } finally {
         setLoading(false)
@@ -125,7 +128,6 @@ export function useChat() {
       activeConversationId,
       addConversation,
       addMessage,
-      updateMessage,
       setLoading,
       setContext
     ]


### PR DESCRIPTION
## Summary
- Fixes the double response UI that appeared during chat loading
- Previously, an empty assistant message placeholder was rendered alongside the "Thinking..." indicator, creating a duplicate visual response
- Now the assistant message is only added after the API response is received

## Changes
- Removed pre-emptive empty placeholder message creation before API call
- Moved assistant message creation to after API response
- Updated error handling to use `addMessage` instead of `updateMessage`