### PR TITLE
fix(ui): enforce proper sidebar resize minimum limit

### DIFF
--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -193,11 +193,11 @@ export function App() {
         <div className="flex-1 overflow-hidden">
           {isPanelOpen ? (
             <ResizablePanelGroup direction="horizontal">
-              <ResizablePanel defaultSize={70} minSize={40}>
+              <ResizablePanel defaultSize={70} minSize={40} maxSize={75}>
                 <Editor />
               </ResizablePanel>
               <ResizableHandle />
-              <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
+              <ResizablePanel defaultSize={30} minSize={25} maxSize={50}>
                 <ChatPanel />
               </ResizablePanel>
             </ResizablePanelGroup>


### PR DESCRIPTION
## Summary
- Increase chat panel minimum size from 20% to 25% to prevent resizing beyond a usable width
- Add `maxSize={75}` to editor panel for proper constraint enforcement with react-resizable-panels

## Test plan
- [ ] Open the app with the chat panel visible
- [ ] Drag the resize handle to make the chat panel as narrow as possible
- [ ] Verify the chat panel stops at 25% width (cannot go smaller)
- [ ] Verify the editor panel stops at 75% width (cannot go larger)

---

Slack thread: https://soloist-hq.slack.com/archives/C0A641EEM3R/p1767422901192149
