### PR TITLE
feat: register as default app for .md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
+electron-screenshot-*.jpeg

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,30 @@
+appId: com.prose.app
+productName: Prose
+directories:
+  buildResources: build
+  output: dist
+
+files:
+  - out/**/*
+
+fileAssociations:
+  - ext: md
+    name: Markdown
+    description: Markdown document
+    role: Editor
+
+mac:
+  category: public.app-category.productivity
+  target:
+    - dmg
+    - dir
+  entitlementsInherit: build/entitlements.mac.plist
+
+win:
+  target:
+    - nsis
+
+linux:
+  target:
+    - AppImage
+  category: Office

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,33 @@ if (is.dev) {
   app.commandLine.appendSwitch('remote-debugging-port', '9222')
 }
 
+// Track file path to open (from command line or open-file event)
+let fileToOpen: string | null = null
+
+// Handle file open from macOS Finder (before app is ready)
+app.on('open-file', (event, path) => {
+  event.preventDefault()
+  fileToOpen = path
+
+  // If app is already running, send to renderer
+  const mainWindow = BrowserWindow.getAllWindows()[0]
+  if (mainWindow) {
+    mainWindow.webContents.send('file:openExternal', path)
+  }
+})
+
+// Check command line args for file path (Windows/Linux)
+function getFileFromArgs(): string | null {
+  // Skip electron executable and script path in dev, or just app path in prod
+  const args = process.argv.slice(is.dev ? 2 : 1)
+  for (const arg of args) {
+    if (arg.endsWith('.md') && !arg.startsWith('-')) {
+      return arg
+    }
+  }
+  return null
+}
+
 function createWindow(): BrowserWindow {
   const mainWindow = new BrowserWindow({
     width: 1200,
@@ -52,9 +79,21 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
+  // Check for file from command line args (Windows/Linux)
+  if (!fileToOpen) {
+    fileToOpen = getFileFromArgs()
+  }
+
   const mainWindow = createWindow()
   setupIpcHandlers()
   createMenu(mainWindow)
+
+  // Send file to renderer once loaded
+  if (fileToOpen) {
+    mainWindow.webContents.once('did-finish-load', () => {
+      mainWindow.webContents.send('file:openExternal', fileToOpen)
+    })
+  }
 
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -32,6 +32,7 @@ export interface ElectronAPI {
   loadSettings: () => Promise<Settings>
   saveSettings: (settings: Settings) => Promise<void>
   onMenuAction: (callback: (action: string) => void) => () => void
+  onFileOpenExternal: (callback: (path: string) => void) => () => void
   llmChat: (request: LLMRequest) => Promise<LLMResponse>
   platform: 'aix' | 'darwin' | 'freebsd' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'android' | 'cygwin' | 'netbsd'
 }
@@ -50,6 +51,15 @@ const api: ElectronAPI = {
     ipcRenderer.on('menu:action', handler)
     return () => {
       ipcRenderer.removeListener('menu:action', handler)
+    }
+  },
+  onFileOpenExternal: (callback: (path: string) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, path: string): void => {
+      callback(path)
+    }
+    ipcRenderer.on('file:openExternal', handler)
+    return () => {
+      ipcRenderer.removeListener('file:openExternal', handler)
     }
   },
   llmChat: (request: LLMRequest) => ipcRenderer.invoke('llm:chat', request),

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -27,7 +27,7 @@ import type { DraftState } from '../../lib/persistence'
 
 export function App() {
   const { isPanelOpen, togglePanel } = useChat()
-  const { openFile, saveFile, saveFileAs, newFile } = useEditor()
+  const { openFile, openFileFromPath, saveFile, saveFileAs, newFile } = useEditor()
   const { setDialogOpen, isShortcutsDialogOpen, setShortcutsDialogOpen, settings, isLoaded: settingsLoaded } = useSettings()
   const [recoveryDialogOpen, setRecoveryDialogOpen] = useState(false)
   const [pendingDraft, setPendingDraft] = useState<DraftState | null>(null)
@@ -144,6 +144,15 @@ export function App() {
 
     return unsubscribe
   }, [openFile, saveFile, saveFileAs, newFile, setDialogOpen, togglePanel])
+
+  // Handle file open from OS (double-click .md file)
+  useEffect(() => {
+    if (!window.api) return
+    const unsubscribe = window.api.onFileOpenExternal((path) => {
+      openFileFromPath(path)
+    })
+    return unsubscribe
+  }, [openFileFromPath])
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -40,6 +40,35 @@ export function useEditor() {
     setActiveChatId(activeConversationId)
   }, [activeConversationId, setActiveChatId])
 
+  const openFileFromPath = useCallback(async (filePath: string) => {
+    if (!window.api) return
+
+    // Save current conversations before switching
+    await saveCurrentConversation(document.documentId)
+
+    try {
+      const content = await window.api.readFile(filePath)
+      const parsed = parseMarkdown(content)
+      const newDocumentId = await generateIdFromPath(filePath)
+
+      setDocument({
+        documentId: newDocumentId,
+        path: filePath,
+        content: parsed.content,
+        frontmatter: parsed.frontmatter,
+        isDirty: false
+      })
+
+      // Load conversations for the document
+      await loadForDocument(newDocumentId)
+
+      // Clear draft since we opened a file
+      await clearDraft()
+    } catch (error) {
+      console.error('Failed to open file:', error)
+    }
+  }, [setDocument, document.documentId, saveCurrentConversation, loadForDocument])
+
   const openFile = useCallback(async () => {
     if (!window.api) return
 
@@ -146,6 +175,7 @@ export function useEditor() {
     setFrontmatter,
     setCursorPosition,
     openFile,
+    openFileFromPath,
     saveFile,
     saveFileAs,
     newFile

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -151,6 +151,11 @@ export const browserApi: ElectronAPI = {
     return () => {}
   },
 
+  onFileOpenExternal: (_callback: (path: string) => void) => {
+    // No external file open in browser mode
+    return () => {}
+  },
+
   llmChat: async (request: LLMRequest): Promise<LLMResponse> => {
     let model
     switch (request.provider) {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -67,6 +67,7 @@ export interface ElectronAPI {
   loadSettings: () => Promise<Settings>
   saveSettings: (settings: Settings) => Promise<void>
   onMenuAction: (callback: (action: string) => void) => () => void
+  onFileOpenExternal: (callback: (path: string) => void) => () => void
   llmChat: (request: LLMRequest) => Promise<LLMResponse>
   platform: 'aix' | 'darwin' | 'freebsd' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'android' | 'cygwin' | 'netbsd' | null
 }


### PR DESCRIPTION
## Summary
- Add file association for Markdown files so Prose can be set as the default editor
- Handle macOS `open-file` events and Windows/Linux command line args
- Create `electron-builder.yml` with fileAssociations config

## Test plan
- [ ] Build the macOS app with `npm run build:mac`
- [ ] Right-click a `.md` file → "Open With" → choose Prose
- [ ] Set Prose as default app for `.md` files
- [ ] Double-click a `.md` file, verify it opens in Prose
- [ ] Open a second `.md` file while Prose is already running

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)