### PR TITLE
feat(chat): rewrite AI prompt, context, and tool use

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -532,7 +532,7 @@ export function setupIpcHandlers(): void {
 
         const stream = client.messages.stream({
           model: request.model,
-          max_tokens: 4096,
+          max_tokens: request.maxTokens || 4096,
           system: request.system,
           messages: anthropicMessages,
           tools: anthropicTools

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -16,11 +16,8 @@ import { useChatStore } from '../../stores/chatStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 
-// Track which documents have been auto-prompted this session
-const autoPromptedDocs = new Set<string>()
-
 export function ChatPanel() {
-  const { messages, isLoading, isStreaming, isInitializing, sendMessage, stopGeneration, clearMessages } = useChat()
+  const { messages, isLoading, isStreaming, sendMessage, stopGeneration, clearMessages } = useChat()
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const {
@@ -45,19 +42,6 @@ export function ChatPanel() {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
   }, [messages, isLoading, isStreaming, lastMessageContent])
-
-  // Auto-prompt when panel opens for a document with content but no chat history
-  useEffect(() => {
-    const hasContent = document.content.trim().length > 0
-    const hasNoHistory = conversations.length === 0
-    const notYetPrompted = !autoPromptedDocs.has(documentId)
-    const appReady = !isInitializing
-
-    if (hasContent && hasNoHistory && notYetPrompted && appReady) {
-      autoPromptedDocs.add(documentId)
-      sendMessage('What is this?', { hidden: true })
-    }
-  }, [documentId, document.content, conversations.length, isInitializing, sendMessage])
 
   const handleNewChat = () => {
     addConversation(documentId)

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -18,6 +18,24 @@ let streamListenersInitialized = false
 // Maximum tool roundtrips before circuit breaker stops the loop
 const MAX_TOOL_ROUNDTRIPS = 5
 
+// Maximum messages to keep in context (plus pinned first user message)
+const MAX_HISTORY_MESSAGES = 20
+
+/**
+ * Summarize tool results to reduce context size.
+ * Strips redundant `markdown` field from read_document results since nodes already contain content.
+ */
+function summarizeToolResult(toolName: string, result: { success: boolean; data?: unknown; error?: string }): string {
+  if (!result.success) return JSON.stringify(result)
+  if (toolName === 'read_document' && result.data) {
+    const data = result.data as { nodes?: unknown[]; markdown?: string }
+    if (data.nodes) {
+      return JSON.stringify({ success: true, data: { nodes: data.nodes, nodeCount: data.nodes.length } })
+    }
+  }
+  return JSON.stringify(result)
+}
+
 // Module-level refs - these must be outside the hook to ensure event handlers
 // registered once at module level can access the same refs that sendMessage uses
 // Each ref includes a streamId to prevent race conditions when streams overlap
@@ -221,10 +239,10 @@ export function useChat() {
               `\n\n*[Tool: ${toolCall.name}] ${resultSummary}*`
           })
 
-          // Add tool result message to API messages
+          // Add tool result message to API messages (summarized to reduce context)
           updatedMessages.push({
             role: 'tool' as const,
-            content: JSON.stringify(result),
+            content: summarizeToolResult(toolCall.name, result),
             tool_call_id: toolCall.id
           })
         }
@@ -268,10 +286,11 @@ export function useChat() {
             apiKey: settingsState.settings.llm.apiKey,
             baseUrl: settingsState.settings.llm.baseUrl,
             messages: updatedMessages,
-            system: buildSystemPrompt(state.includeDocument, editorState.document.content),
+            system: buildSystemPrompt(state.includeDocument, editorState.document.content, state.toolMode, editorState.document.path),
             streamId: newStreamId,
             tools,
-            maxToolRoundtrips: 5
+            maxToolRoundtrips: 5,
+            maxTokens: state.toolMode === 'suggestions' ? 3072 : 4096
           })
         } catch (error) {
           console.error('[Chat] Tool loop error:', error)
@@ -380,13 +399,25 @@ export function useChat() {
       setLoading(true)
 
       // Build messages array for the API
-      const apiMessages: LLMMessage[] = messages.map((m) => ({
+      let apiMessages: LLMMessage[] = messages.map((m) => ({
         role: m.role as 'user' | 'assistant',
         content: m.context
           ? `Regarding this text:\n\n> ${m.context}\n\n${m.content}`
           : m.content
       }))
       apiMessages.push({ role: 'user' as const, content: fullMessage })
+
+      // Prune history: keep first user message + last MAX_HISTORY_MESSAGES
+      if (apiMessages.length > MAX_HISTORY_MESSAGES) {
+        // Find first non-hidden user message (skip auto-describe)
+        const firstUserIdx = messages.findIndex((m) => m.role === 'user' && !m.hidden)
+        const pinned = firstUserIdx >= 0 ? [apiMessages[firstUserIdx]] : []
+        const recent = apiMessages.slice(-MAX_HISTORY_MESSAGES)
+        apiMessages =
+          pinned.length > 0 && !recent.includes(pinned[0])
+            ? [...pinned, ...recent]
+            : recent
+      }
 
       // Create assistant message placeholder for streaming
       const assistantMsgId = createMessageId()
@@ -437,10 +468,11 @@ export function useChat() {
           apiKey: settings.llm.apiKey,
           baseUrl: settings.llm.baseUrl,
           messages: apiMessages,
-          system: buildSystemPrompt(includeDocument, useEditorStore.getState().document.content),
+          system: buildSystemPrompt(includeDocument, useEditorStore.getState().document.content, toolMode, useEditorStore.getState().document.path),
           streamId,
           tools,
-          maxToolRoundtrips: 5
+          maxToolRoundtrips: 5,
+          maxTokens: toolMode === 'suggestions' ? 3072 : 4096
         })
       } catch (error) {
         console.error('[Chat] Error:', error)
@@ -554,8 +586,11 @@ export function useChat() {
 
   // Auto-describe document on open (hidden message triggers AI summary)
   const describeDocument = useCallback(async () => {
-    // Only describe if document context is enabled
     const state = useChatStore.getState()
+
+    // Guard: don't describe if already active or has history
+    if (state.isLoading || state.isStreaming) return
+    if (state.messages.length > 0) return
     if (!state.includeDocument) return
 
     // Only describe if there's content
@@ -565,10 +600,8 @@ export function useChat() {
     // Open chat panel to show the description
     setPanelOpen(true)
 
-    // Send a hidden prompt that triggers declarative description
-    // The prompt encourages confident, direct language without hedging
     await sendMessage(
-      'Briefly describe this document in 1-2 sentences. Be direct and declarative - state what it is, not what it "appears to be". Focus on the content and purpose.',
+      'Summarize this document in 1-2 sentences. State what it is and its purpose. No hedging.',
       { hidden: true }
     )
   }, [sendMessage, setPanelOpen])

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -4,6 +4,7 @@
 
 import type { CommentData } from '../extensions/comments/types'
 import type { AISuggestionData } from '../extensions/ai-suggestions/types'
+import type { ToolMode } from '../../shared/tools/types'
 
 /**
  * Strip comment HTML markup from content.
@@ -17,67 +18,100 @@ function stripCommentMarkup(content: string): string {
     .replace(/<\/span>/gi, '')
 }
 
-export function buildSystemPrompt(includeDocument: boolean, documentContent?: string): string {
-  let prompt = `You are a helpful writing assistant integrated into a markdown editor called Prose.
-You help users with writing, editing, and organizing their documents.
+const BASE_PROMPT = `You are Prose, a writing assistant embedded in a markdown editor.
 
-Keep your responses concise and focused.
+You help writers edit, revise, and improve their documents. You are concise, direct, and opinionated when asked for feedback. You do not hedge or pad your responses with pleasantries.
 
-## Making Edits
+## How you work
 
-You have tools available: \`edit\`, \`suggest_edit\`, and \`read_document\`.
+- When asked to **edit text**, use tools to make changes. Read the document first if you haven't already.
+- When asked for **feedback or critique**, respond in 2-3 sentences. Be specific. Point to exact phrases or passages.
+- When asked to **write or draft** new content, output markdown directly in your response.
+- When **discussing ideas**, keep responses short. One paragraph is usually enough.
 
-### How Editing Works
+## Rules
 
-Each block in the document (paragraph, heading, list item, etc.) has a unique ID. To edit content:
+- Never start a response with "Sure!", "Great!", "Absolutely!", "I'd be happy to", or similar filler.
+- Never restate what the user just said back to them.
+- Never explain what you're about to do before doing it. Just do it.
+- When making edits, don't narrate each change. The diff UI shows the user what changed.
+- If you need to explain *why* you made a change, put it in the edit's \`comment\` field, not in the chat.
+- Prefer multiple small, targeted edits over one large replacement.
+- If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes.
 
-1. Call \`read_document\` to see all nodes with their IDs
-2. Find the node you want to change
-3. Call \`edit\` or \`suggest_edit\` with the node's ID and new content
+## Tone
 
-### Example
+You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice.`
 
-If \`read_document\` returns:
-\`\`\`json
-{ "nodes": [
-    { "id": "abc123", "type": "heading", "content": "Introduction" },
-    { "id": "def456", "type": "paragraph", "content": "The quick brown fox jumps over the lazy dog." }
-  ]
-}
-\`\`\`
+const SUGGESTIONS_MODE_INSTRUCTIONS = `
 
-To change the paragraph:
-\`\`\`json
-{ "nodeId": "def456", "content": "The quick brown fox leaps over the lazy hound." }
-\`\`\`
+You do not have editing tools in this mode. Provide writing feedback, analysis, and suggestions in your response text. When suggesting changes, quote the original text and show the proposed revision.`
 
-### Guidelines
-- Always call \`read_document\` first to get current node IDs
-- Use the exact node ID from the response
-- The \`content\` parameter replaces the entire node content
-- Keep edits focused - one node per tool call
-- Briefly explain what you're changing
+const PLAN_MODE_INSTRUCTIONS = `
 
-## Referencing Line Numbers
+## Tools
 
-When you reference specific line numbers in the document (e.g., when searching or analyzing), format them as clickable markdown links:
+- \`read_document\` — Returns document nodes with unique IDs
+- \`suggest_edit\` — Creates an inline diff the user can accept or reject
 
-- Format: \`[Line N](line:N)\` where N is the line number
-- Example: "Found 3 occurrences: [Line 12](line:12), [Line 45](line:45), and [Line 128](line:128)"
-- These will appear as clickable links that navigate to that line in the editor`
+### Workflow
+1. **Always** call \`read_document\` first — node IDs change between sessions and cannot be guessed
+2. Call \`suggest_edit\` with the target node ID, new content, and a brief comment (under 20 words)
 
+The user sees a highlighted diff and decides whether to accept. You have a budget of 5 tool roundtrips per response.`
+
+const FULL_MODE_INSTRUCTIONS = `
+
+## Tools
+
+- \`read_document\` — Returns document nodes with unique IDs
+- \`suggest_edit\` — Creates an inline diff the user can accept or reject (use when the user should review)
+- \`edit\` — Directly replaces a node's content (use for unambiguous fixes: typos, formatting)
+
+### Workflow
+1. **Always** call \`read_document\` first — node IDs change between sessions and cannot be guessed
+2. Use \`suggest_edit\` when judgment is involved, \`edit\` for obvious fixes
+
+Keep edit comments under 20 words. You have a budget of 5 tool roundtrips per response.`
+
+export function buildSystemPrompt(
+  includeDocument: boolean,
+  documentContent?: string,
+  toolMode?: ToolMode,
+  documentPath?: string | null
+): string {
+  let prompt = BASE_PROMPT
+
+  // Mode-specific tool instructions
+  if (!toolMode || toolMode === 'suggestions') {
+    prompt += SUGGESTIONS_MODE_INSTRUCTIONS
+  } else if (toolMode === 'plan') {
+    prompt += PLAN_MODE_INSTRUCTIONS
+  } else if (toolMode === 'full') {
+    prompt += FULL_MODE_INSTRUCTIONS
+  }
+
+  // Document context
   if (includeDocument && documentContent) {
-    // Strip any comment HTML markup so the AI sees clean text
     const cleanContent = stripCommentMarkup(documentContent)
-    prompt += `
+    if (!toolMode || toolMode === 'suggestions') {
+      // No tools — full document needed in prompt
+      prompt += `\n\nThe user is currently working on the following document:\n\n---\n${cleanContent}\n---`
 
-The user is currently working on the following document:
+      // Line references only when document is in prompt
+      prompt += `\n\n## Referencing Line Numbers\nFormat: [Line N](line:N) — these render as clickable links that navigate to that line.`
+    } else {
+      // Tool modes — short preview, model uses read_document for full content + node IDs
+      const preview =
+        cleanContent.length > 500 ? cleanContent.slice(0, 500) + '\n\n[...]' : cleanContent
+      prompt += `\n\nDocument preview:\n\n---\n${preview}\n---\n\nCall \`read_document\` for full content with node IDs.`
+    }
+  }
 
----
-${cleanContent}
----
-
-Use \`read_document\` to get node IDs before making edits.`
+  // Append filename when available
+  if (documentPath) {
+    const filename = documentPath.split('/').pop() || 'untitled'
+    prompt += `\n\nFile: ${filename}`
   }
 
   return prompt
@@ -96,7 +130,7 @@ export function buildCommentsPrompt(comments: CommentData[]): string {
     prompt += `   Instruction: ${comment.comment}\n\n`
   })
 
-  prompt += `Apply the requested changes using the edit tools. First use read_document to get node IDs, then edit the nodes containing the marked text. Address each comment in order.`
+  prompt += `Apply each comment as an edit. Use read_document for node IDs. Preserve the author's voice.`
 
   return prompt
 }
@@ -118,7 +152,7 @@ export function buildSuggestionRepliesPrompt(suggestions: AISuggestionData[]): s
     prompt += `   User feedback: ${suggestion.userReply}\n\n`
   })
 
-  prompt += `For each item, use suggest_edit to create a new suggestion that addresses the user's feedback. Use read_document first to get current node IDs. The new suggestion should incorporate the user's requested changes while maintaining proper grammar and style.`
+  prompt += `Revise each suggestion to address the feedback. Maintain the author's voice and style.`
 
   return prompt
 }

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -250,6 +250,7 @@ export interface LLMStreamRequest extends LLMRequest {
   streamId: string
   tools?: LLMToolDefinition[]
   maxToolRoundtrips?: number
+  maxTokens?: number
 }
 
 export interface LLMStreamChunk {

--- a/src/shared/tools/schemas/document.ts
+++ b/src/shared/tools/schemas/document.ts
@@ -13,7 +13,8 @@ export const readDocumentSchema = z.object({}).describe('No parameters required'
 
 export const readDocumentConfig: ToolConfig<typeof readDocumentSchema> = {
   name: 'read_document',
-  description: 'Get the full markdown content of the current document',
+  description:
+    'Get the document as structured nodes, each with a unique ID. Returns { nodes: [{ id, type, content }], markdown }. Node IDs are required for edit and suggest_edit calls.',
   schema: readDocumentSchema,
   category: 'document',
   requiresMode: null, // Available in all modes
@@ -77,7 +78,8 @@ export const searchDocumentSchema = z.object({
 
 export const searchDocumentConfig: ToolConfig<typeof searchDocumentSchema> = {
   name: 'search_document',
-  description: 'Find all occurrences of text or regex pattern in the document',
+  description:
+    'Search the document for text or regex matches. Returns match positions with line numbers. Useful for locating content before targeting edits.',
   schema: searchDocumentSchema,
   category: 'document',
   requiresMode: null,

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -64,13 +64,13 @@ export const suggestEditSchema = z.object({
   comment: z
     .string()
     .optional()
-    .describe('Optional comment explaining the suggested change')
+    .describe('Brief rationale for the change, shown in the diff UI. Keep under 20 words.')
 })
 
 export const suggestEditConfig: ToolConfig<typeof suggestEditSchema> = {
   name: 'suggest_edit',
   description:
-    'Show a diff suggestion for a specific node without applying it. Use read_document first to see all nodes with their IDs.',
+    'Create an inline diff suggestion on a node. The user sees a highlighted comparison and can accept or reject it. Use read_document first to get node IDs.',
   schema: suggestEditSchema,
   category: 'editor',
   requiresMode: null, // Available in all modes
@@ -90,7 +90,7 @@ export const acceptDiffSchema = z.object({
 
 export const acceptDiffConfig: ToolConfig<typeof acceptDiffSchema> = {
   name: 'accept_diff',
-  description: 'Accept a pending diff suggestion, applying the change to the document',
+  description: 'Accept a pending suggestion. If no ID provided, accepts all pending suggestions.',
   schema: acceptDiffSchema,
   category: 'editor',
   requiresMode: null, // Available in all modes
@@ -110,7 +110,7 @@ export const rejectDiffSchema = z.object({
 
 export const rejectDiffConfig: ToolConfig<typeof rejectDiffSchema> = {
   name: 'reject_diff',
-  description: 'Reject a pending diff suggestion, keeping the original text',
+  description: 'Reject a pending suggestion. If no ID provided, rejects all pending suggestions.',
   schema: rejectDiffSchema,
   category: 'editor',
   requiresMode: null, // Available in all modes


### PR DESCRIPTION
## Summary

- **System prompt rewrite**: New Prose identity with opinionated editor voice, explicit anti-patterns (no filler, no narration), mode-aware tool instructions (suggestions/plan/full)
- **Context engineering**: History pruning (first user msg + last 20), tool result summarization, removed duplicate auto-prompt from ChatPanel, contextual max_tokens (3072/4096)
- **Tool description fixes**: `read_document`, `suggest_edit`, `accept_diff`/`reject_diff`, `search_document` — descriptions now accurately reflect behavior

## Test plan

- [ ] Open chat in each tool mode (suggestions/plan/full), verify mode-appropriate prompt behavior
- [ ] Ask model to fix a typo — verify it calls `read_document` first, then `edit`/`suggest_edit`
- [ ] Open a document, verify auto-describe fires once (not twice)
- [ ] Have a 15+ message conversation, verify no context overflow
- [ ] Verify responses don't start with filler ("Sure!", "Great!", etc.)

Refs #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)