### PR TITLE
docs: update CLAUDE.md and roadmap skills for multi-agent workflow

### DIFF
--- a/.claude/skills/roadmap-prioritization/SKILL.md
+++ b/.claude/skills/roadmap-prioritization/SKILL.md
@@ -37,32 +37,34 @@ Group **open items only** by status column and present the current state:
 
 | Column | Purpose |
 |--------|---------|
-| **Do First** | Current sprint — active priorities |
-| **Do Next** | Queued — next in line after Do First clears |
+| **User Requested** | Feature requests from users — needs triage into another column |
+| **Do First** | Highest priority — work on these now |
+| **In Progress** | Actively being worked on by a human or agent |
+| **Do Next** | Next up after current work completes |
+| **Later** | Backlog — not yet prioritized |
 | **Quick Wins** | Low-effort items that can ship alongside bigger work |
 | **On Hold** | Blocked or waiting on external factors |
-| **Deferred** | Intentionally postponed — revisit later |
-| **User Requested** | Feature requests from users — needs triage into another column |
 
 Flag any column imbalances:
 - "Do First" is empty → refill from "Do Next"
 - "Do First" is overloaded (5+ items) → suggest narrowing focus
+- "In Progress" has items with no recent activity → flag as potentially stale
 - "User Requested" has untriaged items → flag for review
 
 ### 3. Assess Readiness
 
-For each item in "Do First" and "Do Next", evaluate:
+For each item in "Do First", "In Progress", and "Do Next", evaluate:
 
 - **Well-defined?** Has a description with clear scope, or needs decomposition
 - **Blocked?** Dependencies on other issues, external factors, or missing information
 - **In progress?** Has linked open PRs or `issue-<number>-*` branches
-- **Labels** — `bug` (higher urgency), `launch-blocker` (critical path), `enhancement`, `spike`
+- **Labels** — `bug` (higher urgency), `launch-blockers` (critical path), `feature-request`, `security`
 
 ### 4. Weigh Factors
 
 Apply these prioritization heuristics in order:
 
-1. **Board order is primary signal** — "Do First" > "Do Next" > "Quick Wins"
+1. **Board order is primary signal** — "Do First" > "In Progress" > "Do Next" > "Quick Wins"
 2. **Bugs before features** — bugs degrade existing experience
 3. **Launch blockers first** — if release is approaching, these gate shipping
 4. **Quick wins pair well** — a small fix alongside a bigger feature maintains momentum
@@ -80,6 +82,7 @@ Output a structured recommendation:
 | Column | Count | Notes |
 |--------|-------|-------|
 | Do First | 3 | All well-defined |
+| In Progress | 1 | #127 — active |
 | Do Next | 4 | #55 needs decomposition |
 | Quick Wins | 3 | Ready to ship |
 | ... | | |
@@ -107,18 +110,26 @@ Output a structured recommendation:
 
 ### 6. Optional: Update Board
 
-If the user approves changes (e.g., moving items between columns, triaging user requests):
+If the user approves changes (e.g., moving items between columns, triaging user requests), use **only safe item-level operations**:
 
 ```bash
-# Get project item IDs and field IDs
-gh project item-list 5 --owner solo-ist --format json
-gh project field-list 5 --owner solo-ist --format json
-
 # Move an item to a new status
 gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> --field-id <STATUS_FIELD_ID> --single-select-option-id <OPTION_ID>
+
+# Add an issue to the board
+gh project item-add 5 --owner solo-ist --url <ISSUE_URL>
+
+# Remove a closed item from the board
+gh project item-delete 5 --owner solo-ist --id <ITEM_ID>
 ```
 
 Never move items without explicit approval.
+
+## Dangerous Operations — DO NOT USE
+
+**NEVER use `updateProjectV2Field` to modify single-select field options.** This GraphQL mutation replaces option IDs, which silently disconnects every board item from its status — effectively wiping the entire board. This has happened before and required manual recovery.
+
+If the board needs a new status column or option changes, tell the user to do it manually in the GitHub UI.
 
 ## Key Principles
 
@@ -127,3 +138,4 @@ Never move items without explicit approval.
 - **Pragmatic sequencing.** Prefer shipping a bug fix + quick win over starting a multi-day feature.
 - **Context-aware.** If there are open PRs or in-progress branches, factor that in.
 - **Opinionated but deferential.** Give a clear recommendation, but the user decides.
