### PR TITLE
feat(editor): quick title edit and save with default locations

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,5 +1,5 @@
-import { ipcMain, dialog } from 'electron'
-import { readFile, writeFile, mkdir } from 'fs/promises'
+import { ipcMain, dialog, app, shell } from 'electron'
+import { readFile, writeFile, mkdir, access, rename, unlink } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 import type { Settings } from '../renderer/types'
@@ -90,6 +90,61 @@ export function setupIpcHandlers(): void {
 
     await writeFile(result.filePath, content, 'utf-8')
     return result.filePath
+  })
+
+  // File: Select folder dialog
+  ipcMain.handle('file:selectFolder', async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openDirectory']
+    })
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return null
+    }
+
+    return result.filePaths[0]
+  })
+
+  // File: Save to folder with filename
+  ipcMain.handle(
+    'file:saveToFolder',
+    async (_event, folder: string, filename: string, content: string) => {
+      // Ensure .md extension
+      const finalFilename = filename.endsWith('.md') ? filename : `${filename}.md`
+      const fullPath = join(folder, finalFilename)
+      await writeFile(fullPath, content, 'utf-8')
+      return fullPath
+    }
+  )
+
+  // File: Get Documents path
+  ipcMain.handle('file:documentsPath', async () => {
+    return app.getPath('documents')
+  })
+
+  // File: Check if file exists
+  ipcMain.handle('file:exists', async (_event, path: string) => {
+    try {
+      await access(path)
+      return true
+    } catch {
+      return false
+    }
+  })
+
+  // File: Show in folder (Finder on macOS)
+  ipcMain.handle('file:showInFolder', async (_event, path: string) => {
+    shell.showItemInFolder(path)
+  })
+
+  // File: Rename file
+  ipcMain.handle('file:rename', async (_event, oldPath: string, newPath: string) => {
+    await rename(oldPath, newPath)
+  })
+
+  // File: Delete file
+  ipcMain.handle('file:delete', async (_event, path: string) => {
+    await unlink(path)
   })
 
   // Settings: Load from ~/.prose/settings.json

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,6 +60,14 @@ export interface ElectronAPI {
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => () => void
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => () => void
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
+  // Folder operations for quick save
+  selectFolder: () => Promise<string | null>
+  saveToFolder: (folder: string, filename: string, content: string) => Promise<string>
+  getDocumentsPath: () => Promise<string>
+  fileExists: (path: string) => Promise<boolean>
+  showInFolder: (path: string) => Promise<void>
+  renameFile: (oldPath: string, newPath: string) => Promise<void>
+  deleteFile: (path: string) => Promise<void>
 }
 
 const api: ElectronAPI = {
@@ -92,6 +100,15 @@ const api: ElectronAPI = {
   // Streaming LLM
   llmChatStream: (request: LLMStreamRequest) => ipcRenderer.invoke('llm:stream', request),
   llmAbortStream: (streamId: string) => ipcRenderer.invoke('llm:stream:abort', streamId),
+  // Folder operations for quick save
+  selectFolder: () => ipcRenderer.invoke('file:selectFolder'),
+  saveToFolder: (folder: string, filename: string, content: string) =>
+    ipcRenderer.invoke('file:saveToFolder', folder, filename, content),
+  getDocumentsPath: () => ipcRenderer.invoke('file:documentsPath'),
+  fileExists: (path: string) => ipcRenderer.invoke('file:exists', path),
+  showInFolder: (path: string) => ipcRenderer.invoke('file:showInFolder', path),
+  renameFile: (oldPath: string, newPath: string) => ipcRenderer.invoke('file:rename', oldPath, newPath),
+  deleteFile: (path: string) => ipcRenderer.invoke('file:delete', path),
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, chunk: LLMStreamChunk): void => {
       callback(chunk)

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -1,8 +1,10 @@
+import { useState, useRef, useEffect, type KeyboardEvent } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
 import { isMacOS } from '../../lib/browserApi'
 import { Button } from '../ui/button'
+import { Input } from '../ui/input'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,16 +28,64 @@ import {
 } from 'lucide-react'
 
 export function Toolbar() {
-  const { document, openFile, saveFile, newFile } = useEditor()
+  const { document, openFile, saveFile, newFile, quickSaveWithTitle } = useEditor()
   const { settings, setTheme, setDialogOpen } = useSettings()
   const { isPanelOpen, togglePanel, sendMessage } = useChat()
 
-  const fileName = document.path
-    ? document.path.split('/').pop()
-    : 'Untitled'
+  const [isEditingTitle, setIsEditingTitle] = useState(false)
+  const [editedTitle, setEditedTitle] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Extract filename and extension
+  const fullFileName = document.path?.split('/').pop() || ''
+  const hasExtension = fullFileName.includes('.')
+  const fileName = hasExtension
+    ? fullFileName.substring(0, fullFileName.lastIndexOf('.'))
+    : fullFileName || 'Untitled'
+  const fileExtension = hasExtension
+    ? fullFileName.substring(fullFileName.lastIndexOf('.'))
+    : '.md'
+
+  const handleIconClick = () => {
+    if (document.path && window.api) {
+      window.api.showInFolder(document.path)
+    }
+  }
 
   const toggleTheme = () => {
     setTheme(settings.theme === 'dark' ? 'light' : 'dark')
+  }
+
+  const handleTitleDoubleClick = () => {
+    setEditedTitle(fileName)
+    setIsEditingTitle(true)
+  }
+
+  useEffect(() => {
+    if (isEditingTitle && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditingTitle])
+
+  const handleTitleKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (editedTitle.trim()) {
+        const success = await quickSaveWithTitle(editedTitle.trim())
+        if (success) {
+          setIsEditingTitle(false)
+        }
+      } else {
+        setIsEditingTitle(false)
+      }
+    } else if (e.key === 'Escape') {
+      setIsEditingTitle(false)
+    }
+  }
+
+  const handleTitleBlur = () => {
+    setIsEditingTitle(false)
   }
 
   // Add left padding on macOS to clear traffic lights
@@ -45,11 +95,45 @@ export function Toolbar() {
     <div className={`flex h-12 items-center justify-between border-b border-border bg-background pr-4 ${leftPadding} app-region-drag`}>
       {/* Left: File info */}
       <div className="flex items-center gap-2 app-region-no-drag">
-        <FileText className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm font-medium">
-          {fileName}
-          {document.isDirty && <span className="text-muted-foreground"> *</span>}
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={handleIconClick}
+              disabled={!document.path}
+              className={`p-0.5 rounded ${document.path ? 'cursor-pointer hover:bg-accent' : 'cursor-default'}`}
+              aria-label={document.path ? 'Reveal in Finder' : 'File not saved'}
+            >
+              <FileText className="h-4 w-4 text-muted-foreground" />
+            </button>
+          </TooltipTrigger>
+          {document.path && <TooltipContent>Reveal in Finder</TooltipContent>}
+        </Tooltip>
+        <div className="flex items-center">
+          {isEditingTitle ? (
+            <>
+              <Input
+                ref={inputRef}
+                type="text"
+                value={editedTitle}
+                onChange={(e) => setEditedTitle(e.target.value)}
+                onKeyDown={handleTitleKeyDown}
+                onBlur={handleTitleBlur}
+                className="h-7 w-40 text-sm font-medium"
+              />
+              <span className="text-sm text-muted-foreground">{fileExtension}</span>
+            </>
+          ) : (
+            <span
+              className="text-sm font-medium cursor-pointer hover:text-primary transition-colors"
+              onDoubleClick={handleTitleDoubleClick}
+              title="Double-click to rename and save"
+            >
+              {fileName}
+              <span className="text-muted-foreground">{fileExtension}</span>
+              {document.isDirty && <span className="text-muted-foreground"> *</span>}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Center: Spacer for draggable area */}

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -29,6 +29,7 @@ export function SettingsDialog() {
     setLLMConfig,
     setEditorConfig,
     setRecoveryConfig,
+    setDefaultSaveDirectory,
     saveSettings
   } = useSettings()
 
@@ -90,6 +91,33 @@ export function SettingsDialog() {
               </Select>
               <p className="text-xs text-muted-foreground">
                 Choose how to handle unsaved work when the app restarts
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="defaultSaveDirectory">Default Save Location</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="defaultSaveDirectory"
+                  value={settings.defaultSaveDirectory || ''}
+                  onChange={(e) => setDefaultSaveDirectory(e.target.value)}
+                  placeholder="~/Documents"
+                  className="flex-1"
+                />
+                <Button
+                  variant="outline"
+                  onClick={async () => {
+                    const folder = await window.api?.selectFolder()
+                    if (folder) {
+                      setDefaultSaveDirectory(folder)
+                    }
+                  }}
+                >
+                  Browse...
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Where new documents are saved when you quick-save from the title bar
               </p>
             </div>
           </TabsContent>

--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import { useEditorStore } from '../stores/editorStore'
 import { useChatStore, setCurrentDocumentId } from '../stores/chatStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import { parseMarkdown, serializeMarkdown } from '../lib/markdown'
 import {
   generateId,
@@ -8,6 +9,11 @@ import {
   clearDraft,
   saveConversations
 } from '../lib/persistence'
+
+// Sanitize filename by removing invalid characters
+function sanitizeFilename(name: string): string {
+  return name.replace(/[/\\:*?"<>|]/g, '-').trim()
+}
 
 export function useEditor() {
   const {
@@ -185,6 +191,93 @@ export function useEditor() {
     })
   }, [resetDocument, document.documentId, saveCurrentConversation])
 
+  const quickSaveWithTitle = useCallback(async (title: string): Promise<boolean> => {
+    if (!window.api) return false
+
+    const sanitizedTitle = sanitizeFilename(title)
+    if (!sanitizedTitle) return false
+
+    const content = serializeMarkdown(document.content, document.frontmatter)
+    const settings = useSettingsStore.getState().settings
+    const filename = sanitizedTitle.endsWith('.md') ? sanitizedTitle : `${sanitizedTitle}.md`
+
+    let targetFolder: string
+    let newPath: string
+    let isRename = false
+    const oldPath = document.path
+
+    if (oldPath) {
+      // Existing file: check if we're renaming or just saving
+      const lastSlash = oldPath.lastIndexOf('/')
+      targetFolder = oldPath.substring(0, lastSlash)
+      newPath = `${targetFolder}/${filename}`
+
+      // Check if the name is actually changing
+      isRename = oldPath !== newPath
+    } else {
+      // New file: use default save directory or Documents
+      targetFolder = settings.defaultSaveDirectory || await window.api.getDocumentsPath()
+      newPath = `${targetFolder}/${filename}`
+    }
+
+    // For new files or renames to a different name, check for duplicates
+    // Skip duplicate check if we're just saving to the same path
+    let finalPath = newPath
+    if (!oldPath || isRename) {
+      let counter = 1
+      while (await window.api.fileExists(finalPath)) {
+        // If renaming to a path that already exists (and it's not the current file)
+        if (isRename && finalPath === oldPath) {
+          // We're "renaming" to the same name, just save in place
+          break
+        }
+        const baseName = sanitizedTitle.replace(/\.md$/, '')
+        finalPath = `${targetFolder}/${baseName} (${counter}).md`
+        counter++
+        if (counter > 100) {
+          console.error('Too many duplicate files')
+          return false
+        }
+      }
+    }
+
+    try {
+      if (isRename && oldPath) {
+        // Rename the file: save new content to new path, then delete old file
+        await window.api.saveFile(finalPath, content)
+        await window.api.deleteFile(oldPath)
+      } else {
+        // New file or same name: just save
+        await window.api.saveFile(finalPath, content)
+      }
+
+      // Migrate chat history to path-based ID
+      const newDocumentId = await generateIdFromPath(finalPath)
+      const conversations = useChatStore.getState().conversations
+
+      if (conversations.length > 0) {
+        const migratedConversations = conversations.map((c) => ({
+          ...c,
+          documentId: newDocumentId
+        }))
+        await saveConversations(newDocumentId, migratedConversations)
+        useChatStore.setState({ conversations: migratedConversations })
+      }
+
+      setDocument({ documentId: newDocumentId, path: finalPath })
+      setDirty(false)
+      setCurrentDocumentId(newDocumentId)
+
+      // Clear draft since we saved
+      await clearDraft()
+
+      return true
+    } catch (error) {
+      console.error('Failed to quick save:', error)
+      return false
+    }
+  }, [document, setDocument, setDirty])
+
   return {
     document,
     cursorPosition,
@@ -195,6 +288,7 @@ export function useEditor() {
     openFileFromPath,
     saveFile,
     saveFileAs,
-    newFile
+    newFile,
+    quickSaveWithTitle
   }
 }

--- a/src/renderer/hooks/useSettings.ts
+++ b/src/renderer/hooks/useSettings.ts
@@ -17,7 +17,8 @@ export function useSettings() {
     setTheme,
     setLLMConfig,
     setEditorConfig,
-    setRecoveryConfig
+    setRecoveryConfig,
+    setDefaultSaveDirectory
   } = useSettingsStore()
 
   useEffect(() => {
@@ -40,6 +41,7 @@ export function useSettings() {
     setTheme,
     setLLMConfig,
     setEditorConfig,
-    setRecoveryConfig
+    setRecoveryConfig,
+    setDefaultSaveDirectory
   }
 }

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -331,6 +331,42 @@ export const browserApi: ElectronAPI = {
     return { success: false }
   },
 
+  // Folder operations - limited in browser mode
+  selectFolder: async (): Promise<string | null> => {
+    // Not supported in browser
+    return null
+  },
+
+  saveToFolder: async (_folder: string, filename: string, content: string): Promise<string> => {
+    // Fall back to download
+    await browserApi.saveFile(filename, content)
+    return filename
+  },
+
+  getDocumentsPath: async (): Promise<string> => {
+    // Return placeholder - browser can't access filesystem
+    return '~/Documents'
+  },
+
+  fileExists: async (_path: string): Promise<boolean> => {
+    // Can't check in browser mode
+    return false
+  },
+
+  showInFolder: async (_path: string): Promise<void> => {
+    // Can't reveal in folder in browser mode
+  },
+
+  renameFile: async (_oldPath: string, _newPath: string): Promise<void> => {
+    // Can't rename files in browser mode
+    throw new Error('Cannot rename files in browser mode')
+  },
+
+  deleteFile: async (_path: string): Promise<void> => {
+    // Can't delete files in browser mode
+    throw new Error('Cannot delete files in browser mode')
+  },
+
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => {
     const handler = (e: Event) => callback((e as CustomEvent).detail)
     window.addEventListener('llm:stream:chunk', handler)

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -17,6 +17,7 @@ interface SettingsState {
   setLLMConfig: (config: Partial<Settings['llm']>) => void
   setEditorConfig: (config: Partial<Settings['editor']>) => void
   setRecoveryConfig: (config: Partial<NonNullable<Settings['recovery']>>) => void
+  setDefaultSaveDirectory: (path: string) => void
 }
 
 const defaultSettings: Settings = {
@@ -121,5 +122,10 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         ...state.settings,
         recovery: { ...state.settings.recovery, ...config }
       }
+    })),
+
+  setDefaultSaveDirectory: (path) =>
+    set((state) => ({
+      settings: { ...state.settings, defaultSaveDirectory: path }
     }))
 }))

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -18,6 +18,7 @@ export interface Settings {
   recovery?: {
     mode: 'silent' | 'prompt'
   }
+  defaultSaveDirectory?: string
 }
 
 export interface Document {
@@ -97,6 +98,16 @@ export interface ElectronAPI {
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => () => void
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => () => void
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
+  // Folder operations for quick save
+  selectFolder: () => Promise<string | null>
+  saveToFolder: (folder: string, filename: string, content: string) => Promise<string>
+  getDocumentsPath: () => Promise<string>
+  fileExists: (path: string) => Promise<boolean>
+  // File reveal
+  showInFolder: (path: string) => Promise<void>
+  // File rename/delete
+  renameFile: (oldPath: string, newPath: string) => Promise<void>
+  deleteFile: (path: string) => Promise<void>
 }
 
 declare global {


### PR DESCRIPTION
## Summary

- Double-click document title in toolbar to edit inline
- Press Enter to save with new name, Escape to cancel
- New files save to configurable default directory (Documents by default)
- Existing files are properly renamed (not duplicated)
- Click file icon to reveal file in Finder
- Shows file extension separately after editable filename

## Changes

- **Toolbar.tsx**: Inline title editing UI with separate extension display, clickable icon
- **useEditor.ts**: `quickSaveWithTitle()` with proper rename logic and auto-increment for duplicates
- **SettingsDialog.tsx**: Default Save Location setting in General tab
- **ipc.ts**: New handlers for `file:rename`, `file:delete`, `file:selectFolder`, `file:showInFolder`
- **Types/preload/browserApi**: Updated for new IPC methods

## Test plan

- [ ] Double-click "Untitled" → type name → Enter → creates file in Documents
- [ ] Open existing file → double-click title → rename → Enter → old file deleted, new file created
- [ ] Click file icon → reveals file in Finder
- [ ] Settings → General → change Default Save Location → new files save there
- [ ] Extension shown separately (e.g., `myfile.md` shows as `myfile` + `.md`)

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)