### PR TITLE
Enable window dragging from tab bar area (#107)

### DIFF
--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -114,7 +114,7 @@ export function TabBar({ onTabClick, onTabClose, onTabCloseOthers, onTabCloseAll
       axis="x"
       values={tabs}
       onReorder={setTabOrder}
-      className="flex items-center gap-0.5"
+      className="flex items-center gap-0.5 app-region-no-drag"
     >
       {tabs.map((tab) => (
         <TabItem

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -187,7 +187,7 @@ export function Toolbar() {
         </div>
 
         {/* Center: Tab bar */}
-        <div className="flex-1 flex items-center justify-start ml-2 app-region-no-drag min-w-0">
+        <div className="flex-1 flex items-center justify-start ml-2 app-region-drag min-w-0">
           <TabBar
             onTabClick={handleTabClick}
             onTabClose={handleTabClose}


### PR DESCRIPTION
## Summary

Fixed the inability to drag the application window by clicking on the tab bar area.

## Changes

- Modified drag regions in Toolbar.tsx to enable window dragging from empty space in the tab bar
- Added no-drag region to TabBar.tsx to keep tabs and interactive elements functional

## Testing

- [ ] Can drag the application window by clicking empty space in tab bar
- [ ] Tabs remain clickable for switching documents
- [ ] Tab close buttons remain functional
- [ ] Tab reordering still works
- [ ] Other toolbar buttons remain functional

Fixes #107

Generated with [Claude Code](https://claude.ai/code)