### PR TITLE
fix(ci): remove restrictive allowedTools from cloud agent job

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,7 +76,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: '--allowedTools "Read,Write,Edit,Glob,Grep,Bash,TodoWrite"'
           prompt: |
             You are an autonomous coding agent. Implement the changes described in the
             GitHub issue or comment that triggered this workflow. Do NOT list or browse


### PR DESCRIPTION
## Summary

- The `claude` job (cloud agent for @claude mentions) had `claude_args: '--allowedTools "Read,Write,Edit,Glob,Grep,Bash,TodoWrite"'` which overrode the action's default tool set
- This cut off `gh` CLI and GitHub integration tools, so the agent couldn't fetch PR comments, create PRs, or interact with GitHub
- Removed the restriction — the action provides sensible defaults including all standard tools plus GitHub access

Same root cause as #322 (auto-review job), just the other job in the workflow.

## Test plan

- [ ] Next `@claude` mention on an issue/PR should have `gh` CLI access

🤖 Generated with [Claude Code](https://claude.com/claude-code)