### PR TITLE
fix(menu): add Window menu reopen entry for MAS Build 18 (#419)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "17"
+buildVersion: "18"
 directories:
   buildResources: build
   output: dist

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -270,6 +270,17 @@ export function createMenu(mainWindow: BrowserWindow): void {
         ...(isMac
           ? [
               { type: 'separator' as const },
+              {
+                label: 'Prose',
+                click: (): void => {
+                  if (_menuWindow && !_menuWindow.isDestroyed()) {
+                    if (_menuWindow.isMinimized()) _menuWindow.restore()
+                    _menuWindow.show()
+                    _menuWindow.focus()
+                  }
+                }
+              },
+              { type: 'separator' as const },
               { role: 'front' as const },
               { type: 'separator' as const },
               { role: 'window' as const }


### PR DESCRIPTION
Closes #419

## Apple rejection (repeat)

Submission `c3ddd1bf-4034-417d-b492-58d5e09cd598`, April 13 2026, Guideline 4 — Design.

Apple's reviewer continues to find no menu-bar path to reopen the main window after closing it. Build 17's hide-on-close + dock-click reopen (PR #407) wasn't enough — the reviewer is testing via the Window menu, where Electron's `role: 'window'` only enumerates *visible* windows. Once hidden, the entry disappeared.

## Change

`src/main/menu.ts` — add a persistent "Prose" item to the macOS Window submenu that calls `_menuWindow.show()+.focus()`, restoring from minimized when needed.

`electron-builder.yml` — bump `buildVersion` 17 → 18.

No accelerator. `CmdOrCtrl+0` collides with `resetZoom`; no canonical macOS shortcut exists for "show main window."

## Already verified to be in place (no change needed)

- `src/main/index.ts:177-184` — hide-on-close handler keeps window alive on darwin (`isQuitting` flag at `:42-45` ensures Cmd+Q still terminates cleanly)
- `src/main/index.ts:417-424` — dock-click `activate` reopen
- `src/main/index.ts:427-430` — `window-all-closed` skips `app.quit()` on darwin

## Test plan (against the packaged MAS build, post-merge)

- [ ] Window menu shows "Prose" entry at all times (visible + hidden states)
- [ ] Close via red close button → click Window → Prose → window reopens and focuses
- [ ] Close via Cmd+W → same
- [ ] Minimize → Window → Prose → restores from minimized
- [ ] Click dock icon when window hidden → window reopens (regression on PR #407)
- [ ] Cmd+Q quits cleanly from visible state
- [ ] Cmd+Q quits cleanly from hidden state (regression on quit flow)
- [ ] Open buffer state survives close → reopen cycle
- [ ] No console errors during close → reopen → close cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)