### PR TITLE
fix(editor): wire redo shortcut to TipTap history

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -74,8 +74,20 @@ export function createMenu(mainWindow: BrowserWindow): void {
     {
       label: 'Edit',
       submenu: [
-        { role: 'undo' },
-        { role: 'redo' },
+        {
+          label: 'Undo',
+          accelerator: 'CmdOrCtrl+Z',
+          click: (): void => {
+            mainWindow.webContents.send('menu:action', 'undo')
+          }
+        },
+        {
+          label: 'Redo',
+          accelerator: isMac ? 'Cmd+Shift+Z' : 'Ctrl+Y',
+          click: (): void => {
+            mainWindow.webContents.send('menu:action', 'redo')
+          }
+        },
         { type: 'separator' },
         { role: 'cut' },
         { role: 'copy' },

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -17,6 +17,7 @@ import { useChat } from '../../hooks/useChat'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useEditorStore } from '../../stores/editorStore'
+import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useChatStore, setCurrentDocumentId } from '../../stores/chatStore'
 import {
   loadDraft,
@@ -36,6 +37,7 @@ export function App() {
   const hydrateFromDraft = useEditorStore((state) => state.hydrateFromDraft)
   const documentPath = useEditorStore((state) => state.document.path)
   const isDirty = useEditorStore((state) => state.document.isDirty)
+  const editor = useEditorInstanceStore((state) => state.editor)
 
   // Update window title based on document state
   useEffect(() => {
@@ -168,11 +170,17 @@ export function App() {
         case 'about':
           setAboutDialogOpen(true)
           break
+        case 'undo':
+          editor?.commands.undo()
+          break
+        case 'redo':
+          editor?.commands.redo()
+          break
       }
     })
 
     return unsubscribe
-  }, [openFile, saveFile, saveFileAs, newFile, setDialogOpen, togglePanel, setShortcutsDialogOpen, setAboutDialogOpen, sendMessage])
+  }, [openFile, saveFile, saveFileAs, newFile, setDialogOpen, togglePanel, setShortcutsDialogOpen, setAboutDialogOpen, sendMessage, editor])
 
   // Handle file open from OS (double-click .md file)
   useEffect(() => {


### PR DESCRIPTION
Summary
Fixed redo shortcut (Cmd+Shift+Z / Ctrl+Y) not working in the editor
Replaced Electron's built-in { role: 'undo' } and { role: 'redo' } menu items with custom IPC-based handlers that call TipTap's history commands
Why
The native Electron redo role invokes the browser's contentEditable undo stack, but TipTap uses ProseMirror's own history extension. The two systems don't communicate, so the menu shortcut had no effect.

Test plan
 Open app, type some text
 Press Cmd+Z (Mac) / Ctrl+Z (Win/Linux) to undo - should work
 Press Cmd+Shift+Z (Mac) / Ctrl+Y (Win/Linux) to redo - should work
 Use Edit menu → Undo/Redo - should work
Slack thread: https://soloist-hq.slack.com/archives/C0A641EEM3R/p1767422061458679