### PR TITLE
fix: prevent chat auto-prompt from triggering during app initialization

### DIFF
--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -20,7 +20,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 const autoPromptedDocs = new Set<string>()
 
 export function ChatPanel() {
-  const { messages, isLoading, isStreaming, sendMessage, stopGeneration, clearMessages } = useChat()
+  const { messages, isLoading, isStreaming, isInitializing, sendMessage, stopGeneration, clearMessages } = useChat()
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const {
@@ -51,12 +51,13 @@ export function ChatPanel() {
     const hasContent = document.content.trim().length > 0
     const hasNoHistory = conversations.length === 0
     const notYetPrompted = !autoPromptedDocs.has(documentId)
+    const appReady = !isInitializing
 
-    if (hasContent && hasNoHistory && notYetPrompted) {
+    if (hasContent && hasNoHistory && notYetPrompted && appReady) {
       autoPromptedDocs.add(documentId)
       sendMessage('What is this?', { hidden: true })
     }
-  }, [documentId, document.content, conversations.length, sendMessage])
+  }, [documentId, document.content, conversations.length, isInitializing, sendMessage])
 
   const handleNewChat = () => {
     addConversation(documentId)


### PR DESCRIPTION
## Summary

Fixed the race condition causing the chat auto-prompt to trigger prematurely on first load. The "What's this?" feature was running before app initialization completed, causing unwanted chat actions.

Closes #85

## Changes

- Modified `src/renderer/components/chat/ChatPanel.tsx`
- Added `isInitializing` check to auto-prompt effect conditions
- Updated effect dependencies to prevent race condition

## Test Plan

### Manual Testing

1. **Test clean first load**:
   - Clear app data: `rm -rf ~/.prose/*`
   - Start the app: `npm run dev`
   - Open a document with content
   - ✓ Chat panel should NOT show loading indicator immediately
   - ✓ No premature chat actions should trigger

2. **Test auto-prompt still works**:
   - Start the app with a document that has content
   - Wait for app initialization to complete
   - ✓ Auto-prompt "What is this?" should still trigger for new documents
   - ✓ Hidden message should generate document summary

3. **Test with draft recovery**:
   - Create a dirty document and quit without saving
   - Start the app again
   - ✓ Draft recovery should complete before auto-prompt
   - ✓ No chat loading indicator during recovery dialog

4. **Test existing conversations**:
   - Open a document with existing chat history
   - ✓ Auto-prompt should NOT trigger (only for new documents)

### Expected Behavior

- App initialization completes without premature chat triggers
- Auto-prompt works correctly after initialization
- No loading indicators or chat actions during startup

----

Generated with [Claude Code](https://claude.ai/code)