### PR TITLE
fix(security): warn when secure storage is unavailable

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -477,6 +477,11 @@ export function setupIpcHandlers(): void {
     }
   })
 
+  // Settings: Check if secure storage is available
+  ipcMain.handle('settings:isSecureStorageAvailable', () => {
+    return credentialStore.isAvailable()
+  })
+
   // Settings: Save to ~/.prose/settings.json
   ipcMain.handle('settings:save', async (_event, settings: Settings) => {
     try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -175,6 +175,7 @@ export interface ElectronAPI {
   loadSettings: () => Promise<Settings>
   saveSettings: (settings: Settings) => Promise<void>
   testApiKey: (request: TestApiKeyRequest) => Promise<TestApiKeyResult>
+  isSecureStorageAvailable: () => Promise<boolean>
   onMenuAction: (callback: (action: string) => void) => () => void
   onFileOpenExternal: (callback: (path: string) => void) => () => void
   llmChat: (request: LLMRequest) => Promise<LLMResponse>
@@ -316,6 +317,7 @@ const api: ElectronAPI = {
   loadSettings: () => ipcRenderer.invoke('settings:load'),
   saveSettings: (settings: Settings) => ipcRenderer.invoke('settings:save', settings),
   testApiKey: (request: TestApiKeyRequest) => ipcRenderer.invoke('settings:testApiKey', request),
+  isSecureStorageAvailable: () => ipcRenderer.invoke('settings:isSecureStorageAvailable'),
   onMenuAction: (callback: (action: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, action: string): void => {
       callback(action)

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -71,6 +71,15 @@ export function SettingsDialog() {
   const [testingApiKey, setTestingApiKey] = useState(false)
   const [apiKeyTestResult, setApiKeyTestResult] = useState<{ success: boolean; message: string } | null>(null)
 
+  // Secure storage availability check
+  const [secureStorageAvailable, setSecureStorageAvailable] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    if (window.api?.isSecureStorageAvailable) {
+      window.api.isSecureStorageAvailable().then(setSecureStorageAvailable)
+    }
+  }, [])
+
   // Custom model input (for when user wants to enter a model not in the list)
   const [customModel, setCustomModel] = useState(false)
 
@@ -574,6 +583,12 @@ export function SettingsDialog() {
                 {settings.llm.apiKey && !showApiKey && !apiKeyFormatError && (
                   <p className="text-xs text-muted-foreground">
                     Current key: {maskApiKey(settings.llm.apiKey)}
+                  </p>
+                )}
+                {secureStorageAvailable === false && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                    <AlertCircle className="h-3 w-3 shrink-0" />
+                    Secure storage is unavailable on this system. Your API key will be stored without encryption.
                   </p>
                 )}
               </div>

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -516,7 +516,10 @@ export const browserApi: ElectronAPI = {
 
   // Recent files - not available in browser
   refreshRecentMenu: async (): Promise<void> => {},
-  clearRecentFiles: async (): Promise<void> => {}
+  clearRecentFiles: async (): Promise<void> => {},
+
+  // Secure storage - not available in browser
+  isSecureStorageAvailable: async (): Promise<boolean> => false
 }
 
 /**

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -314,6 +314,7 @@ export interface ElectronAPI {
   loadSettings: () => Promise<Settings>
   saveSettings: (settings: Settings) => Promise<void>
   testApiKey: (request: TestApiKeyRequest) => Promise<TestApiKeyResult>
+  isSecureStorageAvailable: () => Promise<boolean>
   onMenuAction: (callback: (action: string) => void) => () => void
   onFileOpenExternal: (callback: (path: string) => void) => () => void
   llmChat: (request: LLMRequest) => Promise<LLMResponse>


### PR DESCRIPTION
## Summary

- Adds `settings:isSecureStorageAvailable` IPC channel that returns `credentialStore.isAvailable()`
- Exposes it through preload, renderer types, and browser API fallback (`false`)
- Shows an amber warning in Settings below the API key input when secure storage is unavailable: "Secure storage is unavailable on this system. Your API key will be stored without encryption."
- Does **not** block saving — warn only, per SEC-07 guidance

## Test plan

- [ ] Open Settings → verify no warning appears (macOS has safeStorage)
- [ ] Verify API key save/load still works normally
- [ ] Build passes (`npm run build`)

Refs #302, #127