### PR TITLE
refactor(editor): reconcile preview and read-only modes

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -38,7 +38,7 @@ export function Editor() {
   const { document, setContent, openFile, saveFile } = useEditor()
   const isEditing = useEditorStore((state) => state.isEditing)
   const isRemarkableReadOnly = useEditorStore((state) => state.isRemarkableReadOnly)
-  const isPreviewReadOnly = useEditorStore((state) => state.isPreviewReadOnly)
+  const isPreviewTab = useEditorStore((state) => state.isPreviewTab)
   const annotationsVisible = useEditorStore((state) => state.annotationsVisible)
   const toggleAnnotationsVisible = useEditorStore((state) => state.toggleAnnotationsVisible)
   const { settings, setDialogOpen, setShortcutsDialogOpen, setModelPickerOpen } = useSettings()
@@ -120,7 +120,7 @@ export function Editor() {
       handleDOMEvents: {
         mousedown: () => {
           // Clicking the editor while in preview mode promotes the tab
-          if (useEditorStore.getState().isPreviewReadOnly) {
+          if (useEditorStore.getState().isPreviewTab) {
             promoteCurrentPreview()
           }
           return false
@@ -257,8 +257,8 @@ export function Editor() {
   // Update editor editability when read-only mode changes (reMarkable or preview tab)
   useEffect(() => {
     if (!editor) return
-    editor.setEditable(!isRemarkableReadOnly && !isPreviewReadOnly)
-  }, [editor, isRemarkableReadOnly, isPreviewReadOnly])
+    editor.setEditable(!isRemarkableReadOnly && !isPreviewTab)
+  }, [editor, isRemarkableReadOnly, isPreviewTab])
 
   // Check if current file is linked to a reMarkable notebook
   useEffect(() => {
@@ -349,7 +349,7 @@ export function Editor() {
     // Only focus once per document load
     if (hasFocusedRef.current) return
     // Don't steal focus during preview tab navigation
-    if (useEditorStore.getState().isPreviewReadOnly) return
+    if (useEditorStore.getState().isPreviewTab) return
 
     const shouldShowEmptyState = !isEditing && !document.path && !document.content && !document.isDirty
     if (editor && !shouldShowEmptyState) {
@@ -613,13 +613,13 @@ export function Editor() {
   // Focus editor when transitioning from empty state to editing
   // (skip during preview tab navigation — editor is non-editable)
   useEffect(() => {
-    if (!showEmptyState && editor && !isPreviewReadOnly) {
+    if (!showEmptyState && editor && !isPreviewTab) {
       // Small delay to ensure editor is mounted and ready
       requestAnimationFrame(() => {
         editor.commands.focus()
       })
     }
-  }, [showEmptyState, editor, isPreviewReadOnly])
+  }, [showEmptyState, editor, isPreviewTab])
 
   return (
     <div className="h-full flex flex-col relative">

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -38,7 +38,7 @@ export function promoteCurrentPreview(): void {
   if (previewTab) {
     useTabStore.getState().promotePreviewTab(previewTab.id)
   }
-  useEditorStore.getState().setPreviewReadOnly(false)
+  useEditorStore.getState().setPreviewTab(false)
   if (chatPanelStateBeforePreview !== null) {
     useChatStore.getState().setPanelOpen(chatPanelStateBeforePreview)
     chatPanelStateBeforePreview = null
@@ -274,7 +274,7 @@ export function useTabs() {
     const existingTab = getTabByPath(filePath)
     if (existingTab) {
       // Promote preview tab to permanent, or clear preview browsing mode
-      if (existingTab.isPreview || useEditorStore.getState().isPreviewReadOnly) {
+      if (existingTab.isPreview || useEditorStore.getState().isPreviewTab) {
         promoteCurrentPreview()
       }
       await switchToTab(existingTab.id)
@@ -388,7 +388,7 @@ export function useTabs() {
    */
   const openFileInPreviewTab = useCallback(async (filePath: string): Promise<boolean> => {
     // Set editor to non-editable so ProseMirror can't steal focus
-    useEditorStore.getState().setPreviewReadOnly(true)
+    useEditorStore.getState().setPreviewTab(true)
 
     // Close chat panel during preview (save state so we can restore on promote)
     if (chatPanelStateBeforePreview === null) {
@@ -416,7 +416,7 @@ export function useTabs() {
 
     // Read file content
     if (!window.api) {
-      useEditorStore.getState().setPreviewReadOnly(false)
+      useEditorStore.getState().setPreviewTab(false)
       return false
     }
     const content = await window.api.readFile(filePath)

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -20,6 +20,15 @@ function getEditor(): Editor | null {
 }
 
 /**
+ * Check if the editor is in a read-only mode (reMarkable OCR or preview tab).
+ * AI tools should not mutate the document in these modes.
+ */
+function isEditorReadOnly(): boolean {
+  const state = useEditorStore.getState()
+  return state.isRemarkableReadOnly || state.isPreviewTab
+}
+
+/**
  * edit - Replace the content of a node by its ID.
  * Falls back to content matching if the nodeId is stale.
  */
@@ -32,6 +41,10 @@ export function executeEdit(args: {
 
   if (!editor) {
     return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
+  }
+
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
   const { nodeId, content, search } = args
@@ -86,6 +99,10 @@ export function executeInsert(args: {
 
   if (!editor) {
     return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
+  }
+
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
   const { text, position = 'cursor' } = args
@@ -148,6 +165,10 @@ export function executeSuggestEdit(
 
   if (!editor) {
     return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
+  }
+
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
   const { nodeId, content, comment, search } = args

--- a/src/renderer/stores/editorStore.ts
+++ b/src/renderer/stores/editorStore.ts
@@ -30,8 +30,8 @@ interface EditorState {
   lastSelection: SelectionCache | null
   // Autosave in-progress flag (true only during the actual save call)
   isAutosaving: boolean
-  // Preview tab read-only mode (prevents editor from stealing focus)
-  isPreviewReadOnly: boolean
+  // Preview tab mode: single-click file opens as non-editable preview; clicking editor promotes to edit
+  isPreviewTab: boolean
   // AI annotation visibility toggle
   annotationsVisible: boolean
   setDocument: (doc: Partial<Document>) => void
@@ -53,7 +53,7 @@ interface EditorState {
   setLastSelection: (sel: SelectionCache | null) => void
   getLastSelection: () => SelectionCache | null
   setAutosaving: (isAutosaving: boolean) => void
-  setPreviewReadOnly: (val: boolean) => void
+  setPreviewTab: (val: boolean) => void
   toggleAnnotationsVisible: () => void
 }
 
@@ -78,7 +78,7 @@ export const useEditorStore = create<EditorState>()(
     readCache: { content: null, documentId: null },
     lastSelection: null,
     isAutosaving: false,
-    isPreviewReadOnly: false,
+    isPreviewTab: false,
     annotationsVisible: true,
 
     setDocument: (doc) =>
@@ -192,7 +192,7 @@ export const useEditorStore = create<EditorState>()(
     getLastSelection: () => get().lastSelection,
 
     setAutosaving: (isAutosaving) => set({ isAutosaving }),
-    setPreviewReadOnly: (val) => set({ isPreviewReadOnly: val }),
+    setPreviewTab: (val) => set({ isPreviewTab: val }),
 
     toggleAnnotationsVisible: () =>
       set((state) => ({ annotationsVisible: !state.annotationsVisible }))


### PR DESCRIPTION
## Summary
- Renames `isPreviewReadOnly` to `isPreviewTab` across all files for clarity
- Documents the distinction between the two read-only modes:
  - `isRemarkableReadOnly`: viewing reMarkable OCR output before transforming to editable
  - `isPreviewTab`: single-click file preview that promotes to edit on click
- Adds read-only guards to AI tool executors (`edit`, `insert`, `suggest_edit`) to prevent document mutation when the editor is in either read-only mode

## Test plan
- [ ] Open a reMarkable OCR document — should show transform button, editor is read-only, AI tools return error
- [ ] Single-click a file in sidebar — preview tab opens, editor is read-only
- [ ] Click in editor during preview — tab promotes to edit mode, editor becomes editable
- [ ] AI suggestions in normal edit mode work correctly (no regression)

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)