### PR TITLE
fix(security): restrict MCP HTTP server CORS to app:// origin

### DIFF
--- a/src/main/mcp/http-server.ts
+++ b/src/main/mcp/http-server.ts
@@ -116,10 +116,16 @@ export class McpHttpServer {
 
     // Create HTTP server
     this.httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      // Handle CORS for browser-based clients
-      res.setHeader('Access-Control-Allow-Origin', '*')
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id')
+      // Restrict CORS to the Electron app origin only.
+      // Wildcard (*) would allow any web page the user visits to invoke MCP tools.
+      // Claude Desktop uses stdio transport, not HTTP, so it is unaffected by this header.
+      const origin = req.headers['origin'] as string | undefined
+      const allowedOrigin = 'app://'
+      if (origin === allowedOrigin) {
+        res.setHeader('Access-Control-Allow-Origin', allowedOrigin)
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id')
+      }
 
       if (req.method === 'OPTIONS') {
         res.writeHead(204)


### PR DESCRIPTION
## Summary

- Replaces `Access-Control-Allow-Origin: *` in the MCP HTTP server with a conditional header that only allows the Electron app origin (`app://`)
- CORS headers (Allow-Origin, Allow-Methods, Allow-Headers) are now set only when the incoming `Origin` header matches `app://`; requests from any other origin — including arbitrary web pages — receive no ACAO header and are blocked by the browser
- Preflight (OPTIONS) responses are subject to the same origin check, so the restriction applies consistently to both simple and preflighted requests

## Note on Claude Desktop

Claude Desktop connects to the MCP server via stdio transport, not HTTP. It does not send an `Origin` header and is completely unaffected by this change. The HTTP server is already marked `@deprecated` in favor of the Unix socket server; this fix hardens it while it remains in the codebase.

## Test plan

- [ ] Build passes: `npm run build` completes without errors
- [ ] From the Electron renderer (`app://` origin), MCP requests to `http://localhost:9877/mcp` succeed (ACAO header present)
- [ ] From a web browser or any other origin, cross-origin requests to `http://localhost:9877/mcp` are rejected by the browser (no ACAO header returned)
- [ ] Claude Desktop stdio integration is unaffected (no origin header sent)

Fixes #303
Refs #127