### PR TITLE
test(e2e): fix Playwright infrastructure for CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  issue_comment:
+    types: [created]
+
+jobs:
+  e2e:
+    # Only run on PRs, or on /test comments (but not @claude mentions)
+    if: |
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/test') &&
+        !contains(github.event.comment.body, '@claude')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Install Playwright system deps
+        run: npx playwright install --with-deps
+
+      - name: Build Electron app
+        run: npm run build
+
+      - name: Run E2E tests
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: npx playwright test
+          options: -screen 0 1280x1024x24
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-results
+          path: |
+            test-results.json
+            test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,10 @@ electron-screenshot-*.jpeg
 qa-screenshots/
 *.code-workspace
 
+# Playwright
+test-results/
+test-results.json
+playwright-report/
+
 # Claude Code
 .claude/settings.local.json

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared test helpers for Playwright Electron tests.
+ *
+ * These helpers are consumed by both CI (Playwright CLI) and local dev
+ * (Circuit Electron MCP). They wrap common patterns for interacting with
+ * the TipTap editor, toolbar, and app chrome.
+ */
+
+import { type ElectronApplication, type Page, _electron as electron } from '@playwright/test'
+import { findLatestBuild, parseElectronApp } from 'electron-playwright-helpers'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+
+// ---------------------------------------------------------------------------
+// Selectors — single source of truth for both tiers
+// ---------------------------------------------------------------------------
+
+export const selectors = {
+  editor: '.ProseMirror',
+  editorContent: '.prose-editor',
+  emptyState: '[data-testid="empty-state"]',
+  chatInput: 'textarea',
+  fileList: '[data-testid="file-list"]',
+  toolbar: '[data-testid="toolbar"]',
+} as const
+
+// ---------------------------------------------------------------------------
+// Launch helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Launch the Electron app for testing.
+ *
+ * In CI, launches from the built output (requires `npm run build` first).
+ * Locally, can optionally launch from source via electron-vite dev.
+ */
+export async function launchApp(): Promise<{ app: ElectronApplication; page: Page }> {
+  const projectRoot = resolve(__dirname, '..')
+
+  // Try to find a packaged build first (electron-builder output)
+  let appPath: string
+  try {
+    appPath = findLatestBuild(projectRoot)
+    console.log(`[e2e] Using packaged build: ${appPath}`)
+  } catch {
+    // No packaged build — launch from source using electron-vite output
+    appPath = resolve(projectRoot, 'out/main/index.js')
+    if (!existsSync(appPath)) {
+      throw new Error(
+        `Build output not found at ${appPath}. Run "npm run build" before running tests.`,
+      )
+    }
+    console.log(`[e2e] Using dev build: ${appPath}`)
+  }
+
+  // Determine if we're launching a packaged app or from source
+  const isPackaged = !appPath.endsWith('.js')
+
+  let app: ElectronApplication
+
+  if (isPackaged) {
+    const appInfo = parseElectronApp(appPath)
+    app = await electron.launch({
+      executablePath: appInfo.executable,
+      args: [appInfo.main],
+    })
+  } else {
+    app = await electron.launch({
+      args: [appPath],
+    })
+  }
+
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+
+  return { app, page }
+}
+
+// ---------------------------------------------------------------------------
+// Editor interaction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wait for the TipTap editor to be mounted and ready.
+ *
+ * The editor instance is exposed as `window.__prose_editor` by the renderer.
+ * Note: this reference becomes `null` after a file close, so callers should
+ * re-call `waitForEditor` if they reopen a document.
+ */
+export async function waitForEditor(page: Page): Promise<void> {
+  await page.waitForSelector(selectors.editor, { state: 'attached', timeout: 10_000 })
+}
+
+/** Get the editor's JSON document via window.editor. */
+export async function getEditorJSON(page: Page): Promise<unknown> {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    return editor?.getJSON() ?? null
+  })
+}
+
+/** Get the editor's markdown content. */
+export async function getEditorMarkdown(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    return editor?.storage?.markdown?.getMarkdown() ?? ''
+  })
+}
+
+/** Set the editor content via TipTap commands (bypasses input pipeline). */
+export async function setEditorContent(page: Page, html: string): Promise<void> {
+  await page.evaluate((content) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    editor?.commands.setContent(content)
+  }, html)
+}
+
+/** Type into the editor using real keyboard events (goes through ProseMirror). */
+export async function typeInEditor(page: Page, text: string): Promise<void> {
+  await page.click(selectors.editor)
+  await page.keyboard.type(text)
+}
+
+/** Check if the editor is in the empty state (no document open). */
+export async function isEmptyState(page: Page): Promise<boolean> {
+  const placeholder = await page.locator(selectors.editor).getAttribute('data-placeholder')
+  // When empty, TipTap shows the placeholder "Start writing..."
+  const text = await page.locator(selectors.editor).innerText()
+  return text.trim() === '' && placeholder !== null
+}
+
+/** Run a TipTap chain command (e.g., toggleBold, toggleItalic). */
+export async function runEditorCommand(page: Page, command: string): Promise<void> {
+  await page.evaluate((cmd) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    if (editor) {
+      const chain = editor.chain().focus()
+      if (typeof chain[cmd] === 'function') {
+        chain[cmd]().run()
+      }
+    }
+  }, command)
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Smoke test — verifies the app launches, the editor mounts,
+ * and basic text input works.
+ */
+
+import { test, expect } from '@playwright/test'
+import {
+  launchApp,
+  waitForEditor,
+  typeInEditor,
+  getEditorMarkdown,
+  setEditorContent,
+  runEditorCommand,
+} from './helpers'
+import type { ElectronApplication, Page } from '@playwright/test'
+
+let app: ElectronApplication
+let page: Page
+
+test.beforeAll(async () => {
+  const launched = await launchApp()
+  app = launched.app
+  page = launched.page
+})
+
+test.afterAll(async () => {
+  await app?.close()
+})
+
+test('app window opens with correct title', async () => {
+  const title = await page.title()
+  // Electron app title — may be "prose" or "Prose" depending on build
+  expect(title.toLowerCase()).toContain('prose')
+})
+
+test('editor mounts and accepts input', async () => {
+  await waitForEditor(page)
+
+  // Type some text
+  await typeInEditor(page, 'Hello from Playwright')
+
+  // Verify via markdown export
+  const markdown = await getEditorMarkdown(page)
+  expect(markdown).toContain('Hello from Playwright')
+})
+
+test('bold formatting works via command', async () => {
+  // Clear and set fresh content
+  await setEditorContent(page, '<p>format me</p>')
+
+  // Select all and toggle bold
+  await page.click('.ProseMirror')
+  await page.keyboard.press('ControlOrMeta+A')
+  await runEditorCommand(page, 'toggleBold')
+
+  // Check that bold mark is active
+  const isBold = await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    return editor?.isActive('bold') ?? false
+  })
+  expect(isBold).toBe(true)
+})
+
+test('keyboard shortcut Cmd+B toggles bold', async () => {
+  await setEditorContent(page, '<p>shortcut test</p>')
+
+  await page.click('.ProseMirror')
+  await page.keyboard.press('ControlOrMeta+A')
+  await page.keyboard.press('ControlOrMeta+B')
+
+  const isBold = await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    return editor?.isActive('bold') ?? false
+  })
+  expect(isBold).toBe(true)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/node": "^22.10.2",
         "@types/react": "^18.3.17",
         "@types/react-dom": "^18.3.5",