+- **Never mutate field definitions.** Only move items between existing columns.

--- a/.claude/skills/roadmap-refinement/SKILL.md
+++ b/.claude/skills/roadmap-refinement/SKILL.md
@@ -13,7 +13,7 @@ Audit the backlog and project board, then present findings for approval before m
 /roadmap-refinement
 ```
 
-No arguments. Operates on `solo-ist/prose` and the Prose Roadmap project.
+No arguments. Operates on `solo-ist/prose` and the Prose Roadmap project (project #5).
 
 ## Workflow
 
@@ -35,7 +35,7 @@ For each open issue, check if it's likely completed:
 
 - **Linked merged PRs**: Issue referenced in a merged PR's body or commit messages
 - **Closed branches**: An `issue-<number>-*` branch exists but the issue is open
-- **Stale "In Progress"**: On the board as in-progress but no activity in 30+ days
+- **Stale "In Progress"**: On the board as In Progress but no activity in 30+ days
 
 Flag these as candidates for closing. Do NOT close automatically.
 
@@ -87,12 +87,52 @@ Output a structured report:
 
 ### 6. Execute on Approval
 
-Wait for the user to review the report. Then:
+Wait for the user to review the report. Then use **only safe operations**:
 
-1. Close approved issues with the suggested notes
-2. Add missing items to the project board
-3. Fix status assignments
-4. Optionally create follow-up issues for items that need decomposition
+**Closing issues:**
+```
+mcp__github__issue_write (method: "update", owner: "solo-ist", repo: "prose", issueNumber: N, state: "CLOSED", comment: "...")
+```
+
+**Removing closed items from board:**
+```bash
+gh project item-delete 5 --owner solo-ist --id <ITEM_ID>
+```
+
+**Moving items between columns:**
+```bash
+gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> --field-id <STATUS_FIELD_ID> --single-select-option-id <OPTION_ID>
+```
+
+**Adding issues to the board:**
+```bash
+gh project item-add 5 --owner solo-ist --url <ISSUE_URL>
+```
+
+## Board Columns
+
+Current status options on the Prose Roadmap board:
+
+| Column | Purpose |
+|--------|---------|
+| **User Requested** | Feature requests from users — needs triage |
+| **Do First** | Highest priority — work on these now |
+| **In Progress** | Actively being worked on by a human or agent |
+| **Do Next** | Next up after current work completes |
+| **Later** | Backlog — not yet prioritized |
+| **Quick Wins** | Low effort, high value — ship alongside bigger work |
+| **On Hold** | Blocked or paused |
+
+## Dangerous Operations — DO NOT USE
+
+**NEVER use `updateProjectV2Field` to modify single-select field options.** This GraphQL mutation replaces option IDs, which silently disconnects every board item from its status — effectively wiping the entire board. This has happened before and required manual recovery.
+
+If the board needs a new status column or option changes, tell the user to do it manually in the GitHub UI.
+
+Safe operations are limited to:
+- `gh project item-edit` — move items between existing columns
+- `gh project item-delete` — remove items from the board
+- `gh project item-add` — add items to the board
 
 ## Key Principles
 
@@ -100,3 +140,4 @@ Wait for the user to review the report. Then:
 - **Evidence over assumptions.** Link to the merged PR or commit that completed the work.
 - **Board is source of truth for priority.** If an issue isn't on the board, it's not prioritized.
 - **Stale != irrelevant.** Flag staleness, but let the user decide disposition.
+- **Never mutate field definitions.** Only move items between existing columns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Development Environment
+
+This project uses an **agentic, multi-agent development workflow**:
+
+- **Multiple Claude Code agents** may run simultaneously on the same machine — across terminal sessions, git worktrees, different branches, or different repos. Never assume you're the only agent running.
+- **Prefer Agent Teams and git worktrees** for parallelizing independent work. Use `isolation: "worktree"` when spawning agents that need to make changes without conflicting with the main working tree. This avoids branch conflicts and lets multiple agents write code simultaneously.
+- **Cloud agents** (via GitHub Actions) handle PR reviews, automated fixes, and pipeline triage. Local agents handle implementation, QA, and complex features.
+- **The CI pipeline is self-enhancing** — automated review (`claude.yml`), scoring (`pipeline-triage.yml`), and auto-fix (`ci-gate.yml`) run on every PR. Skills and workflows evolve alongside the codebase.
+- **Be mindful of concurrent sessions.** Other terminal sessions or worktree agents may be running builds, dev servers, or tests at the same time. Check for port conflicts before starting servers. Use PID files (not `pkill` patterns) for process management. Use `gh` CLI (not GitHub MCP) for all GitHub operations. Always `git fetch origin` before comparing branches — another session may have pushed.
+- **The project board** (GitHub Projects #5) tracks priority and in-progress work. Move items to "In Progress" when starting, back to "Do First" if pausing. Never mutate board field definitions — only move items between existing columns.
+
 ## Commands
 
 ```bash
