### PR TITLE
fix: update new_file tool description to prevent misuse (#97)

### DIFF
--- a/src/shared/tools/schemas/file.ts
+++ b/src/shared/tools/schemas/file.ts
@@ -36,7 +36,7 @@ export const newFileSchema = z.object({
 
 export const newFileConfig: ToolConfig<typeof newFileSchema> = {
   name: 'new_file',
-  description: 'Create a new unsaved document. Optionally provide initial content.',
+  description: 'Create a NEW document, replacing the current one. This clears the current document and chat history. Only use when the user explicitly requests a new document. To add content to the current document, use the "insert" tool instead.',
   schema: newFileSchema,
   category: 'file',
   requiresMode: null,


### PR DESCRIPTION
## Summary

Fixes issue where generating text from a blank document causes the chat to disappear.

The root cause was the AI incorrectly calling `new_file` when it should use `insert`. This updates the tool description to:
- Explicitly state that `new_file` replaces/clears the current document and chat history
- Direct the AI to use `insert` for adding content to the current document

Closes #97