### PR TITLE
fix(ci): fix pipeline end-to-end token/dispatch/loop issues

### DIFF
--- a/.github/scripts/analyze-review-feedback.mjs
+++ b/.github/scripts/analyze-review-feedback.mjs
@@ -83,27 +83,33 @@ Output EXACTLY this markdown format. Omit any section that has zero items:
 ---
 *Automated triage — for code-level validation, run \`/review-feedback ${PR_NUMBER}\` locally.*`
 
-const response = await fetch('https://api.anthropic.com/v1/messages', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'x-api-key': ANTHROPIC_API_KEY,
-    'anthropic-version': '2023-06-01',
-  },
-  body: JSON.stringify({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 2048,
-    system: systemPrompt,
-    messages: [{ role: 'user', content: userPrompt }],
-  }),
+import { withRetry } from './lib/retry.mjs'
+
+const data = await withRetry(async () => {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: process.env.FEEDBACK_MODEL || 'claude-sonnet-4-6',
+      max_tokens: 2048,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Anthropic API error: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}, {
+  maxRetries: 3,
+  onRetry: (attempt, err, delay) =>
+    console.warn(`Retry ${attempt}/3 after ${delay}ms: ${err.message}`)
 })
-
-if (!response.ok) {
-  console.error(`Anthropic API error: ${response.status} ${response.statusText}`)
-  process.exit(1)
-}
-
-const data = await response.json()
 
 if (!data.content?.[0]?.text) {
   console.error(`Unexpected API response structure: ${JSON.stringify(data).substring(0, 200)}`)

--- a/.github/scripts/lib/retry.mjs
+++ b/.github/scripts/lib/retry.mjs
@@ -1,0 +1,123 @@
+/**
+ * Network retry utility with exponential backoff.
+ * Plain JS port of src/shared/utils/retry.ts for CI scripts.
+ */
+
+const DEFAULT_OPTIONS = {
+  maxRetries: 3,
+  initialDelay: 1000,
+  maxDelay: 10000,
+  backoffMultiplier: 2,
+  jitter: true,
+  totalTimeout: 120000,
+}
+
+/**
+ * Check if an error is retryable (transient network error).
+ */
+export function isRetryableError(error) {
+  if (!(error instanceof Error)) return false
+
+  const message = error.message.toLowerCase()
+
+  // Network connectivity errors
+  if (message.includes('econnrefused')) return true
+  if (message.includes('econnreset')) return true
+  if (message.includes('etimedout')) return true
+  if (message.includes('enotfound')) return true
+  if (message.includes('network')) return true
+  if (message.includes('fetch failed')) return true
+
+  // Rate limiting (429)
+  if (message.includes('429') || message.includes('rate_limit') || message.includes('rate limit')) return true
+
+  // Server errors (5xx)
+  if (message.includes('500') || message.includes('502') || message.includes('503') || message.includes('504')) return true
+  if (message.includes('internal server error')) return true
+  if (message.includes('bad gateway')) return true
+  if (message.includes('service unavailable')) return true
+  if (message.includes('gateway timeout')) return true
+
+  // Anthropic overload (529)
+  if (message.includes('529')) return true
+  if (message.includes('overloaded')) return true
+
+  return false
+}
+
+function calculateDelay(attempt, initialDelay, maxDelay, backoffMultiplier, jitter) {
+  let delay = initialDelay * Math.pow(backoffMultiplier, attempt)
+  delay = Math.min(delay, maxDelay)
+
+  if (jitter) {
+    const jitterAmount = delay * 0.25 * Math.random()
+    delay += jitterAmount
+  }
+
+  return Math.round(delay)
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Execute a function with retry logic for transient errors.
+ *
+ * @param {() => Promise<any>} fn - Function to execute
+ * @param {object} options - Retry options
+ * @param {number} options.maxRetries - Max retry attempts (default: 3)
+ * @param {number} options.initialDelay - Initial delay in ms (default: 1000)
+ * @param {number} options.maxDelay - Max delay in ms (default: 10000)
+ * @param {number} options.backoffMultiplier - Backoff multiplier (default: 2)
+ * @param {boolean} options.jitter - Add jitter to delays (default: true)
+ * @param {number} options.totalTimeout - Total timeout in ms (default: 120000)
+ * @param {(attempt: number, error: Error, delay: number) => void} options.onRetry - Retry callback
+ */
+export async function withRetry(fn, options = {}) {
+  const config = { ...DEFAULT_OPTIONS, ...options }
+  const deadline = Date.now() + config.totalTimeout
+  let lastError
+
+  for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+    if (Date.now() >= deadline) {
+      throw lastError || new Error(`Total timeout of ${config.totalTimeout}ms exceeded`)
+    }
+
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error))
+
+      if (!isRetryableError(error)) {
+        throw lastError
+      }
+
+      if (attempt >= config.maxRetries) {
+        throw lastError
+      }
+
+      const delay = calculateDelay(
+        attempt,
+        config.initialDelay,
+        config.maxDelay,
+        config.backoffMultiplier,
+        config.jitter
+      )
+
+      // Don't sleep past the deadline
+      const remainingTime = deadline - Date.now()
+      if (delay >= remainingTime) {
+        throw lastError
+      }
+
+      if (config.onRetry) {
+        config.onRetry(attempt + 1, lastError, delay)
+      }
+
+      await sleep(delay)
+    }
+  }
+
+  throw lastError
+}

