### PR TITLE
 feat(ui): add Close option to app menu

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, app, shell } from 'electron'
+import { ipcMain, dialog, app, shell, BrowserWindow } from 'electron'
 import { readFile, writeFile, mkdir, access, rename, unlink } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
@@ -341,5 +341,17 @@ export function setupIpcHandlers(): void {
       return { success: true }
     }
     return { success: false }
+  })
+
+  // Window: Close window (macOS) or quit app (Windows/Linux)
+  ipcMain.handle('window:close', (event) => {
+    const window = BrowserWindow.fromWebContents(event.sender)
+    if (window) {
+      if (process.platform === 'darwin') {
+        window.close()
+      } else {
+        app.quit()
+      }
+    }
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,6 +68,8 @@ export interface ElectronAPI {
   showInFolder: (path: string) => Promise<void>
   renameFile: (oldPath: string, newPath: string) => Promise<void>
   deleteFile: (path: string) => Promise<void>
+  // Window operations
+  closeWindow: () => Promise<void>
 }
 
 const api: ElectronAPI = {
@@ -109,6 +111,7 @@ const api: ElectronAPI = {
   showInFolder: (path: string) => ipcRenderer.invoke('file:showInFolder', path),
   renameFile: (oldPath: string, newPath: string) => ipcRenderer.invoke('file:rename', oldPath, newPath),
   deleteFile: (path: string) => ipcRenderer.invoke('file:delete', path),
+  closeWindow: () => ipcRenderer.invoke('window:close'),
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, chunk: LLMStreamChunk): void => {
       callback(chunk)

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, type KeyboardEvent } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
-import { isMacOS } from '../../lib/browserApi'
+import { isMacOS, getApi } from '../../lib/browserApi'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import {
@@ -195,6 +195,10 @@ export function Toolbar() {
             <DropdownMenuItem onClick={() => setDialogOpen(true)}>
               <Settings className="mr-2 h-4 w-4" />
               Settings
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => getApi().closeWindow()}>
+              Close
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -367,6 +367,11 @@ export const browserApi: ElectronAPI = {
     throw new Error('Cannot delete files in browser mode')
   },
 
+  closeWindow: async (): Promise<void> => {
+    // Try to close the window/tab in browser mode
+    window.close()
+  },
+
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => {
     const handler = (e: Event) => callback((e as CustomEvent).detail)
     window.addEventListener('llm:stream:chunk', handler)

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -108,6 +108,8 @@ export interface ElectronAPI {
   // File rename/delete
   renameFile: (oldPath: string, newPath: string) => Promise<void>
   deleteFile: (path: string) => Promise<void>
+  // Window operations
+  closeWindow: () => Promise<void>
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Add "Close" menu item to the dropdown menu in the top right of the app
- On macOS: closes the window (consistent with Cmd+W behavior)
- On Windows/Linux: quits the application
- Includes browser fallback using `window.close()`

## Test plan
- [ ] Open the app on macOS, click the three-dot menu, verify "Close" appears after Settings
- [ ] Click "Close" on macOS - window should close
- [ ] Open the app on Windows/Linux, click "Close" - app should quit
- [ ] Verify the menu item styling matches other menu items
