### PR TITLE
feat: add copy-to-clipboard buttons for chat content (#38)

### DIFF
--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -8,6 +8,7 @@ import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useChatStore } from '../../stores/chatStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useSettingsStore } from '../../stores/settingsStore'
+import { CopyButton } from '../ui/copy-button'
 
 // Tool call indicator component with AI sparkle styling
 function ToolCallIndicator({ name, status, children }: { name: string; status: 'executing' | 'success' | 'error'; children?: React.ReactNode }) {
@@ -206,10 +207,16 @@ function renderMarkdown(content: string): React.ReactNode {
     if (line.startsWith('```')) {
       if (inCodeBlock) {
         // End code block
+        const codeText = codeContent.join('\n')
         elements.push(
-          <pre key={`code-${i}`} className="my-2 rounded bg-muted p-3 overflow-x-auto">
-            <code className="text-xs font-mono">{codeContent.join('\n')}</code>
-          </pre>
+          <div key={`code-${i}`} className="relative group my-2">
+            <pre className="rounded bg-muted p-3 pr-10 overflow-x-auto">
+              <code className="text-xs font-mono">{codeText}</code>
+            </pre>
+            <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <CopyButton value={codeText} />
+            </div>
+          </div>
         )
         codeContent = []
         inCodeBlock = false
@@ -333,7 +340,7 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   return (
     <div
       className={cn(
-        'flex gap-3 p-4 transition-colors',
+        'flex gap-3 p-4 transition-colors group',
         isUser ? 'bg-transparent' : 'bg-muted/30'
       )}
       onMouseEnter={() => setShowTimestamp(true)}
@@ -352,6 +359,14 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
         )}
       </div>
       <div className="flex-1 space-y-2 overflow-hidden">
+        {!isUser && (
+          <div className="flex items-center justify-between mb-1">
+            <div className="flex-1" />
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+              <CopyButton value={message.content} />
+            </div>
+          </div>
+        )}
         {message.context && (
           <div className="rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
             <span className="font-medium">Context:</span>

--- a/src/renderer/components/ui/copy-button.tsx
+++ b/src/renderer/components/ui/copy-button.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react'
+import { Check, Copy } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import { Button } from './button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip'
+
+interface CopyButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string
+  className?: string
+}
+
+export function CopyButton({ value, className, ...props }: CopyButtonProps) {
+  const [copied, setCopied] = React.useState(false)
+
+  const handleCopy = React.useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      console.error('Failed to copy to clipboard:', error)
+    }
+  }, [value])
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn('h-7 w-7 text-muted-foreground hover:text-foreground', className)}
+            onClick={handleCopy}
+            {...props}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            <span className="sr-only">{copied ? 'Copied' : 'Copy to clipboard'}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{copied ? 'Copied!' : 'Copy to clipboard'}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}


### PR DESCRIPTION
## Summary

Implements copy-to-clipboard functionality for chat content as requested in #38.

## Changes

- Created reusable CopyButton component with tooltip and visual feedback
- Added copy buttons to code blocks in AI responses (visible on hover)
- Added copy button to AI message headers for copying entire response
- Used navigator.clipboard API with 2-second "Copied!" feedback
- Fully compatible with dark/light mode themes

## Acceptance Criteria

- ✅ Code blocks in chat have a copy button
- ✅ Clicking copy button copies content to clipboard
- ✅ Visual feedback confirms copy succeeded
- ✅ Can copy entire AI response

Closes #38

---

Generated with [Claude Code](https://claude.ai/code)