@@ -74,6 +75,7 @@
         "autoprefixer": "^10.4.20",
         "electron": "^40.4.0",
         "electron-builder": "^26.8.1",
+        "electron-playwright-helpers": "^2.1.0",
         "electron-vite": "^5.0.0",
         "postcss": "^8.4.49",
         "react": "^18.3.1",
@@ -223,6 +225,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1221,7 +1224,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1243,7 +1245,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1260,7 +1261,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1275,7 +1275,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2366,6 +2365,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3808,6 +3823,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.1.tgz",
       "integrity": "sha512-nkerkl8syHj44ZzAB7oA2GPmmZINKBKCa79FuNvmGJrJ4qyZwlkDzszud23YteFZEytbc87kVd/fP76ROS6sLg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4193,6 +4209,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.1.tgz",
       "integrity": "sha512-ijKo3+kIjALthYsnBmkRXAuw2Tswd9gd7BUR5OMfIcjGp8v576vKxOxrRfuYiUM78GPt//P0sVc1WV82H5N0PQ==",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4435,6 +4452,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4445,6 +4463,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4613,6 +4632,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.3.tgz",
       "integrity": "sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ==",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.2",
         "@ai-sdk/provider": "3.0.0",
@@ -4632,6 +4652,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5228,6 +5249,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5909,8 +5931,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6102,6 +6123,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -6276,6 +6298,7 @@
       "integrity": "sha512-31l4V7Ys4oUuXyaN/cCNnyBdDXN9RwOVOG+JhiHCf4zx5tZkHd43PKGY6KLEWpeYCxaphsuGSEjagJLfPqKj8g==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -6360,6 +6383,16 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-playwright-helpers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/electron-playwright-helpers/-/electron-playwright-helpers-2.1.0.tgz",