@@ -92,11 +103,12 @@ dist/mac-arm64/prose.app
 
 ## Workflow
 
+- **Use `gh` CLI for all GitHub operations**: Issues, PRs, project board, checks, releases — always use `gh` commands via Bash, never a GitHub MCP server. The `gh` CLI is pre-authenticated and available both locally and in CI.
 - **Track work in GitHub Issues**: Create issues before starting work.
 - **Branching**: Create a branch per issue using format `issue-<number>-<short-description>` (e.g., `issue-42-fix-login-bug`). Branch from `main`.
 - **Commits**: Reference issue numbers in commits (e.g., `Fix login validation (#42)`).
 - **Pull requests**: One PR per issue. Merge to `main` after code review.
-- **Before merging any PR**: Check for unresolved review comments (`/review-feedback <pr-number>` or `get_review_comments` + `get_comments`). Do not merge until all feedback is addressed, dismissed with rationale, or deferred to a follow-up issue.
+- **Before merging any PR**: Check for unresolved review comments (`/review-feedback <pr-number>` or `gh api repos/solo-ist/prose/pulls/<number>/comments`). Do not merge until all feedback is addressed, dismissed with rationale, or deferred to a follow-up issue.
 - **Always output links**: After creating, closing, or commenting on issues or PRs, always output the full URL (e.g., `https://github.com/solo-ist/prose/pull/42`) so the user can Cmd+click from the terminal.
 - **Issue documentation**: For complex issues, create a folder in `docs/issues/<number>/`. See `docs/issues/README.md` for details.
 
@@ -134,7 +146,7 @@ All workflows in `.github/workflows/`:
 The app is designed to run both as an Electron desktop app and as a standalone web app. All platform-specific code is abstracted behind the `ElectronAPI` interface:
 
 - **Electron**: Uses IPC to call main process for file dialogs, settings persistence (`~/.prose/settings.json`), and LLM API calls
-- **Web**: Uses File System Access API (with `<input>` fallback), localStorage for settings, and direct API calls (limited by CORS—only OpenRouter and Ollama work in browser)
+- **Web**: Uses File System Access API (with `<input>` fallback), localStorage for settings, and direct API calls (limited by CORS — Anthropic blocks browser requests, so web mode LLM features are unavailable)
 
 Always use `getApi()` from `src/renderer/lib/browserApi.ts` instead of accessing `window.api` directly. This returns the Electron API when available, or a browser-compatible fallback.
 
@@ -183,7 +195,7 @@ Client-side persistence uses IndexedDB (`src/renderer/lib/persistence.ts`). When
 
 ### LLM Integration
 
-**Anthropic is the only supported provider.** The codebase has legacy multi-provider code (OpenAI, OpenRouter, Ollama) but Anthropic is the only provider that matters. Don't invest effort in other providers.
+**Anthropic is the only provider.** All legacy multi-provider code (OpenAI, OpenRouter, Ollama) has been removed. The `Settings` type defines `provider: 'anthropic'` only.
 
 LLM calls flow: `useChat` hook → `getApi().llmChatStream()` → IPC → main process → Anthropic SDK (with tools) or Vercel AI SDK (without)
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: New Development Environment section documenting multi-agent awareness, Agent Teams/worktree preference, concurrent session handling, `gh` CLI over GitHub MCP, project board protocol. Fixed stale legacy provider references.
- **roadmap-refinement**: Added board column table, safe/dangerous operations guide, `updateProjectV2Field` warning
- **roadmap-prioritization**: Updated columns to match current board (added In Progress, replaced Deferred with Later), added dangerous operations warning

## Test plan

- [x] Documentation-only changes, no code modified
- [ ] Verify skills load correctly in Claude Code (`/roadmap-refinement`, `/roadmap-prioritization`)

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)