### PR TITLE
fix(remarkable): preserve ocrPath when OCR fails on re-sync

### DIFF
--- a/src/main/remarkable/sync.ts
+++ b/src/main/remarkable/sync.ts
@@ -407,6 +407,19 @@ export async function syncAll(
             onProgress?.(`Saved OCR: ${ocrPath}`)
           }
 
+          // If OCR failed but a previous OCR file exists on disk, reuse it
+          if (!ocrPath) {
+            const ocrFileName = `${sanitizeName(doc.name)}.md`
+            const existingOcrFile = join(hiddenDir, doc.id, ocrFileName)
+            try {
+              await access(existingOcrFile)
+              ocrPath = join(doc.id, ocrFileName)
+              console.log(`[reMarkable] Reusing existing OCR file: ${ocrPath}`)
+            } catch {
+              // No existing file on disk either
+            }
+          }
+
           newMeta.notebooks[doc.id] = {
             ...existingEntry!,
             ocrPath,
@@ -465,6 +478,19 @@ export async function syncAll(
             await writeFile(ocrFullPath, markdown, 'utf-8')
             ocrPath = join(doc.id, ocrFileName)
             onProgress?.(`Saved OCR: ${ocrPath}`)
+          }
+
+          // If OCR failed but a previous OCR file exists on disk, reuse it
+          if (!ocrPath) {
+            const ocrFileName = `${sanitizeName(doc.name)}.md`
+            const existingOcrFile = join(hiddenDir, doc.id, ocrFileName)
+            try {
+              await access(existingOcrFile)
+              ocrPath = join(doc.id, ocrFileName)
+              console.log(`[reMarkable] Reusing existing OCR file: ${ocrPath}`)
+            } catch {
+              // No existing file on disk either
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

- When a notebook is untracked then re-added to sync, OCR runs again. If it fails (e.g., no API key), the metadata was overwritten without `ocrPath` — even though a valid OCR file from a previous sync still existed on disk
- This made the notebook un-openable from the Notebooks panel (clicks silently ignored)
- Both sync paths (OCR-only and download+OCR) now check for an existing OCR file on disk as a fallback when `processNotebookWithOCR` returns null

## Test plan

- [ ] Untrack a notebook that has OCR, sync, re-add it, sync again without an API key → `ocrPath` preserved via disk fallback
- [ ] Click the notebook in Notebooks panel → opens in read-only
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)