### PR TITLE
fix(ci): set bypassPermissions for Claude Code jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: 'claude'
+          settings: |
+            {
+              "permissions": {
+                "defaultMode": "bypassPermissions"
+              }
+            }
           prompt: |
             Review this pull request. Focus on:
             - Code correctness and potential bugs
@@ -76,6 +82,12 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
+          settings: |
+            {
+              "permissions": {
+                "defaultMode": "bypassPermissions"
+              }
+            }
           prompt: |
             You are an autonomous coding agent. Implement the changes described in the
             GitHub issue or comment that triggered this workflow. Do NOT list or browse


### PR DESCRIPTION
## Summary

- Both Claude Code jobs (`auto-review` and `claude`) ran with `permissionMode: "default"`, requiring interactive approval for every bash command
- In CI nobody can approve, so every `gh`, `env`, pipe, and `$()` command failed with "This command requires approval"
- Added `settings` input with `"defaultMode": "bypassPermissions"` to both jobs
- Also includes the previous fix: removed restrictive `--allowedTools` from the cloud agent job (#323)

## Test plan

- [ ] Merge, then `@claude` on any issue/PR and verify it can run `gh` commands
- [ ] Next PR opened should get an auto-review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)