### PR TITLE
fix(files): default to Documents folder in File Explorer (#95)

### DIFF
--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -45,7 +45,7 @@ export const useFileListStore = create<FileListState>()(
   subscribeWithSelector((set, get) => ({
     isPanelOpen: false,
     isLoading: false,
-    viewMode: 'notebooks' as ViewMode,
+    viewMode: 'folder' as ViewMode,
     isInitialized: false,
     files: [],
     rootPath: null,


### PR DESCRIPTION
## Summary
- Changes default File Explorer view from "Notebooks" to "Files" (folder view)
- Single-line change in `fileListStore.ts`: `viewMode: 'folder'` instead of `'notebooks'`

## Test plan
- [x] Fresh launch shows "Documents" header with folder tree
- [x] All view modes (Files, Notebooks, Recent) switch correctly
- [x] View mode resets to "Files" on app restart

Fixes #95

🤖 Generated with [Claude Code](https://claude.ai/code)