### PR TITLE
fix(ci): add posting instruction to auto-review prompt

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -95,6 +95,11 @@ jobs:
 
             This trailer is machine-readable and drives the downstream triage pipeline. Always include it.
 
+            ## Posting
+
+            You MUST post your review as a PR comment. Do not just output text.
+            Use: `gh pr comment <PR_NUMBER> --body "<your review>"`
+
   # Manual invocation via @claude mentions
   claude:
     if: |


### PR DESCRIPTION
## Summary

- `claude-code-action` in agent mode expects Claude to post its own review via `gh pr comment` — it does NOT auto-post the output
- Without the posting instruction, Claude runs the review internally but never posts anything (observed on PR #332)
- Adds explicit "You MUST post your review as a PR comment" instruction to the prompt

One-line fix. Merge directly to unblock pipeline testing.

Refs #327