### PR TITLE
fix(ci): use --dangerously-skip-permissions for Claude Code jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,12 +42,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: 'claude'
-          settings: |
-            {
-              "permissions": {
-                "defaultMode": "bypassPermissions"
-              }
-            }
+          claude_args: '--dangerously-skip-permissions'
           prompt: |
             Review this pull request. Focus on:
             - Code correctness and potential bugs
@@ -82,12 +77,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          settings: |
-            {
-              "permissions": {
-                "defaultMode": "bypassPermissions"
-              }
-            }
+          claude_args: '--dangerously-skip-permissions'
           prompt: |
             You are an autonomous coding agent. Implement the changes described in the
             GitHub issue or comment that triggered this workflow. Do NOT list or browse


### PR DESCRIPTION
## Summary

- The `settings` input with `permissions.defaultMode: "bypassPermissions"` writes to `~/.claude/settings.json` but the SDK ignores it — it always starts with `permissionMode: "default"`
- Replaced with `claude_args: '--dangerously-skip-permissions'` which passes through to the SDK as an `extraArg` and actually sets the permission mode
- Applied to both `auto-review` and `claude` jobs

Third time's the charm.

## Test plan

- [ ] Merge, then `@claude` on a PR and verify `gh` commands execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)