### PR TITLE
feat(security): migrate LLM API key storage to safeStorage/Keychain

### DIFF
--- a/src/main/credentialStore.ts
+++ b/src/main/credentialStore.ts
@@ -7,8 +7,9 @@ const SETTINGS_DIR = join(homedir(), '.prose')
 const CREDENTIALS_DIR = join(SETTINGS_DIR, 'credentials')
 
 function keyToFilename(key: string): string {
-  // Convert key to a safe filename (alphanumeric, dashes, dots, underscores only)
-  return key.replace(/[^a-z0-9\-_.]/gi, '-')
+  // Convert key to a safe filename (alphanumeric, dashes, underscores only)
+  // Dots are stripped to prevent path traversal (e.g. '..' escaping CREDENTIALS_DIR)
+  return key.replace(/[^a-z0-9\-_]/gi, '-')
 }
 
 export const credentialStore = {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -410,9 +410,9 @@ export function setupIpcHandlers(): void {
         const { apiKey, ...llmWithoutKey } = settings.llm
         if (apiKey) {
           await credentialStore.set(LLM_API_KEY, apiKey)
-        } else {
-          await credentialStore.delete(LLM_API_KEY)
         }
+        // Don't delete stored key when apiKey is empty — preserves the
+        // credential if the field is momentarily cleared during editing
         const settingsToSave = { ...settings, llm: { ...llmWithoutKey, apiKey: '' } }
         await writeFile(SETTINGS_PATH, JSON.stringify(settingsToSave, null, 2), 'utf-8')
       } else {


### PR DESCRIPTION
Closes #237

Migrate LLM provider API key storage from plaintext `settings.json` to Electron's `safeStorage` API (macOS Keychain), satisfying Apple Guideline 5.1.2(i) for Mac App Store submission.

## Changes
- New `src/main/credentialStore.ts`: safeStorage wrapper following the same pattern as `google/auth.ts`
- `settings:load`: auto-migrates existing plaintext keys on first launch; injects decrypted key for renderer
- `settings:save`: routes apiKey through credentialStore, never writes to JSON
- `remarkable:sync` and `emoji:generate`: read key from credentialStore instead of settings.json
- Graceful fallback to plaintext on platforms where safeStorage is unavailable

Generated with [Claude Code](https://claude.ai/code)