### PR TITLE
fix(editor): sort streaming tool calls by position to prevent shifts

### DIFF
--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -8,7 +8,7 @@ import { buildSystemPrompt, buildCommentsPrompt, buildSuggestionRepliesPrompt } 
 import { getApi } from '../lib/browserApi'
 import { getComments } from '../extensions/comments'
 import { getSuggestionsWithFeedback } from '../extensions/ai-suggestions'
-import { executeTool } from '../lib/tools'
+import { executeTool, resolveToolPosition } from '../lib/tools'
 import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
 
@@ -214,11 +214,38 @@ export function useChat() {
           documentId: useEditorStore.getState().document.documentId || '',
         }
 
+        // Sort editor-mutating tool calls by document position (descending)
+        // so bottom-of-document edits execute first and don't shift positions above
+        const EDITOR_MUTATING_TOOLS = new Set(['edit', 'insert', 'suggest_edit'])
+        const sortedToolCalls = [...toolCalls]
+        if (sortedToolCalls.some(tc => EDITOR_MUTATING_TOOLS.has(tc.name))) {
+          // Pre-resolve positions before any edits execute
+          const positions = sortedToolCalls.map(tc =>
+            EDITOR_MUTATING_TOOLS.has(tc.name)
+              ? resolveToolPosition(tc.name, tc.args as Record<string, unknown>)
+              : -1
+          )
+          // Stable sort: editor tools by position descending, non-editor tools keep original order
+          const indexed = sortedToolCalls.map((tc, i) => ({ tc, pos: positions[i], origIdx: i }))
+          indexed.sort((a, b) => {
+            const aIsEditor = EDITOR_MUTATING_TOOLS.has(a.tc.name)
+            const bIsEditor = EDITOR_MUTATING_TOOLS.has(b.tc.name)
+            if (aIsEditor && bIsEditor) {
+              if (a.pos === b.pos) return 0
+              return b.pos > a.pos ? 1 : -1 // descending position
+            }
+            if (aIsEditor && !bIsEditor) return 1 // editor tools after non-editor
+            if (!aIsEditor && bIsEditor) return -1 // non-editor tools first
+            return a.origIdx - b.origIdx // preserve original order for non-editor
+          })
+          sortedToolCalls.splice(0, sortedToolCalls.length, ...indexed.map(x => x.tc))
+        }
+
         // Execute each tool and collect results
         const toolResults: Array<{ id: string; name: string; result: unknown }> = []
         let currentErrorSignature: string | null = null
 
-        for (const toolCall of toolCalls) {
+        for (const toolCall of sortedToolCalls) {
           const result = await executeTool(toolCall.name, toolCall.args, state.toolMode, provenance)
           toolResults.push({ id: toolCall.id, name: toolCall.name, result })
 

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -33,6 +33,41 @@ function isEditorReadOnly(): boolean {
 }
 
 /**
+ * Resolve the target document position for an editor-mutating tool call.
+ * Used to sort tool calls by position (descending) before batch execution,
+ * so bottom-of-document edits don't shift positions of earlier edits.
+ * Returns Infinity for tools that don't target a specific position.
+ */
+export function resolveToolPosition(toolName: string, args: Record<string, unknown>): number {
+  const editor = getEditor()
+  if (!editor) return Infinity
+
+  if (toolName === 'edit' || toolName === 'suggest_edit') {
+    const nodeId = args.nodeId as string
+    const search = args.search as string | undefined
+    if (!nodeId) return Infinity
+
+    let found = findNodeById(editor.state.doc, nodeId)
+    if (!found && search) {
+      found = findNodeByContent(editor.state.doc, search)
+    }
+    return found ? found.pos : Infinity
+  }
+
+  if (toolName === 'insert') {
+    const position = (args.position as string) || 'cursor'
+    switch (position) {
+      case 'start': return 0
+      case 'end': return editor.state.doc.content.size
+      case 'cursor': return editor.state.selection.from
+      default: return Infinity
+    }
+  }
+
+  return Infinity
+}
+
+/**
  * edit - Replace the content of a node by its ID.
  * Falls back to content matching if the nodeId is stale.
  */

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -24,7 +24,8 @@ import {
   executeSuggestEdit,
   executeAcceptDiff,
   executeRejectDiff,
-  executeListDiffs
+  executeListDiffs,
+  resolveToolPosition
 } from './executors/editor'
 
 // File executors
@@ -141,5 +142,6 @@ export function getAvailableTools(): string[] {
  * Re-export types and utilities.
  */
 export { checkToolAccess, getDefaultMode } from './modes'
+export { resolveToolPosition }
 export type { ToolResult, ToolMode } from '../../../shared/tools/types'
 export { toolSuccess, toolError } from '../../../shared/tools/types'


### PR DESCRIPTION
## Summary
- Pre-resolves document positions for all editor-mutating tool calls before executing any edits
- Sorts `edit`, `insert`, and `suggest_edit` calls by position descending (bottom-up) so edits at higher document positions execute first
- Prevents position cascade where earlier edits shift the document and cause subsequent edits to target wrong positions
- Non-editor tools (read, search, etc.) maintain original order and execute before editor tools

## Implementation
- Added `resolveToolPosition()` in `editor.ts` that finds target positions for tool calls without executing them
- Sorting in `useChat.ts` uses a stable sort: non-editor tools first (original order), then editor tools by descending position

## Test plan
- [ ] Open a document with multiple paragraphs
- [ ] Ask AI to edit both the first and last paragraphs simultaneously (e.g., "rewrite the first and last paragraphs")
- [ ] Verify both edits apply correctly without content corruption
- [ ] Also test single-edit scenarios to confirm no regression

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)