+      "integrity": "sha512-aQOefS1irz/Ou6IYuTE34ZLmIKVHKoTGUwkVuwu2P5iguuMTLtsg6CFImsWu0cabRPVZ1NgEpcGPumFZNDdrqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.2.4"
       }
     },
     "node_modules/electron-publish": {
@@ -6460,7 +6493,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6481,7 +6513,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6520,16 +6551,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -7582,6 +7603,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7966,6 +7988,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8656,7 +8679,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9293,6 +9315,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -9326,6 +9395,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9464,7 +9534,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9482,7 +9551,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9638,6 +9706,7 @@
       "version": "1.25.4",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9664,6 +9733,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9708,6 +9778,7 @@
       "version": "1.41.4",
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
       "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -9843,6 +9914,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9854,6 +9926,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10105,7 +10178,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10834,6 +10906,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -10907,7 +10980,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -11039,6 +11111,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11237,6 +11310,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11449,6 +11523,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12045,6 +12120,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12226,6 +12302,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "build:linux": "npm run build && electron-builder --linux",
     "dev:web": "vite --config vite.web.config.ts",
     "build:web": "vite build --config vite.web.config.ts",
-    "preview:web": "vite preview --config vite.web.config.ts --open"
+    "preview:web": "vite preview --config vite.web.config.ts --open",
+    "test:e2e": "npm run build && npx playwright test",
+    "test:e2e:dev": "npx playwright test",
+    "typecheck:e2e": "tsc --project tsconfig.e2e.json --noEmit"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.1",
@@ -76,6 +79,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.17",
     "@types/react-dom": "^18.3.5",
@@ -84,6 +88,7 @@
     "autoprefixer": "^10.4.20",
     "electron": "^40.4.0",
     "electron-builder": "^26.8.1",
+    "electron-playwright-helpers": "^2.1.0",
     "electron-vite": "^5.0.0",
     "postcss": "^8.4.49",
     "react": "^18.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  globalTimeout: 120_000,
+  workers: 1,
+  fullyParallel: false,
+  retries: 1,
+  reporter: process.env.CI
+    ? [
+        ['json', { outputFile: 'test-results.json' }],
+        ['github'],
+      ]
+    : 'list',
+  use: {
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+})

--- a/src/renderer/stores/editorInstanceStore.ts
+++ b/src/renderer/stores/editorInstanceStore.ts
@@ -14,5 +14,10 @@ interface EditorInstanceState {
 
 export const useEditorInstanceStore = create<EditorInstanceState>()(subscribeWithSelector((set) => ({
   editor: null,
-  setEditor: (editor) => set({ editor }),
+  setEditor: (editor) => {
+    // Expose editor on window for Playwright / Circuit Electron testing
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__prose_editor = editor
+    set({ editor })
+  },
 })))

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "node",
+    "allowImportingTsExtensions": false
+  },
+  "include": ["e2e/**/*"]
+}


### PR DESCRIPTION
## Summary

- Fix keyboard shortcuts (`Meta+` → `ControlOrMeta+`) so tests pass on Linux CI
- Add serial execution (`workers: 1`) and global timeout (120s) to prevent LevelDB conflicts and hung CI
- Switch CI reporter to `json` + `github` for inline PR annotations
- Tighten `e2e.yml` PR guard to match `claude.yml` pattern (require `issue.pull_request`, exclude `@claude`)
- Add `existsSync` build check with actionable error message
- Create `tsconfig.e2e.json` for e2e type checking
- Add `test:e2e:dev` and `typecheck:e2e` convenience scripts

Fixes #289

## Test plan

- [x] `npm run typecheck:e2e` exits 0
- [x] `npm run test:e2e` — all 4 tests pass (builds + runs)
- [x] `npm run test:e2e:dev` — runs against existing build, 4/4 pass
- [ ] Verify `e2e.yml` diff matches `claude.yml` PR guard pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)