### PR TITLE
fix(ci): close pipeline audit gaps

### DIFF
--- a/.github/scripts/run-pe-analysis.mjs
+++ b/.github/scripts/run-pe-analysis.mjs
@@ -23,7 +23,7 @@ if (!ANTHROPIC_API_KEY) {
 const reviewComment = readFileSync('/tmp/review-comment.txt', 'utf-8').trim()
 
 if (!reviewComment) {
-  console.error('No review comment found')
+  console.error('No review comment found. Run /review first to generate one, then /triage to re-analyze.')
   process.exit(1)
 }
 
@@ -71,7 +71,7 @@ Analyze the architectural risk of these changes. For each concern, explain:
 3. How severe the impact would be
 
 Determine the PRIVILEGE boundary status:
-- Set "privileged": true if ANY changed file matches: src/main/**, src/preload/**, electron-builder.*, electron.vite.config.*
+- Set "privileged": true if ANY changed file matches: src/main/**, src/preload/**, electron-builder.*, electron.vite.config.* (NOTE: this list is duplicated in claude.yml review prompt — keep both in sync)
 - Set "privileged": false otherwise
 
 Rate the overall risk as exactly one of: LOW, MEDIUM, HIGH, CRITICAL

--- a/.github/scripts/run-scorer.mjs
+++ b/.github/scripts/run-scorer.mjs
@@ -26,7 +26,7 @@ if (!ANTHROPIC_API_KEY) {
 const reviewComment = readFileSync('/tmp/review-comment.txt', 'utf-8').trim()
 
 if (!reviewComment) {
-  console.error('No review comment found')
+  console.error('No review comment found. Run /review first to generate one, then /triage to re-analyze.')
   process.exit(1)
 }
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -82,6 +82,7 @@ jobs:
             - [ ] Content Security Policy not weakened
 
             If the PR touches privilege-boundary files (`src/main/**`, `src/preload/**`, `electron-builder.*`, `electron.vite.config.*`), prepend your review with:
+            (NOTE: This list is duplicated in run-pe-analysis.mjs — keep both in sync)
 
             > **[SECURITY GATE]** This PR modifies Electron privilege-boundary code. Requires human review regardless of other findings.
 

--- a/.github/workflows/pipeline-fix.yml
+++ b/.github/workflows/pipeline-fix.yml
@@ -20,7 +20,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         (github.event.comment.user.login == 'github-actions[bot]' || github.event.comment.user.login == 'claude[bot]') &&
-        contains(github.event.comment.body, '<!-- orchestrator-verdict: auto-fix -->') &&
+        (contains(github.event.comment.body, '<!-- orchestrator-verdict: auto-fix -->') || contains(github.event.comment.body, '<!-- orchestrator-verdict: auto-fix-verify -->')) &&
         !contains(github.event.comment.body, '<!-- agent-fix-attempt:')
       )
     runs-on: ubuntu-latest
@@ -138,3 +138,25 @@ jobs:
             <!-- agent-fix-attempt: 1 -->
 
             Then summarize what you fixed in a brief list.
+
+      - name: Request human verification
+        if: steps.guard.outputs.attempts == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Check if this was an auto-fix-verify route (medium complexity, needs human sign-off)
+          VERDICT_COMMENT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | contains("<!-- orchestrator-verdict: auto-fix-verify -->"))] | length')
+          if [ "$VERDICT_COMMENT" -ge 1 ]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "<!-- human-verification-requested -->
+          ## Human Verification Requested
+
+          An automated fix was pushed for this PR, but the triage pipeline flagged it as
+          **auto-fix-verify** (medium complexity, low risk). Please review the fix commit
+          before merging.
+
+          **Action required:** A human must approve this PR before merge."
+          fi

--- a/.github/workflows/review-feedback.yml
+++ b/.github/workflows/review-feedback.yml
@@ -68,6 +68,17 @@ jobs:
             printf '%s' "$COMMENT_BODY" > /tmp/review-comment.txt
           fi
 
+      - name: Warn on missing verdict trailer
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "<!-- pipeline-bypass-warning -->
+          > **Pipeline bypass:** Review from claude[bot] contains \`## Code Review\` but no verdict trailer (\`<!-- review-verdict: ... -->\`). Falling back to legacy triage. If this is unexpected, check the review prompt in \`claude.yml\`."
+
       - name: Analyze review feedback
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Follow-up to #336 — closes gaps identified during pipeline audit.

- **Gap 1 (auto-fix-verify dead route):** `pipeline-fix.yml` trigger now matches both `auto-fix` and `auto-fix-verify` orchestrator verdicts. For `auto-fix-verify`, posts a "Human Verification Requested" comment after the fix commit.
- **Gap 3 (unhelpful error on /triage without review):** Scorer and PE scripts now say "Run /review first to generate one, then /triage to re-analyze."
- **Gap 4 (silent fallback to legacy triage):** `review-feedback.yml` posts a `<!-- pipeline-bypass-warning -->` comment when a claude[bot] review has `## Code Review` but no verdict trailer.
- **Privilege-boundary duplication:** Added cross-reference comments between `claude.yml` review prompt and `run-pe-analysis.mjs` so future edits stay in sync.

## Test plan

- [x] YAML syntax valid (`npx js-yaml` on all 3 modified workflows)
- [x] JS syntax valid (`node --check` on both modified scripts)
- [ ] Open a low-complexity PR to verify `auto-fix-verify` route triggers the fix workflow and posts verification comment

Refs #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)