### PR TITLE
feat(remarkable): sync folder movements to reMarkable cloud

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1039,6 +1039,36 @@ export function setupIpcHandlers(): void {
     }
   )
 
+  // reMarkable: Move a notebook to a new parent folder on the cloud
+  ipcMain.handle(
+    'remarkable:moveNotebook',
+    async (_event, deviceToken: string, notebookHash: string, newParentId: string) => {
+      const { connect } = await import('./remarkable/client')
+      const client = await connect(deviceToken)
+      await client.moveNotebook(notebookHash, newParentId)
+    }
+  )
+
+  // reMarkable: Create a folder on the cloud
+  ipcMain.handle(
+    'remarkable:createFolder',
+    async (_event, deviceToken: string, name: string, parentId?: string) => {
+      const { connect } = await import('./remarkable/client')
+      const client = await connect(deviceToken)
+      return await client.createFolder(name, parentId)
+    }
+  )
+
+  // reMarkable: Update notebook parent in local sync metadata
+  ipcMain.handle(
+    'remarkable:updateNotebookParent',
+    async (_event, notebookId: string, newParentId: string, syncDirectory: string) => {
+      const safeDir = validatePath(syncDirectory)
+      const { updateNotebookParent } = await import('./remarkable/sync')
+      return await updateNotebookParent(notebookId, newParentId, safeDir)
+    }
+  )
+
   // Emoji: Generate emoji for a tab title (runs in main process to avoid CORS)
   ipcMain.handle('emoji:generate', async (_event, title: string, contentPreview?: string): Promise<{ emoji: string | null; error?: string }> => {
     try {

--- a/src/main/remarkable/client.ts
+++ b/src/main/remarkable/client.ts
@@ -18,6 +18,8 @@ export interface RemarkableNotebook {
 export interface RemarkableClient {
   listNotebooks(): Promise<RemarkableNotebook[]>
   downloadNotebook(id: string, hash: string): Promise<Uint8Array>
+  moveNotebook(hash: string, newParentId: string): Promise<void>
+  createFolder(name: string, parentId?: string): Promise<string>
   disconnect(): void
 }
 
@@ -144,6 +146,15 @@ function createClient(api: RemarkableApi): RemarkableClient {
     async downloadNotebook(id: string, hash: string): Promise<Uint8Array> {
       // getDocument returns a zip containing all notebook files
       return await api.getDocument(hash)
+    },
+
+    async moveNotebook(hash: string, newParentId: string): Promise<void> {
+      await api.move(hash, newParentId)
+    },
+
+    async createFolder(name: string, parentId?: string): Promise<string> {
+      const entry = await api.putFolder(name, parentId || '')
+      return entry.hash
     },
 
     disconnect(): void {

--- a/src/main/remarkable/sync.ts
+++ b/src/main/remarkable/sync.ts
@@ -811,6 +811,34 @@ export async function clearNotebookMarkdownPath(
 }
 
 /**
+ * Update the cloud parent ID of a notebook in local sync metadata.
+ * Called after successfully moving a notebook on the reMarkable cloud.
+ *
+ * @param notebookId - The notebook ID to update
+ * @param newParentId - The new cloud folder ID (empty string for root)
+ * @param syncDirectory - Base sync directory
+ * @returns true if updated successfully, false if notebook not found
+ */
+export async function updateNotebookParent(
+  notebookId: string,
+  newParentId: string,
+  syncDirectory: string
+): Promise<boolean> {
+  const baseDir = expandPath(syncDirectory)
+  const metadata = await loadMetadata(baseDir)
+  if (!metadata) return false
+
+  const notebook = metadata.notebooks[notebookId]
+  if (!notebook) return false
+
+  notebook.parent = newParentId || null
+
+  await saveMetadata(baseDir, metadata)
+  console.log(`[reMarkable] Updated parent for notebook ${notebookId} to "${newParentId}"`)
+  return true
+}
+
+/**
  * Purge sync state and cached data (hidden .remarkable/ directory only).
  * Does NOT delete user-visible markdown files — those belong to the user.
  * Called on disconnect to ensure a clean slate for reconnection.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -222,6 +222,9 @@ export interface ElectronAPI {
   remarkableCreateEditableVersion: (notebookId: string, syncDirectory: string) => Promise<string | null>
   remarkableFindNotebookByFilePath: (filePath: string, syncDirectory: string) => Promise<string | null>
   remarkableClearNotebookMarkdownPath: (notebookId: string, syncDirectory: string) => Promise<boolean>
+  remarkableMoveNotebook: (deviceToken: string, notebookHash: string, newParentId: string) => Promise<void>
+  remarkableCreateFolder: (deviceToken: string, name: string, parentId?: string) => Promise<string>
+  remarkableUpdateNotebookParent: (notebookId: string, newParentId: string, syncDirectory: string) => Promise<boolean>
   // MCP tool execution (only used in MCP server mode)
   onMcpToolInvoke: (
     callback: (requestId: string, toolName: string, args: unknown) => void
@@ -392,6 +395,12 @@ const api: ElectronAPI = {
     ipcRenderer.invoke('remarkable:findNotebookByFilePath', filePath, syncDirectory),
   remarkableClearNotebookMarkdownPath: (notebookId: string, syncDirectory: string) =>
     ipcRenderer.invoke('remarkable:clearNotebookMarkdownPath', notebookId, syncDirectory),
+  remarkableMoveNotebook: (deviceToken: string, notebookHash: string, newParentId: string) =>
+    ipcRenderer.invoke('remarkable:moveNotebook', deviceToken, notebookHash, newParentId),
+  remarkableCreateFolder: (deviceToken: string, name: string, parentId?: string) =>
+    ipcRenderer.invoke('remarkable:createFolder', deviceToken, name, parentId),
+  remarkableUpdateNotebookParent: (notebookId: string, newParentId: string, syncDirectory: string) =>
+    ipcRenderer.invoke('remarkable:updateNotebookParent', notebookId, newParentId, syncDirectory),
   // MCP tool execution
   onMcpToolInvoke: (callback: (requestId: string, toolName: string, args: unknown) => void) => {
     const handler = (

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -286,6 +286,9 @@ export function FileListPanel() {
 
       await api.renameFile(oldPath, newPath)
 
+      // Sync move to reMarkable cloud if applicable
+      await syncRemarkableCloudMove(oldPath, newPath)
+
       // Tab sync: update tab if file was open
       const tab = useTabStore.getState().getTabByPath(oldPath)
       if (tab) {
@@ -315,7 +318,7 @@ export function FileListPanel() {
     } catch (error) {
       console.error('Error renaming file:', error)
     }
-  }, [api, googleDocsMetadata, loadGoogleDocsMetadata, loadFiles, selectFile, setRenamingPath])
+  }, [api, googleDocsMetadata, loadGoogleDocsMetadata, loadFiles, selectFile, setRenamingPath, syncRemarkableCloudMove])
 
   const handleRenameCancel = useCallback(() => {
     setRenamingPath(null)
@@ -351,6 +354,9 @@ export function FileListPanel() {
 
       await api.renameFile(renameFilePath, newPath)
 
+      // Sync move to reMarkable cloud if applicable
+      await syncRemarkableCloudMove(renameFilePath, newPath)
+
       // Tab sync
       const tab = useTabStore.getState().getTabByPath(renameFilePath)
       if (tab) {
@@ -384,6 +390,99 @@ export function FileListPanel() {
       setOperationError('Failed to rename file. Please try again.')
     }
   }
+
+  // Sync a file move/rename to the reMarkable cloud if the file is a synced notebook.
+  // Runs after the local filesystem move has already succeeded.
+  // Errors are logged but never propagate — the local move already succeeded.
+  const syncRemarkableCloudMove = useCallback(async (oldPath: string, newPath: string) => {
+    if (!syncDirectory || !deviceToken || !notebookMetadata) return
+
+    // Normalize to forward slashes for portable comparison
+    const normSync = syncDirectory.replace(/\\/g, '/')
+    const normOld = oldPath.replace(/\\/g, '/')
+
+    // Only act on files inside the reMarkable sync directory
+    if (!normOld.startsWith(normSync + '/')) return
+
+    try {
+      // Find the notebook in local metadata
+      const notebookId = await window.api?.remarkableFindNotebookByFilePath?.(oldPath, syncDirectory)
+      if (!notebookId) return
+
+      const notebookEntry = notebookMetadata.notebooks[notebookId]
+      if (!notebookEntry?.hash) return
+
+      // Determine the target directory from the new path
+      const normNew = newPath.replace(/\\/g, '/')
+      const newTargetDir = normNew.substring(0, normNew.lastIndexOf('/'))
+
+      // Resolve the cloud folder ID for the target directory.
+      // Walk notebookMetadata looking for a folder whose localPath (relative to syncDir)
+      // matches the relative target dir path.
+      const relTargetDir = newTargetDir.startsWith(normSync + '/')
+        ? newTargetDir.slice(normSync.length + 1)
+        : ''
+
+      let cloudFolderId = '' // empty string = root on reMarkable cloud
+
+      if (relTargetDir) {
+        // Look for a folder entry whose localPath matches
+        const folderEntry = Object.entries(notebookMetadata.notebooks).find(
+          ([, meta]) => meta.type === 'folder' && meta.localPath.replace(/\\/g, '/') === relTargetDir
+        )
+
+        if (folderEntry) {
+          // Folder already exists in cloud — use its ID
+          cloudFolderId = folderEntry[0]
+        } else {
+          // Target folder doesn't exist in cloud yet — create it (and any missing ancestors)
+          const segments = relTargetDir.split('/')
+          let currentParentId = ''
+
+          for (const segment of segments) {
+            // Check if this segment exists as a child of currentParentId
+            const existing = Object.entries(notebookMetadata.notebooks).find(([, meta]) => {
+              if (meta.type !== 'folder') return false
+              const folderRelPath = meta.localPath.replace(/\\/g, '/')
+              // Must match the accumulated path
+              const accumulatedPath = currentParentId
+                ? Object.entries(notebookMetadata.notebooks).find(([id]) => id === currentParentId)?.[1]?.localPath + '/' + segment
+                : segment
+              return folderRelPath === accumulatedPath?.replace(/\\/g, '/')
+            })
+
+            if (existing) {
+              currentParentId = existing[0]
+            } else {
+              // Create folder on cloud
+              const newFolderHash = await window.api?.remarkableCreateFolder?.(
+                deviceToken,
+                segment,
+                currentParentId || undefined
+              )
+              if (!newFolderHash) {
+                console.warn('[reMarkable] Failed to create cloud folder:', segment)
+                return
+              }
+              currentParentId = newFolderHash
+            }
+          }
+
+          cloudFolderId = currentParentId
+        }
+      }
+
+      // Move the notebook on the cloud
+      await window.api?.remarkableMoveNotebook?.(deviceToken, notebookEntry.hash, cloudFolderId)
+
+      // Update local metadata to reflect the new parent
+      await window.api?.remarkableUpdateNotebookParent?.(notebookId, cloudFolderId, syncDirectory)
+
+      console.log(`[reMarkable] Synced cloud move for notebook ${notebookId} to folder "${cloudFolderId}"`)
+    } catch (error) {
+      console.warn('[reMarkable] Failed to sync move to cloud (local move succeeded):', error)
+    }
+  }, [syncDirectory, deviceToken, notebookMetadata])
 
   // Drag-and-drop move handler
   const handleFileDrop = useCallback(async (sourcePath: string, targetDirPath: string) => {
@@ -420,6 +519,9 @@ export function FileListPanel() {
     try {
       await api.renameFile(sourcePath, destPath)
 
+      // Sync move to reMarkable cloud if applicable
+      await syncRemarkableCloudMove(sourcePath, destPath)
+
       // Update tab if the moved file was open
       const tab = useTabStore.getState().getTabByPath(sourcePath)
       if (tab) {
@@ -432,7 +534,7 @@ export function FileListPanel() {
     } catch (error) {
       console.error('Error moving file:', error)
     }
-  }, [api, loadFiles, selectFile])
+  }, [api, loadFiles, selectFile, syncRemarkableCloudMove])
 
   // Show in folder handler
   const handleFileShowInFolder = async (path: string) => {

--- a/src/renderer/mocks/webApi.ts
+++ b/src/renderer/mocks/webApi.ts
@@ -459,6 +459,24 @@ export function createMockApi(): ElectronAPI {
       _syncDirectory: string
     ): Promise<boolean> => false,
 
+    remarkableMoveNotebook: async (
+      _deviceToken: string,
+      _notebookHash: string,
+      _newParentId: string
+    ): Promise<void> => { throw new Error('reMarkable move not available in web mode') },
+
+    remarkableCreateFolder: async (
+      _deviceToken: string,
+      _name: string,
+      _parentId?: string
+    ): Promise<string> => { throw new Error('reMarkable create folder not available in web mode') },
+
+    remarkableUpdateNotebookParent: async (
+      _notebookId: string,
+      _newParentId: string,
+      _syncDirectory: string
+    ): Promise<boolean> => false,
+
     // ---- Google Docs (stubs) ----------------------------------------------
 
     googleIsConfigured: async (): Promise<boolean> => false,

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -376,6 +376,9 @@ export interface ElectronAPI {
   remarkableCreateEditableVersion: (notebookId: string, syncDirectory: string) => Promise<string | null>
   remarkableFindNotebookByFilePath: (filePath: string, syncDirectory: string) => Promise<string | null>
   remarkableClearNotebookMarkdownPath: (notebookId: string, syncDirectory: string) => Promise<boolean>
+  remarkableMoveNotebook: (deviceToken: string, notebookHash: string, newParentId: string) => Promise<void>
+  remarkableCreateFolder: (deviceToken: string, name: string, parentId?: string) => Promise<string>
+  remarkableUpdateNotebookParent: (notebookId: string, newParentId: string, syncDirectory: string) => Promise<boolean>
   // MCP tool execution (only used in MCP server mode)
   onMcpToolInvoke: (
     callback: (requestId: string, toolName: string, args: unknown) => void


### PR DESCRIPTION
## Summary

- Exposes `rmapi-js` `move()` and `putFolder()` through `client.ts`, IPC handlers, and preload bindings
- Intercepts file moves in the explorer (`FileListPanel.tsx`) to update reMarkable cloud when a synced notebook is relocated
- Creates missing cloud folders automatically when moving to a local folder with no cloud counterpart (recursive parent chain creation)
- Adds `updateNotebookParent()` in `sync.ts` to persist metadata after cloud moves
- Errors are caught and logged without affecting the local file move

## Test plan

- [ ] Move a synced notebook's markdown to a different folder in Prose — confirm reMarkable cloud reflects the new parent
- [ ] Move a notebook into a new local folder (no cloud counterpart) — confirm cloud folder is created automatically
- [ ] Move a non-reMarkable file — confirm no errors or cloud API calls
- [ ] Build compiles cleanly

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)