### PR TITLE
fix(ci): use PAT for cross-workflow trigger comments

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Trigger auto-review
         if: steps.pr.outputs.number
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -97,7 +97,7 @@ jobs:
       - name: Post fix request
         if: steps.guard.outputs.attempts == '0'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Dispatch /pipeline
         if: steps.cmd.outputs.command == 'pipeline'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |

--- a/.github/workflows/pipeline-triage.yml
+++ b/.github/workflows/pipeline-triage.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Post orchestrator verdict
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         run: |
           gh pr comment "${{ steps.pr.outputs.number }}" \
             --body-file /tmp/orchestrator-output.md


### PR DESCRIPTION
## Summary

- Swap `github.token` → `secrets.PROJECT_TOKEN` in 4 comment-posting steps that must trigger downstream workflows
- Fixes silent pipeline breakage: `ci-gate.yml` posts `/review` but GitHub's anti-loop protection prevents `github.token`-created comments from firing `issue_comment` events, so `claude.yml` never triggers
- Only changes steps where comments must trigger downstream workflows; leaves `github.token` in place for `workflow_dispatch` calls and informational comments

### Changed workflows
| Workflow | Step | Why |
|----------|------|-----|
| `ci-gate.yml` | `trigger-review` (line 34) | `/review` comment must trigger `claude.yml` |
| `ci-gate.yml` | `post-fix-request` (line 100) | `@claude` comment must trigger `claude.yml` |
| `dispatch.yml` | `/pipeline` handler (line 84) | `/review` comment must trigger `claude.yml` |
| `pipeline-triage.yml` | `orchestrate` verdict (line 199) | Verdict comment must trigger `pipeline-fix.yml` |

## Test plan

- [ ] Open a new PR → E2E passes → verify Claude auto-review comment appears (triggered by `ci-gate.yml`)
- [ ] Comment `/review` on an existing PR → verify `claude.yml` fires
- [ ] Comment `/pipeline` on a PR → verify the full chain runs (review → triage → route)

Fixes #347
Refs #346, #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)