### PR TITLE
feat: add Save as option to menu (#70)

### DIFF
--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -31,7 +31,7 @@ import {
 } from 'lucide-react'
 
 export function Toolbar() {
-  const { document, openFile, saveFile, newFile, quickSaveWithTitle } = useEditor()
+  const { document, openFile, saveFile, saveFileAs, newFile, quickSaveWithTitle } = useEditor()
   const { settings, isLoaded, setTheme, setDialogOpen } = useSettings()
   const { isPanelOpen: isChatOpen, togglePanel: toggleChatPanel } = useChat()
   const { isPanelOpen: isFileListOpen, togglePanel: toggleFileListPanel } = useFileList()
@@ -207,6 +207,9 @@ export function Toolbar() {
             </DropdownMenuItem>
             <DropdownMenuItem onClick={saveFile}>
               Save
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={saveFileAs}>
+              Save as...
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => setDialogOpen(true)}>


### PR DESCRIPTION
## Summary

Adds "Save as..." menu item to the triple dot menu in the toolbar.

Closes #70

## Changes

- Added `saveFileAs` to the Toolbar component's useEditor hook destructuring
- Added "Save as..." menu item after the "Save" option in the dropdown menu

The `saveFileAs` function already existed in the codebase, this PR just exposes it in the UI.

## Test Plan

1. Launch the app (`npm run dev` or `npm run build`)
2. Open or create a document
3. Click the triple dot menu (MoreHorizontal icon) in the top right corner
4. Verify that "Save as..." option appears after the "Save" option
5. Click "Save as..." and verify that the native file save dialog opens
6. Save the file with a new name and verify:
   - The document is saved to the new location
   - The title bar updates to show the new filename
   - Chat history and annotations are migrated to the new file's document ID

🤖 Generated with [Claude Code](https://claude.ai/code)