### PR TITLE
feat(chat): change Enter to send, Shift+Enter for new line

### DIFF
--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -59,8 +59,8 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    // Cmd+Enter or Ctrl+Enter to send
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    // Enter to send, Shift+Enter for new line
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       handleSubmit()
     }
@@ -173,7 +173,7 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
         </div>
         <p className="text-xs text-muted-foreground">
           <kbd className="rounded bg-muted px-1 py-0.5 text-[10px] font-medium">
-            ⌘↵
+            ↵
           </kbd>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Changed chat input to send messages with Enter (previously Cmd/Ctrl+Enter)
- Shift+Enter now adds a new line
- Updated keyboard shortcut hint in UI from ⌘↵ to ↵

This matches the common chat UX pattern used in apps like Slack.

---
Slack thread: https://soloist-hq.slack.com/archives/C0A641EEM3R/p1767423114121499
