### PR TITLE
feat: add Termy Green theme variants (#159)

### DIFF
--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -176,6 +176,8 @@ export function SettingsDialog() {
                   <SelectItem value="light">Light</SelectItem>
                   <SelectItem value="dark">Dark</SelectItem>
                   <SelectItem value="system">System</SelectItem>
+                  <SelectItem value="termy-green-light">Termy Green Light</SelectItem>
+                  <SelectItem value="termy-green-dark">Termy Green Dark</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -47,6 +47,50 @@
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
   }
+
+  .termy-green-dark {
+    --background: 120 20% 4%;
+    --foreground: 120 100% 70%;
+    --card: 120 20% 6%;
+    --card-foreground: 120 100% 70%;
+    --popover: 120 20% 6%;
+    --popover-foreground: 120 100% 70%;
+    --primary: 120 100% 70%;
+    --primary-foreground: 120 20% 4%;
+    --secondary: 120 25% 12%;
+    --secondary-foreground: 120 100% 70%;
+    --muted: 120 25% 12%;
+    --muted-foreground: 120 60% 50%;
+    --accent: 120 25% 12%;
+    --accent-foreground: 120 100% 70%;
+    --destructive: 0 80% 45%;
+    --destructive-foreground: 120 100% 70%;
+    --border: 120 30% 15%;
+    --input: 120 30% 15%;
+    --ring: 120 100% 70%;
+  }
+
+  .termy-green-light {
+    --background: 40 30% 96%;
+    --foreground: 120 60% 20%;
+    --card: 40 30% 98%;
+    --card-foreground: 120 60% 20%;
+    --popover: 40 30% 98%;
+    --popover-foreground: 120 60% 20%;
+    --primary: 120 60% 25%;
+    --primary-foreground: 40 30% 96%;
+    --secondary: 120 20% 88%;
+    --secondary-foreground: 120 60% 20%;
+    --muted: 120 20% 88%;
+    --muted-foreground: 120 40% 40%;
+    --accent: 120 20% 88%;
+    --accent-foreground: 120 60% 20%;
+    --destructive: 0 70% 50%;
+    --destructive-foreground: 40 30% 96%;
+    --border: 120 25% 80%;
+    --input: 120 25% 80%;
+    --ring: 120 60% 25%;
+  }
 }
 
 @layer base {

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -7,11 +7,19 @@ type SettingsTab = 'general' | 'editor' | 'llm' | 'integrations' | 'account'
 
 // Helper to apply theme to document
 function applyTheme(theme: Settings['theme']): void {
-  const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
-  if (isDark) {
-    document.documentElement.classList.add('dark')
+  // Remove all theme classes first
+  document.documentElement.classList.remove('dark', 'termy-green-dark', 'termy-green-light')
+
+  // Apply the appropriate theme class(es)
+  if (theme === 'termy-green-dark') {
+    document.documentElement.classList.add('dark', 'termy-green-dark')
+  } else if (theme === 'termy-green-light') {
+    document.documentElement.classList.add('termy-green-light')
   } else {
-    document.documentElement.classList.remove('dark')
+    const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+    if (isDark) {
+      document.documentElement.classList.add('dark')
+    }
   }
 }
 
@@ -74,6 +82,12 @@ const defaultSettings: Settings = {
 function getEffectiveTheme(theme: Settings['theme']): 'dark' | 'light' {
   if (theme === 'system') {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  if (theme === 'termy-green-dark') {
+    return 'dark'
+  }
+  if (theme === 'termy-green-light') {
+    return 'light'
   }
   return theme
 }

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,7 +1,7 @@
 import type { ToolResult } from '../../shared/tools/types'
 
 export interface Settings {
-  theme: 'light' | 'dark' | 'system'
+  theme: 'light' | 'dark' | 'system' | 'termy-green-light' | 'termy-green-dark'
   llm: {
     provider: 'anthropic' | 'openai' | 'openrouter' | 'ollama'
     model: string


### PR DESCRIPTION
Implement "Termy Green" theme inspired by classic IBM 3278 green phosphor terminals. Includes two variants:
- Termy Green Dark: Very dark background with bright phosphor green text
- Termy Green Light: Cream background with dark forest green text

Closes #159

Generated with [Claude Code](https://claude.ai/code)