### PR TITLE
fix(e2e): dismiss onboarding dialogs before smoke tests

### DIFF
--- a/e2e/shared.ts
+++ b/e2e/shared.ts
@@ -22,6 +22,27 @@ export const selectors = {
 } as const
 
 // ---------------------------------------------------------------------------
+// App-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Dismiss the AI consent dialog that appears on first launch (no settings).
+ * Clicks "Use Without AI" if the dialog is visible; does nothing otherwise.
+ */
+export async function dismissConsentDialog(page: Page): Promise<void> {
+  const btn = page.getByRole('button', { name: 'Use Without AI' })
+  const visible = await btn.isVisible({ timeout: 3_000 }).catch(() => false)
+  if (visible) {
+    await btn.click()
+    // Wait for the overlay to disappear
+    await page.waitForSelector('[data-state="open"][aria-hidden="true"]', {
+      state: 'detached',
+      timeout: 3_000,
+    }).catch(() => {})
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Editor interaction helpers
 // ---------------------------------------------------------------------------
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -6,6 +6,7 @@
 import { test, expect } from '@playwright/test'
 import {
   launchApp,
+  dismissConsentDialog,
   waitForEditor,
   typeInEditor,
   getEditorMarkdown,
@@ -18,9 +19,20 @@ let app: ElectronApplication
 let page: Page
 
 test.beforeAll(async () => {
+  test.setTimeout(60_000)
+
   const launched = await launchApp()
   app = launched.app
   page = launched.page
+
+  // Dismiss onboarding dialogs shown on fresh installs
+  await dismissConsentDialog(page)
+
+  // DefaultHandlerPrompt ("Make Prose Your Default Markdown Editor") — appears after 1s delay
+  const gotItButton = page.getByRole('button', { name: 'Got It' })
+  if (await gotItButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await gotItButton.click()
+  }
 
   // If the app opens to the empty "Start Writing" state, create a new document
   const newDocButton = page.getByRole('button', { name: 'New Document' })


### PR DESCRIPTION
## Summary

- On fresh installs (CI), the **AI consent dialog** and **default handler prompt** overlay the editor with a full-screen modal backdrop, blocking all pointer events
- The E2E smoke tests now dismiss both dialogs in `beforeAll` before interacting with the editor
- Added `dismissConsentDialog()` as a shared helper in `e2e/shared.ts` for reuse
- Increased `beforeAll` timeout to 60s to accommodate Electron launch + dialog dismissal

This is the root cause of **all** E2E editor-mount timeout failures on CI — the tests have never passed because this dialog was never dismissed.

## Test plan

- [x] `npx playwright test e2e/smoke.spec.ts` passes locally (4/4)
- [ ] CI E2E workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)