### PR TITLE
Change default font to IBM Plex Mono

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,4 +140,4 @@ OCR requires an Anthropic API key. If using Anthropic as the LLM provider, that 
 
 - **Component library**: Use shadcn/ui components. Don't introduce other UI libraries.
 - **Animations**: Keep minimal. Use only what shadcn/ui and tailwindcss-animate provide out of the box.
-- **Fonts**: Source Code Pro for all text (UI and editor).
+- **Fonts**: IBM Plex Mono for all text (UI and editor) by default. Users can change fonts in Settings → Editor.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -93,7 +93,7 @@ const defaultSettings: Settings = {
   editor: {
     fontSize: 16,
     lineHeight: 1.6,
-    fontFamily: "'Source Code Pro', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontFamily: "'IBM Plex Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
   },
   recovery: {
     mode: 'silent'

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -207,7 +207,7 @@ export function SettingsDialog() {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value='"IBM Plex Mono", monospace'>
-                    IBM Plex Mono
+                    IBM Plex Mono (Default)
                   </SelectItem>
                   <SelectItem value='"IBM Plex Sans", sans-serif'>
                     IBM Plex Sans

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -33,7 +33,7 @@ const defaultSettings: Settings = {
   editor: {
     fontSize: 16,
     lineHeight: 1.6,
-    fontFamily: "'Source Code Pro', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontFamily: "'IBM Plex Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
   }
 }
 


### PR DESCRIPTION
Fixes #108

Changes the default font from Source Code Pro to IBM Plex Mono across the application.

## Changes
- Updated default fontFamily in browserApi.ts and ipc.ts
- Updated SettingsDialog to show IBM Plex Mono as default
- Updated CLAUDE.md documentation

Generated with [Claude Code](https://claude.ai/code)