### PR TITLE
feat(ui): add Report a Bug option to toolbar dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report a bug in Prose
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please search existing issues before creating a new one.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong?
+      placeholder: Describe the bug...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Open the app
+        2. Click on...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Describe what should have happened...
+    validations:
+      required: false
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Describe what happened instead...
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Prose version, and any other relevant info
+      placeholder: |
+        - OS: macOS 15.x / Windows 11 / Linux
+        - Prose version: x.x.x
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Editor
+        - AI / Chat
+        - File Management
+        - Settings
+        - Integrations
+        - Other
+    validations:
+      required: false

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -46,6 +46,7 @@ import {
   Check,
   Timer,
   CircleUserRound,
+  Bug,
   MessageSquarePlus,
   MessagesSquare
 } from 'lucide-react'
@@ -434,6 +435,10 @@ export function Toolbar() {
                 Settings
               </DropdownMenuItem>
               <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => window.open('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml', '_blank', 'noopener,noreferrer')}>
+                <Bug className="mr-2 h-4 w-4" />
+                Report a Bug
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={() => window.open('https://github.com/solo-ist/prose/issues/new?template=feature-request.yml', '_blank', 'noopener,noreferrer')}>
                 <MessageSquarePlus className="mr-2 h-4 w-4" />
                 Request a Feature


### PR DESCRIPTION
## Summary

- Adds "Report a Bug" menu item to the triple-dot dropdown in the toolbar
- Uses lucide-react `Bug` icon, positioned between Settings and Request a Feature
- Opens GitHub bug report issue template in default browser
- Creates `.github/ISSUE_TEMPLATE/bug-report.yml` with appropriate fields

Closes #205

## Test Plan

- [x] Automated QA passed (see comment below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)