### PR TITLE
feat(settings): add AI consent/disclosure flow for MAS compliance

### DIFF
--- a/src/renderer/components/AIConsentDialog.tsx
+++ b/src/renderer/components/AIConsentDialog.tsx
@@ -1,0 +1,78 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from './ui/alert-dialog'
+import { useSettingsStore } from '../stores/settingsStore'
+
+export function AIConsentDialog() {
+  const isOpen = useSettingsStore((s) => s.isAIConsentDialogOpen)
+  const setAIConsent = useSettingsStore((s) => s.setAIConsent)
+  const setAIConsentDialogOpen = useSettingsStore((s) => s.setAIConsentDialogOpen)
+
+  const handleEnable = () => {
+    setAIConsent(true)
+  }
+
+  const handleDecline = () => {
+    setAIConsent(false)
+  }
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => {
+      if (!open) setAIConsentDialogOpen(false)
+    }}>
+      <AlertDialogContent className="max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>AI Writing Assistance</AlertDialogTitle>
+        </AlertDialogHeader>
+
+        <div className="space-y-3 text-sm text-muted-foreground">
+          <p>
+            Prose can optionally connect to AI services to help with your writing.
+            Before enabling this feature, please review how it works:
+          </p>
+          <ul className="space-y-2">
+            <li className="flex gap-2">
+              <span className="shrink-0">•</span>
+              <span>
+                <strong className="text-foreground">What is sent:</strong> When you use the AI
+                assistant, selected text and document content are sent to an external AI provider
+                (such as Anthropic).
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="shrink-0">•</span>
+              <span>
+                <strong className="text-foreground">Your API key:</strong> AI features require
+                your own API key (BYOK). Prose does not store or access your content on any
+                server — requests go directly from your device to the provider.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="shrink-0">•</span>
+              <span>
+                <strong className="text-foreground">Entirely optional:</strong> Prose works as a
+                full-featured markdown editor without AI. You can enable or disable AI features
+                at any time in Settings → LLM.
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleDecline}>
+            Use Without AI
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={handleEnable}>
+            Enable AI Features
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -11,6 +11,7 @@ import { DefaultHandlerPrompt } from './DefaultHandlerPrompt'
 import { KeyboardShortcutsDialog } from '../settings/KeyboardShortcutsDialog'
 import { AboutDialog } from '../settings/AboutDialog'
 import { ModelPickerDialog } from '../ModelPickerDialog'
+import { AIConsentDialog } from '../AIConsentDialog'
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -42,7 +43,7 @@ import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useChatStore, setCurrentDocumentId } from '../../stores/chatStore'
 import { useTabStore, createTab, restoreSession, clearSavedSession, hasUnsavedTabs } from '../../stores/tabStore'
 import { useFileListStore } from '../../stores/fileListStore'
-import { useSettingsStore } from '../../stores/settingsStore'
+import { useSettingsStore, AI_CONSENT_VERSION } from '../../stores/settingsStore'
 import { useAutosave } from '../../hooks/useAutosave'
 import {
   loadDraft,
@@ -563,6 +564,16 @@ export function App() {
     }
   }, [importDocId, importAsAI, createNewTab, openFileInTab])
 
