### PR TITLE
fix(ci): route @claude /review to auto-review, not implementation agent

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,11 +15,11 @@ on:
 jobs:
   # Automatic code review on PR open, or on-demand via /review comment
   auto-review:
+    # /review always routes here, even if combined with @claude
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/review') &&
-      !contains(github.event.comment.body, '@claude')
+      contains(github.event.comment.body, '/review')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -95,7 +95,7 @@ jobs:
   # Manual invocation via @claude mentions
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))


### PR DESCRIPTION
## Summary

When a user comments `@claude /review` on a PR, both `@claude` and `/review` are present. The old routing:
- `auto-review`: excluded because `!contains('@claude')` → **skipped**
- `claude` (implementation): matched `@claude` → **ran, created duplicate PR #344**

New routing:
- `auto-review`: `/review` always wins, regardless of `@claude` → **runs review**
- `claude`: excludes comments containing `/review` → **skipped**

## Test plan

- [ ] Comment `/review` on a PR → auto-review fires, claude skips
- [ ] Comment `@claude /review` on a PR → auto-review fires, claude skips
- [ ] Comment `@claude fix this bug` on a PR → claude fires, auto-review skips

Refs #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)