### PR TITLE
fix(ci): prompt cloud agents to open PRs on completion

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -73,3 +73,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Follow the instructions in CLAUDE.md for commit conventions and branch naming.
+
+            When you complete implementation work on an issue, always open a pull request
+            using `gh pr create`. The PR should:
+            - Reference the issue (e.g., "Fixes #<number>") in the body
+            - Use conventional commit format for the title
+            - Include a brief summary and test plan in the body
+
+            If the trigger is just a question or discussion (not implementation), respond
+            with a comment instead.


### PR DESCRIPTION
## Summary

- Adds a `prompt` parameter to the `claude` job in `claude.yml` instructing cloud agents to open PRs after completing implementation work
- Agents will use `gh pr create` with issue references, conventional commit titles, and test plans
- Non-implementation triggers (questions/discussion) still get comment responses only

## Context

Previously, cloud agents would commit work to a branch and post a summary comment on the issue with a link to manually open a PR. This closes the loop by having the agent create the PR automatically.

No new dependencies needed — `gh` is pre-installed on GitHub-hosted runners and auto-authenticates via `GITHUB_TOKEN`.

## Test plan

- [ ] Push to `main` and trigger a cloud agent via `@claude` on a test issue
- [ ] Verify the agent creates a branch, commits, and opens a PR (not just a comment)
- [ ] Verify the PR body references the issue with "Fixes #N"

🤖 Generated with [Claude Code](https://claude.com/claude-code)