+  // Auto-show AI consent dialog on first launch or when disclosure version changes
+  const setAIConsentDialogOpen = useSettingsStore((s) => s.setAIConsentDialogOpen)
+  useEffect(() => {
+    if (!settingsLoaded) return
+    const aiConsent = settings.aiConsent
+    if (!aiConsent || aiConsent.version < AI_CONSENT_VERSION) {
+      setAIConsentDialogOpen(true)
+    }
+  }, [settingsLoaded, settings.aiConsent, setAIConsentDialogOpen])
+
   // Check for session/draft recovery after settings are loaded
   useEffect(() => {
     if (!settingsLoaded) return
@@ -835,6 +846,7 @@ export function App() {
           onOpenChange={setModelPickerOpen}
         />
         <DefaultHandlerPrompt />
+        <AIConsentDialog />
 
         {/* Google Docs Import Dialog */}
         <AlertDialog open={importDialogOpen} onOpenChange={(open) => {

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useSettings } from '../../hooks/useSettings'
+import { useSettingsStore } from '../../stores/settingsStore'
 import {
   Dialog,
   DialogContent,
@@ -45,6 +46,20 @@ export function SettingsDialog() {
     setAutosaveConfig,
     saveSettings
   } = useSettings()
+
+  const setAIConsent = useSettingsStore((s) => s.setAIConsent)
+  const setAIConsentDialogOpen = useSettingsStore((s) => s.setAIConsentDialogOpen)
+
+  const aiEnabled = settings.aiConsent?.consented === true
+
+  const handleAIToggle = (enabled: boolean) => {
+    if (enabled && !settings.aiConsent?.consented) {
+      // Show consent dialog if not yet consented
+      setAIConsentDialogOpen(true)
+    } else {
+      setAIConsent(enabled)
+    }
+  }
 
   // null = unknown/can't detect, true = is default, false = not default
   const [isDefaultHandler, setIsDefaultHandler] = useState<boolean | null>(null)
@@ -401,6 +416,24 @@ export function SettingsDialog() {
           </TabsContent>
 
           <TabsContent value="llm" className="space-y-4 mt-4 overflow-y-auto flex-1" ref={llmTabRef}>
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1 flex-1">
+                <Label htmlFor="aiEnabled">Enable AI Features</Label>
+                <p className="text-xs text-muted-foreground">
+                  When active, text and document content is sent to your configured AI provider.
+                  Requires your own API key — no data is stored by Prose.
+                </p>
+              </div>
+              <Switch
+                id="aiEnabled"
+                checked={aiEnabled}
+                onCheckedChange={handleAIToggle}
+              />
+            </div>
+
+            <Separator />
+
+            <div className={!aiEnabled ? 'opacity-50 pointer-events-none' : ''}>
             <div className="space-y-2">
               <Label htmlFor="provider">Provider</Label>
               <Select
@@ -561,6 +594,7 @@ export function SettingsDialog() {
                 disabled={settings.llm.provider !== 'anthropic' || !settings.llm.apiKey}
               />
             </div>
+            </div>{/* end AI features wrapper */}
 
           </TabsContent>
 

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -356,6 +356,18 @@ export function useChat() {
         addConversation(document.documentId)
       }
 
+      // Check AI consent before making any API calls
+      if (!settings.aiConsent?.consented) {
+        const consentMsgId = createMessageId()
+        addMessage({
+          id: consentMsgId,
+          role: 'assistant',
+          content: 'AI features are not enabled. Enable them in Settings → LLM to use the assistant.',
+          timestamp: new Date()
+        })
+        return
+      }
+
       // Validate config first
       console.log('[useChat] Validating config:', settings.llm?.provider, settings.llm?.model)
       const configError = validateConfig(settings.llm)

--- a/src/renderer/hooks/useSettings.ts
+++ b/src/renderer/hooks/useSettings.ts
@@ -9,6 +9,7 @@ export function useSettings() {
     isShortcutsDialogOpen,
     isAboutDialogOpen,
     isModelPickerOpen,
+    isAIConsentDialogOpen,
     dialogTab,
     effectiveTheme,
     autosaveActive,
@@ -29,7 +30,9 @@ export function useSettings() {
     setGoogleConfig,
     setFileAssociationConfig,
     setAutosaveConfig,
-    toggleAutosaveActive
+    toggleAutosaveActive,
+    setAIConsent,
+    setAIConsentDialogOpen
   } = useSettingsStore()
 
   useEffect(() => {
@@ -45,6 +48,7 @@ export function useSettings() {
     isShortcutsDialogOpen,
     isAboutDialogOpen,
     isModelPickerOpen,
+    isAIConsentDialogOpen,
     dialogTab,
     effectiveTheme,
     autosaveActive,
@@ -64,6 +68,8 @@ export function useSettings() {
     setGoogleConfig,
     setFileAssociationConfig,
     setAutosaveConfig,
-    toggleAutosaveActive
+    toggleAutosaveActive,
+    setAIConsent,
+    setAIConsentDialogOpen
   }
 }

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -6,6 +6,8 @@ const MAX_RECENT_FILES = 15
 
 type SettingsTab = 'general' | 'editor' | 'llm' | 'integrations' | 'account'
 
+export const AI_CONSENT_VERSION = 1
+
 // Helper to apply theme to document
 function applyTheme(theme: Settings['theme']): void {
   // Remove all theme classes first
@@ -55,6 +57,9 @@ interface SettingsState {
   toggleAutosaveActive: () => void
   addRecentFile: (path: string) => void
   removeRecentFile: (path: string) => void
+  setAIConsent: (consented: boolean) => void
+  isAIConsentDialogOpen: boolean
+  setAIConsentDialogOpen: (open: boolean) => void
 }
 
 const defaultSettings: Settings = {
@@ -130,6 +135,7 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
   isShortcutsDialogOpen: false,
   isAboutDialogOpen: false,
   isModelPickerOpen: false,
+  isAIConsentDialogOpen: false,
   dialogTab: 'general' as SettingsTab,
   effectiveTheme: 'dark',
   autosaveActive: true, // Runtime toggle, starts active
@@ -305,5 +311,22 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
       }
     })
     get().saveSettings()
-  }
+  },
+
+  setAIConsent: (consented) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        aiConsent: {
+          consented,
+          consentedAt: new Date().toISOString(),
+          version: AI_CONSENT_VERSION
+        }
+      },
+      isAIConsentDialogOpen: false
+    }))
+    get().saveSettings()
+  },
+
+  setAIConsentDialogOpen: (open) => set({ isAIConsentDialogOpen: open })
 })))

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -41,6 +41,11 @@ export interface Settings {
     mode: 'off' | 'auto' | 'custom'
     intervalSeconds: number  // only used when mode === 'custom'
   }
+  aiConsent?: {
+    consented: boolean      // User explicitly agreed to AI data disclosure
+    consentedAt?: string    // ISO timestamp of consent
+    version: number         // Consent version (bump when disclosure text changes materially)
+  }
 }
 
 export interface Document {


### PR DESCRIPTION
Implements the AI consent/disclosure flow for Mac App Store compliance.

## Changes

- First-run consent dialog (`AIConsentDialog.tsx`) shown before any AI API calls
- Settings → LLM tab AI enable/disable toggle with disclosure text
- API call guard in `useChat.ts` blocking sends without consent
- Consent state persisted in `settings.json` with versioning for future re-consent

Closes #238
Refs #127, #138

Generated with [Claude Code](https://claude.ai/code)