### PR TITLE
fix(remarkable): ensure sync directory exists on fresh install

### DIFF
--- a/src/main/remarkable/sync.ts
+++ b/src/main/remarkable/sync.ts
@@ -320,7 +320,8 @@ export async function syncAll(
       notebooks: {}
     }
 
-    // Ensure directories exist (visibleDir is same as baseDir, created with hiddenDir's parent)
+    // Ensure directories exist - create baseDir first, then hiddenDir
+    await mkdir(baseDir, { recursive: true })
     await mkdir(hiddenDir, { recursive: true })
 
     // Load sync state to see which notebooks are selected


### PR DESCRIPTION
## Summary
- Explicitly creates the base sync directory before the hidden `.remarkable/` subdirectory during sync
- On fresh install, the sync directory (e.g., `~/Documents/Remarkable`) may not exist yet
- While `mkdir(hiddenDir, { recursive: true })` implicitly creates parent dirs, making this explicit prevents subtle ordering issues

## Test plan
- [ ] Delete `~/Documents/Remarkable/` (or configured sync directory)
- [ ] Run reMarkable sync from Settings → Integrations
- [ ] Confirm directories are created and notebooks download successfully

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)