### PR TITLE
fix(ci): let claude-code-action handle review posting natively

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,34 +37,18 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Determine PR number
-        id: pr
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: 'claude'
-          claude_args: '--allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Glob,Grep"'
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ steps.pr.outputs.number }}
-
             Review this pull request. Focus on:
             - Code correctness and potential bugs
             - Security concerns
             - Performance implications
 
             Be concise. Only comment on significant issues - if the code looks good, say so briefly.
-
-            IMPORTANT: Post your review as a PR comment using `gh pr comment ${{ steps.pr.outputs.number }}`
-            Do not just output text - you must use the gh command to post your feedback.
 
   # Manual invocation via @claude mentions
   claude:


### PR DESCRIPTION
## Summary

- The `auto-review` job had custom `claude_args` with `--allowedTools "Bash(gh pr comment:*),..."` patterns that weren't matching Claude's actual tool calls, causing **13 permission denials per run**
- Claude spent $0.80 and 11 turns trying to post a review comment that kept getting blocked
- Removed the custom tool allowlist and manual `gh pr comment` prompt — `claude-code-action` handles PR comment posting natively in agent mode
- Cleaned up the now-unused "Determine PR number" step

## Test plan

- [ ] This PR's own auto-review job should post a review comment (meta-test!)
- [ ] Verify on a subsequent PR that the review comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)