### PR TITLE
fix(annotations): split partially-overlapping annotations on unannotate

### DIFF
--- a/src/renderer/extensions/ai-annotations/store.ts
+++ b/src/renderer/extensions/ai-annotations/store.ts
@@ -84,13 +84,39 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
     get().saveAnnotations()
   },
 
-  // Remove all annotations overlapping a range
+  // Remove annotations in a range, splitting partially-overlapping ones into remnants
   removeAnnotationsInRange: (from, to) => {
-    set((state) => ({
-      annotations: state.annotations.filter(
-        (a) => a.to <= from || a.from >= to // Keep if no overlap
-      ),
-    }))
+    set((state) => {
+      const updated: AIAnnotation[] = []
+
+      for (const a of state.annotations) {
+        if (a.to <= from || a.from >= to) {
+          // No overlap — keep as-is
+          updated.push(a)
+        } else {
+          // Overlaps — split into before/after remnants
+          if (a.from < from) {
+            updated.push({
+              ...a,
+              id: generateId(),
+              to: from,
+              content: a.content.slice(0, from - a.from),
+            })
+          }
+          if (a.to > to) {
+            updated.push({
+              ...a,
+              id: generateId(),
+              from: to,
+              content: a.content.slice(to - a.from),
+            })
+          }
+          // If fully contained (a.from >= from && a.to <= to), no remnants → removed
+        }
+      }
+
+      return { annotations: updated }
+    })
 
     get().saveAnnotations()
   },


### PR DESCRIPTION
## Summary

- Fixes unannotating a subsection of AI-authored text removing the entire annotation instead of just the selected portion
- `removeAnnotationsInRange` now splits partially-overlapping annotations into before/after remnants
- Fully contained annotations are still removed entirely (no behavior change for that case)

## Test plan

- [x] Build succeeds
- [x] QA: Mark a paragraph as AI-authored, select a middle subsection, unannotate — surrounding text retains annotation
- [x] QA: Select an entire remaining annotation span and unannotate — fully removed, no remnants

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)