--- a/.github/scripts/run-orchestrator.mjs
+++ b/.github/scripts/run-orchestrator.mjs
@@ -22,9 +22,10 @@ const { PR_NUMBER, REPO } = process.env
 const comments = readFileSync('/tmp/all-comments.txt', 'utf-8')
 
 function parseSentinel(prefix, text) {
-  const re = new RegExp(`<!-- ${prefix}: (\\{.*?\\}) -->`, 's')
-  const m = text.match(re)
-  if (!m) return null
+  const re = new RegExp(`<!-- ${prefix}: (\\{.*?\\}) -->`, 'g')
+  const matches = [...text.matchAll(re)]
+  if (matches.length === 0) return null
+  const m = matches[matches.length - 1]
   try {
     return JSON.parse(m[1])
   } catch {

--- a/.github/scripts/run-pe-analysis.mjs
+++ b/.github/scripts/run-pe-analysis.mjs
@@ -97,27 +97,33 @@ At the very end, on its own line, include this machine-readable sentinel:
 
 Where N is the count of concerns listed.`
 
-const response = await fetch('https://api.anthropic.com/v1/messages', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'x-api-key': ANTHROPIC_API_KEY,
-    'anthropic-version': '2023-06-01',
-  },
-  body: JSON.stringify({
-    model: 'claude-opus-4-6',
-    max_tokens: 8192,
-    system: systemPrompt,
-    messages: [{ role: 'user', content: userPrompt }],
-  }),
+import { withRetry } from './lib/retry.mjs'
+
+const data = await withRetry(async () => {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: process.env.PE_MODEL || 'claude-opus-4-6',
+      max_tokens: 8192,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Anthropic API error: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}, {
+  maxRetries: 3,
+  onRetry: (attempt, err, delay) =>
+    console.warn(`Retry ${attempt}/3 after ${delay}ms: ${err.message}`)
 })
-
-if (!response.ok) {
-  console.error(`Anthropic API error: ${response.status} ${response.statusText}`)
-  process.exit(1)
-}
-
-const data = await response.json()
 
 if (!data.content?.[0]?.text) {
   console.error(`Unexpected API response structure: ${JSON.stringify(data).substring(0, 200)}`)

--- a/.github/scripts/run-scorer.mjs
+++ b/.github/scripts/run-scorer.mjs
@@ -82,27 +82,33 @@ Where:
 - COMPOSITE = average of 6 dimension scores × 2, rounded to one decimal place
 - THRESHOLD = "auto-fix" if score <= 3, "review" if score <= 6, "complex" if score >= 7`
 
-const response = await fetch('https://api.anthropic.com/v1/messages', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'x-api-key': ANTHROPIC_API_KEY,
-    'anthropic-version': '2023-06-01',
-  },
-  body: JSON.stringify({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 2048,
-    system: systemPrompt,
-    messages: [{ role: 'user', content: userPrompt }],
-  }),
+import { withRetry } from './lib/retry.mjs'
+
+const data = await withRetry(async () => {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: process.env.SCORER_MODEL || 'claude-sonnet-4-6',
+      max_tokens: 2048,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Anthropic API error: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}, {
+  maxRetries: 3,
+  onRetry: (attempt, err, delay) =>
+    console.warn(`Retry ${attempt}/3 after ${delay}ms: ${err.message}`)
 })
-
-if (!response.ok) {
-  console.error(`Anthropic API error: ${response.status} ${response.statusText}`)
-  process.exit(1)
-}
-
-const data = await response.json()
 
 if (!data.content?.[0]?.text) {
   console.error(`Unexpected API response structure: ${JSON.stringify(data).substring(0, 200)}`)

--- a/.github/scripts/validate-pipeline.sh
+++ b/.github/scripts/validate-pipeline.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# validate-pipeline.sh — verify pipeline bug fixes for issue #327
+# validate-pipeline.sh — verify pipeline invariants
 set -euo pipefail
 
 ERRORS=0
@@ -57,12 +57,12 @@ else
 fi
 echo ""
 
-# 6. dotAll flag on parseSentinel regex
-echo "--- Check: parseSentinel dotAll flag ---"
-if grep -q "'s'" .github/scripts/run-orchestrator.mjs; then
+# 6. parseSentinel uses matchAll (not single match with dotAll)
+echo "--- Check: parseSentinel uses matchAll ---"
+if grep -q "matchAll" .github/scripts/run-orchestrator.mjs; then
   echo "PASS"
 else
-  echo "FAIL: parseSentinel regex missing dotAll flag"
+  echo "FAIL: parseSentinel should use matchAll for last-match semantics"
   ERRORS=$((ERRORS + 1))
 fi
 echo ""
@@ -97,10 +97,93 @@ else
 fi
 echo ""
 
-# 10. JS syntax check
+# 10. retry.mjs exists
+echo "--- Check: retry utility exists ---"
+if [ -f ".github/scripts/lib/retry.mjs" ]; then
+  echo "PASS"
+else
+  echo "FAIL: .github/scripts/lib/retry.mjs not found"
+  ERRORS=$((ERRORS + 1))
+fi
+echo ""
+
+# 11. All API scripts use withRetry
+echo "--- Check: API scripts use retry ---"
+RETRY_OK=true
+for f in .github/scripts/run-scorer.mjs .github/scripts/run-pe-analysis.mjs .github/scripts/analyze-review-feedback.mjs; do
+  if ! grep -q "withRetry" "$f"; then
+    echo "FAIL: $f does not use withRetry"
+    RETRY_OK=false
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+if $RETRY_OK; then
+  echo "PASS"
+fi
+echo ""
+
+# 12. Model env var overrides exist
+echo "--- Check: Model env var overrides ---"
+MODEL_OK=true
+if ! grep -q "SCORER_MODEL" .github/scripts/run-scorer.mjs; then
+  echo "FAIL: SCORER_MODEL override missing in run-scorer.mjs"
+  MODEL_OK=false
+  ERRORS=$((ERRORS + 1))
+fi
+if ! grep -q "PE_MODEL" .github/scripts/run-pe-analysis.mjs; then
+  echo "FAIL: PE_MODEL override missing in run-pe-analysis.mjs"
+  MODEL_OK=false
+  ERRORS=$((ERRORS + 1))
+fi
+if ! grep -q "FEEDBACK_MODEL" .github/scripts/analyze-review-feedback.mjs; then
+  echo "FAIL: FEEDBACK_MODEL override missing in analyze-review-feedback.mjs"
+  MODEL_OK=false
+  ERRORS=$((ERRORS + 1))
+fi
+if $MODEL_OK; then
+  echo "PASS"
+fi
+echo ""
+
+# 13. No id-token: write in workflows that don't need it
+echo "--- Check: No unnecessary id-token: write ---"
+IDTOKEN_OK=true
+for f in .github/workflows/claude.yml .github/workflows/pipeline-fix.yml; do
+  if grep -q "id-token: write" "$f"; then
+    echo "FAIL: $f has unnecessary id-token: write permission"
+    IDTOKEN_OK=false
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+if $IDTOKEN_OK; then
+  echo "PASS"
+fi
+echo ""
+
+# 14. dispatch.yml has loop-prevention sentinel
+echo "--- Check: dispatch.yml loop sentinel ---"
+if grep -q "dispatch-generated" .github/workflows/dispatch.yml; then
+  echo "PASS"
+else
+  echo "FAIL: dispatch.yml missing dispatch-generated sentinel"
+  ERRORS=$((ERRORS + 1))
+fi
+echo ""
+
+# 15. Direct dispatch step in orchestrate job
+echo "--- Check: Direct dispatch in orchestrate ---"
+if grep -q "gh workflow run pipeline-fix.yml" .github/workflows/pipeline-triage.yml; then
+  echo "PASS"
+else
+  echo "FAIL: orchestrate job missing direct dispatch step"
+  ERRORS=$((ERRORS + 1))
+fi
+echo ""
+
+# 16. JS syntax check (includes lib/)
 echo "--- Check: JS syntax ---"
 JS_OK=true
-for f in .github/scripts/*.mjs; do
+for f in $(find .github/scripts -name '*.mjs'); do
   if ! node --check "$f" 2>/dev/null; then
     echo "FAIL: Syntax error in $f"
     JS_OK=false
@@ -112,7 +195,7 @@ if $JS_OK; then
 fi
 echo ""
 
-# 11. YAML syntax check (requires npx js-yaml or similar)
+# 17. YAML syntax check
 echo "--- Check: YAML syntax ---"
 YAML_OK=true
 for f in .github/workflows/*.yml; do

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Trigger auto-review
         if: steps.pr.outputs.number
         env:
+          # PROJECT_TOKEN required: github.token events don't trigger downstream
+          # issue_comment workflows. claude.yml checks body content, not author.
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
@@ -97,6 +99,8 @@ jobs:
       - name: Post fix request
         if: steps.guard.outputs.attempts == '0'
         env:
+          # PROJECT_TOKEN required: github.token events don't trigger downstream
+          # issue_comment workflows. claude.yml checks body content, not author.
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -100,7 +99,7 @@ jobs:
       - name: Ensure review comment was posted
         if: steps.claude-review.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -134,7 +133,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read
     steps:
       - name: Checkout repository

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -9,11 +9,13 @@ jobs:
     # Route pipeline slash commands on PRs — only for human comments (not bots)
     # /review is handled directly by claude.yml — this workflow adds /triage, /fix, /pipeline
     # Guard: never fire on @claude mentions (claude.yml owns those)
+    # Guard: never fire on comments this workflow generated (prevent /pipeline loop)
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      !contains(github.event.comment.user.login, '[bot]') &&
+      github.event.comment.user.type != 'Bot' &&
       !contains(github.event.comment.body, '@claude') &&
+      !contains(github.event.comment.body, '<!-- dispatch-generated -->') &&
       (
         contains(github.event.comment.body, '/triage') ||
         contains(github.event.comment.body, '/fix') ||
@@ -84,4 +86,6 @@ jobs:
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
             --body "/review
 
-          *Triggered by \`/pipeline\` — full pipeline will run: review → triage → route*"
+          *Full pipeline triggered. Sequence: review → triage → route → auto-fix (if applicable)*
+
+          <!-- dispatch-generated -->"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
         !contains(github.event.comment.body, '@claude')
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Resolve PR ref
         id: pr
@@ -58,6 +59,7 @@ jobs:
       - name: Run E2E tests
         uses: coactions/setup-xvfb@v1
         env:
+          # CI Linux runners lack kernel namespace support for Chrome's sandbox
           ELECTRON_DISABLE_SANDBOX: 1
         with:
           run: npx playwright test

--- a/.github/workflows/feature-request-triage.yml
+++ b/.github/workflows/feature-request-triage.yml
@@ -18,7 +18,8 @@ jobs:
         run: |
           set -e
 
-          # Add issue to Prose Roadmap project
+          # Add issue to Prose Roadmap project (project #5)
+          # To look up IDs: gh api graphql -f query='{ organization(login:"solo-ist") { projectsV2(first:10) { nodes { id number title } } } }'
           ITEM_ID=$(gh project item-add 5 --owner solo-ist \
             --url "${{ github.event.issue.html_url }}" \
             --format json --jq '.id')
@@ -28,6 +29,8 @@ jobs:
           fi
 
           # Look up "User Requested" option ID dynamically
+          # Field ID: PVTSSF_lADOC6voP84BPTiXzg9wHj8 = "Status" field on project PVT_kwDOC6voP84BPTiX
+          # To look up field IDs: gh project field-list 5 --owner solo-ist --format json
           OPTION_ID=$(gh api graphql -f query='{
             node(id: "PVTSSF_lADOC6voP84BPTiXzg9wHj8") {
               ... on ProjectV2SingleSelectField {
@@ -41,6 +44,7 @@ jobs:
           fi
 
           # Set status to "User Requested"
+          # Project node ID: PVT_kwDOC6voP84BPTiX = Prose Roadmap (project #5)
           gh project item-edit \
             --project-id PVT_kwDOC6voP84BPTiX \
             --id "$ITEM_ID" \

--- a/.github/workflows/pipeline-fix.yml
+++ b/.github/workflows/pipeline-fix.yml
@@ -28,7 +28,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Determine PR number
         id: pr

--- a/.github/workflows/pipeline-triage.yml
+++ b/.github/workflows/pipeline-triage.yml
@@ -13,15 +13,13 @@ on:
 jobs:
   run-scorer:
     # Auto-trigger: claude[bot] review with issues-found verdict
-    # Skip if scorer already ran (prevent loops)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.login == 'claude[bot]' &&
-        contains(github.event.comment.body, '<!-- review-verdict: issues-found -->') &&
-        !contains(github.event.comment.body, '<!-- scorer-output:')
+        contains(github.event.comment.body, '<!-- review-verdict: issues-found -->')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -48,7 +46,25 @@ jobs:
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check for existing scorer output
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          SENTINEL="<!-- scorer-output:"
+          COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$SENTINEL\")))] | length")
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::notice::Scorer output already exists ($COUNT comment(s)). Skipping to prevent duplicate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fetch review comment
+        if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -65,6 +81,7 @@ jobs:
           fi
 
       - name: Run scorer
+        if: steps.guard.outputs.skip != 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -72,6 +89,7 @@ jobs:
         run: node .github/scripts/run-scorer.mjs
 
       - name: Post scorer comment
+        if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -86,8 +104,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.login == 'claude[bot]' &&
-        contains(github.event.comment.body, '<!-- review-verdict: issues-found -->') &&
-        !contains(github.event.comment.body, '<!-- pe-output:')
+        contains(github.event.comment.body, '<!-- review-verdict: issues-found -->')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -114,7 +131,25 @@ jobs:
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check for existing PE output
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          SENTINEL="<!-- pe-output:"
+          COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$SENTINEL\")))] | length")
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::notice::PE output already exists ($COUNT comment(s)). Skipping to prevent duplicate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fetch review comment and changed files
+        if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -136,6 +171,7 @@ jobs:
             > /tmp/changed-files.txt
 
       - name: Run PE analysis
+        if: steps.guard.outputs.skip != 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -143,6 +179,7 @@ jobs:
         run: node .github/scripts/run-pe-analysis.mjs
 
       - name: Post PE analysis comment
+        if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -157,6 +194,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      actions: write          # needed for gh workflow run (direct dispatch)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -196,10 +234,37 @@ jobs:
 
       - name: Post orchestrator verdict
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr comment "${{ steps.pr.outputs.number }}" \
             --body-file /tmp/orchestrator-output.md
+
+      - name: Dispatch auto-fix if routed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          VERDICT=$(cat /tmp/orchestrator-verdict.txt)
+          if [ "$VERDICT" = "auto-fix" ] || [ "$VERDICT" = "auto-fix-verify" ]; then
+            # Circuit breaker: only dispatch once per PR
+            LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
+            if echo "$LABELS" | grep -q "auto-fix-dispatched"; then
+              echo "::warning::Auto-fix already dispatched for this PR. Skipping to prevent loop."
+              gh pr comment "$PR_NUMBER" --repo "$REPO" \
+                --body "<!-- auto-fix-circuit-breaker -->
+          > **Auto-fix cycle exhausted.** A fix was already attempted for this PR. Escalating to human review."
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "needs-review"
+            else
+              echo "Dispatching pipeline-fix.yml for PR #$PR_NUMBER (verdict: $VERDICT)"
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "auto-fix-dispatched"
+              gh workflow run pipeline-fix.yml \
+                --repo "$REPO" \
+                -f pr_number="$PR_NUMBER"
+            fi
+          else
+            echo "Verdict '$VERDICT' does not require auto-fix dispatch."
+          fi
 
       - name: Ensure pipeline labels exist
         env:
@@ -207,6 +272,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh label create "auto-fix-queued" --repo "$REPO" --color "0E8A16" --description "Queued for automated fix" --force || true
+          gh label create "auto-fix-dispatched" --repo "$REPO" --color "1D76DB" --description "Auto-fix workflow dispatched" --force || true
           gh label create "complex" --repo "$REPO" --color "D93F0B" --description "Complex changes requiring full review" --force || true
           gh label create "needs-review" --repo "$REPO" --color "FBCA04" --description "Awaiting human review" --force || true
 

--- a/.github/workflows/validate-pipeline.yml
+++ b/.github/workflows/validate-pipeline.yml
@@ -1,0 +1,25 @@
+name: Validate Pipeline
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run pipeline validation
+        run: bash .github/scripts/validate-pipeline.sh

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -16,10 +16,7 @@ jobs:
     if: |
       (
         github.event_name == 'pull_request' &&
-        (
-          contains(github.event.pull_request.labels.*.name, 'accelerated') ||
-          github.event.pull_request.user.login == 'claude[bot]'
-        )
+        contains(github.event.pull_request.labels.*.name, 'accelerated')
       ) ||
       (
         github.event_name == 'issue_comment' &&


### PR DESCRIPTION
## Summary

Fixes the auto-fix pipeline which has never worked end-to-end. The chain (E2E pass → review → triage → score → PE → orchestrate → auto-fix) broke silently due to token/identity mismatches, infinite dispatch loops, stale sentinel parsing, and missing retry logic.

**16 findings fixed across 4 phases:**

- **Phase 1 — Token Strategy + Direct Dispatch (C1, C2, L1)**: Orchestrator verdict posted with `github.token`, auto-fix triggered via `gh workflow run` (direct dispatch) instead of relying on `issue_comment` events, label-based circuit breaker prevents infinite fix cycles
- **Phase 2 — Correctness (C3, H1, H4, H5)**: `parseSentinel` uses `matchAll` for last-match semantics, inert loop guards replaced with runtime comment checks, dispatch.yml `/pipeline` loop broken, web-e2e.yml dead code removed
- **Phase 3 — Robustness (M1, M2, M3, M4)**: New `retry.mjs` utility wraps all API calls with exponential backoff (incl. 529 handling), model IDs configurable via env vars, removed unnecessary `id-token: write`, added e2e job timeout
- **Phase 4 — Hardening (L2, L3, L4, L5)**: Bot detection uses `user.type`, hardcoded project IDs documented, new `validate-pipeline.yml` workflow, sandbox comment added

## Test plan

- [ ] Verify `validate-pipeline.yml` triggers on this PR (since it modifies `.github/` files)
- [ ] Open a test PR with a deliberate bug → E2E pass → review → triage cycle should complete with orchestrator dispatching `pipeline-fix.yml` directly
- [ ] Verify circuit breaker: second triage cycle should post "Auto-fix cycle exhausted" comment
- [ ] Post `/pipeline` on a PR → confirm dispatch.yml fires exactly once (no loop)
- [ ] Verify JS syntax: `node --check .github/scripts/lib/retry.mjs`
- [ ] Verify YAML syntax: all workflows pass `js-yaml` parsing

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)