### PR TITLE
fix(electron): prevent HMR reloads from stealing window focus

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -128,8 +128,12 @@ function createWindow(): BrowserWindow {
     }
   })
 
+  let hasBeenShown = false
   mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
+    if (!hasBeenShown) {
+      mainWindow.show()
+      hasBeenShown = true
+    }
   })
 
   // Notify renderer of fullscreen changes (for traffic light padding)


### PR DESCRIPTION
## Summary

- Track whether the window has been shown once via a `hasBeenShown` flag
- On first `ready-to-show`, call `show()` as before (so the app focuses on launch)
- On subsequent `ready-to-show` events (HMR reloads), skip `show()` — the window stays visible without stealing focus

## Test plan

- [ ] `npm run dev`, switch to another app, edit a renderer file — confirm Prose does **not** steal focus
- [ ] Kill dev server, restart — confirm initial launch still brings the window to the foreground

Fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)