### PR TITLE
chore: working-tree hygiene + archive historical docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Thumbs.db
 # Editor directories
 .idea/
 .vscode/
+.zed/
 *.swp
 *.swo
 
@@ -39,6 +40,10 @@ playwright-report/
 
 # Claude Code
 .claude/settings.local.json
+
+# Claude Cowork artifacts (per-session tooling outputs, not project files)
+.skills/
+*.plugin
 
 # MCP config (contains secrets)
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,19 @@ This prevents LevelDB lock conflicts and ensures the user sees the latest change
 
 Always include human-readable verification steps when presenting completed work. These should let the user independently confirm the changes work. Format as numbered steps with exact commands to run and what to look for in the output. Prefer verification against the locally running dev server; only use `npm run build:mac` + the built app when the change specifically requires a production build to verify.
 
+## Working Tree Hygiene
+
+Before announcing a task complete, run `git status`. Every untracked file must have a destination — do not leave files orphaned across sessions.
+
+- **Project code/config** (e.g., `.claude/` — standard Claude Code project config) → committed
+- **Project docs** → commit under `docs/` (or `docs/issues/<n>/` for issue-linked docs)
+- **Historical/reference docs** (launch checklists, audits, proposals) → commit under an appropriate `docs/` subdirectory such as `docs/launch/` or `docs/audits/`
+- **Claude Cowork artifacts** (`.skills/`, `*.plugin`) → gitignored; these are per-session tooling outputs, not project files
+- **Editor/IDE state** (`.vscode/`, `.idea/`, `.zed/`) → gitignored
+- **Local-only scratch** (one-off drafts) → either delete, or place under a gitignored path
+
+If a file's destination needs user input, ask explicitly — don't defer the decision by leaving it untracked.
+
 ## QA Testing
 
 The app supports automated QA testing via Circuit Electron MCP (configured at parent level).

--- a/docs/audits/agentic-documentation-audit.md
+++ b/docs/audits/agentic-documentation-audit.md
@@ -1,0 +1,151 @@
+# Agentic Documentation Audit
+
+**Date:** 2026-03-13
+**Scope:** All project documentation, evaluated for usefulness in an agentic development SDLC
+**Auditor:** Claude Opus 4.6
+
+---
+
+## Executive Summary
+
+Prose has an unusually mature agentic documentation setup. The `CLAUDE.md` is one of the best I've seen — it functions as a genuine operating manual for an AI agent, not just a README with extra steps. The custom skills (QA, release, review-feedback, roadmap) encode entire workflows that would otherwise require repeated human instruction. The `docs/issues/` convention and the codebase-architect skill create a planning layer that separates "thinking about what to build" from "building it," which is exactly the right architecture for agentic development.
+
+That said, there are clear gaps. The documentation is strongest where you've been burned (process management, Circuit Electron gotchas, the IndexedDB schema trap) and weakest where things have been working fine but are getting complex enough that an agent could make expensive mistakes (component patterns, the tool/suggestion pipeline, the streaming architecture). The roadmap doc is stale. And the memory system is empty, which means every new session starts cold.
+
+**Overall grade: B+.** The bones are excellent. The gaps are fixable.
+
+---
+
+## What's Working Well
+
+### CLAUDE.md — The Agent's Operating Manual
+
+This is the single most important file for agentic development, and it's strong. Specific things that work:
+
+**Operational guardrails are concrete.** The PID protocol for dev server management, the `NEVER: pkill -f node` warnings, the multi-agent awareness section — these prevent the exact class of mistakes agents make when given bash access. The "use SEPARATE Bash calls — never chain with &&" instruction shows you've debugged agent-specific failure modes, not just human ones.
+
+**The "Before Implementation" and "Before Presenting Work" checklists** are high-value. Agents are bad at remembering to do pre/post work unless it's explicitly listed. These checklists short-circuit the most common agent failure: diving straight into code without checking branch state, or announcing "done" without verifying the build compiles.
+
+**Architecture section is the right depth.** It names the key files, explains the process model, calls out the cross-platform abstraction (`getApi()` not `window.api`), and flags landmines (IndexedDB version bumps, "Anthropic is the only supported provider"). An agent reading this section can orient itself in the codebase within seconds.
+
+**The workflow section encodes your actual process**, not an aspirational one. Branch naming conventions, commit message format, PR review protocol, the automated review analysis pipeline — this is all directly actionable.
+
+### Custom Skills — Encoded Workflows
+
+The skills are where this project goes from "well-documented" to "agentic-native." Each one is essentially a runbook an agent can follow autonomously:
+
+**`qa-pr`** is particularly well-crafted. It handles the full lifecycle (fetch PR → checkout branch → kill stale processes → build → test → post results), includes workarounds for known Circuit Electron limitations, and has a collaborative manual testing protocol for things automation can't reach. The "Setup → Handoff → Verify" pattern is a genuine innovation for human-agent collaboration.
+
+**`review-feedback`** encodes judgment, not just process. The "pragmatism over compliance" philosophy, the severity/effort matrix, the distinction between "Must Fix," "Consider Fixing," "Defer," and "Dismissed" — this gives an agent a decision framework, not just a checklist.
+
+**`release`** is an end-to-end runbook that would be terrifying without documentation (version bump → build → regression test → release notes → GitHub release → local install verification → push). Each step has exact commands and expected outputs.
+
+**`codebase-architect`** is the most architecturally interesting skill. It creates a clear separation between "planning agent" (read-only, advisory) and "implementation agent" (writes code). The execution boundary section is explicitly designed to prevent a common failure mode: an advisory agent accidentally making changes. The modes of operation (Plan Review, Codebase Q&A, Issue Triage, Acceleration Prep, PR Review) give the agent a clear role depending on context.
+
+### docs/issues/ Convention
+
+The per-issue documentation folders are excellent for agentic development. Issue #74 (database recovery) is a model: problem statement, current architecture analysis with code references, tiered solution design, implementation plan with specific files to modify, risk assessment, and testing strategy. An agent handed this document and told "implement Phase 1" has everything it needs.
+
+Issue #55 (frontmatter editing) is equally good — it documents the investigation, presents options with tradeoffs, makes a recommendation, and flags risks. This is the kind of document that prevents an agent from making a well-intentioned but architecturally wrong choice.
+
+---
+
+## What's Missing or Weak
+
+### 1. Stale Roadmap (High Impact)
+
+`docs/roadmap.md` was last updated December 2024 and is significantly out of date. It lists "Multi-provider LLM chat" as a completed feature when `CLAUDE.md` says "Anthropic is the only supported provider." It references phases (Agentic Editing, Document Management, Streaming) that have been partially or fully completed. The "Key Files" section at the bottom references files that may no longer exist or have moved.
+
+**Why this matters for agents:** The roadmap-prioritization and roadmap-refinement skills both read this document. If they cross-reference it with the actual issue board, they'll get confused by contradictions. More importantly, `MVP.md` appears to be the actual source of truth for current state but it's not referenced from the roadmap.
+
+**Recommendation:** Either deprecate `roadmap.md` in favor of `MVP.md` + the GitHub project board, or update it to reflect current state. Add a "canonical sources of truth" note to `CLAUDE.md` so agents know which document to trust when they conflict.
+
+### 2. No Component/Pattern Guide (High Impact)
+
+The architecture section in `CLAUDE.md` names the stores and key files, but there's no documentation of UI component patterns. For an agent implementing a new feature, questions like these have no documented answers:
+
+- How do you add a new settings tab? (What's the pattern in SettingsDialog?)
+- How do you add a new IPC channel end-to-end? (handler in ipc.ts → type in preload → exposure in browserApi.ts)
+- How do you add a new TipTap extension? (registration, where to put it, how to wire to stores)
+- How do you add a new tool to the AI chat system? (tool definition, handler, rendering)
+- How do you add a new panel to the resizable layout?
+
+These are the "recipes" an agent needs most. Right now, an agent has to reverse-engineer these patterns from existing code every time. A section in `CLAUDE.md` called "Common Patterns" with 5-10 of these recipes would dramatically reduce implementation time and error rate.
+
+**Recommendation:** Add a "Common Patterns" or "How to Add..." section to `CLAUDE.md`. Each pattern should list the files to touch, the order of operations, and link to an existing example in the codebase.
+
+### 3. Empty Memory System (Medium Impact)
+
+The `memory/` directory exists with `context/`, `people/`, and `projects/` subdirectories, but they're all empty. The productivity:memory-management skill is installed but has nothing to work with.
+
+**Why this matters for agents:** Every Cowork session starts from zero context. The memory system is designed to accumulate project vocabulary (what "the tool pipeline" means, what "suggestion mode" refers to), people context (who works on what), and project context (current priorities, recent decisions). Without it, agents have to re-derive this context from `CLAUDE.md` and the codebase each time.
+
+**Recommendation:** Seed the memory system with at least a `projects/prose.md` file covering: current phase, recent decisions, vocabulary/jargon, and the relationship between MVP.md/roadmap.md/the project board.
+
+### 4. No Documentation of the LLM Tool Pipeline (Medium Impact)
+
+The chat system's tool architecture is the most complex subsystem in the app, and it's the one most likely to be extended by agents (new tools, new modes). But there's no documentation of:
+
+- The three tool modes (Suggestions, Full, Plan) and how they differ in behavior
+- How tools are defined and registered
+- The streaming pipeline (stream ID validation, tool roundtrip limits, abort handling)
+- The suggestion/diff workflow (how AI edits become inline suggestions, how accept/reject works)
+
+The codebase-architect skill's reference doc mentions these exist but `CLAUDE.md` only has a one-line description: "LLM calls flow: useChat hook → window.api.llmChat() → IPC → main process → Vercel AI SDK."
+
+**Recommendation:** Add a "Chat & Tool Architecture" section to `CLAUDE.md` that documents the tool pipeline, tool modes, and streaming behavior. This is the area where an agent making a wrong assumption causes the most user-visible damage.
+
+### 5. QA_feedback.md is Abandoned (Low Impact)
+
+`docs/QA_feedback.md` references issues #2 through #7 and appears to be from the very early days of the project. It's not being maintained and the issues it references are likely long-closed. It creates noise for agents that scan the docs directory.
+
+**Recommendation:** Delete it or archive it. QA feedback now flows through Circuit Electron test results posted to PRs, which is the better system.
+
+### 6. No Error Recovery Playbook (Medium Impact)
+
+`CLAUDE.md` has great preventive documentation (don't do X, always do Y) but no recovery documentation. When an agent encounters common failure states — build fails, port conflict, stale LevelDB lock, IndexedDB corruption in dev, Circuit Electron session won't connect — there's no documented recovery procedure beyond the scattered mentions in individual skills.
+
+**Recommendation:** Add a "Troubleshooting" section to `CLAUDE.md` with the 5-10 most common failure states and their fixes. The skills already contain some of this (the QA skills have troubleshooting sections), but having it centralized in the main agent instructions means it's always in context.
+
+### 7. docs/README.md Doesn't Map the Full Docs Landscape (Low Impact)
+
+The docs README lists three items (roadmap, issues, QA_feedback) but doesn't mention spikes, research, or the relationship to MVP.md and CLAUDE.md. For an agent trying to understand where documentation lives, this is incomplete.
+
+**Recommendation:** Update to include all documentation locations: spikes/, research/, the .claude/skills/ directory, MVP.md, and the memory/ system.
+
+### 8. Security Audit Has No CLAUDE.md Integration (Low Impact)
+
+The security audit at `docs/issues/127/findings.md` is thorough, but its findings aren't reflected in `CLAUDE.md`. An agent implementing a new IPC handler won't know about the SEC-03 pattern (missing path validation) unless it happens to read the security audit. The lesson — "always call validatePath() on file-writing IPC handlers" — should be a permanent instruction.
+
+**Recommendation:** Add security-relevant implementation rules to the architecture section of `CLAUDE.md`: always validate paths in IPC handlers, never use innerHTML with dynamic data, always use safeStorage for secrets.
+
+---
+
+## Structural Observations
+
+### Documentation is Agent-First, Not Human-First
+
+This is a strength, not a criticism. The docs are written for an entity that reads fast, follows instructions literally, and needs explicit guardrails against destructive actions. The PID protocol, the "NEVER" warnings, the exact command sequences in skills — these are all calibrated for an agent audience. A human developer would find some of this overly prescriptive. For agents, it's exactly right.
+
+### The Planning/Execution Split is Well-Designed
+
+The separation between codebase-architect (read-only advisory) and implementation agents (write code) is architecturally sound. The `docs/issues/` plans serve as the handoff artifact. The acceleration workflow (architect produces brief → agent implements → QA validates) is a genuine SDLC, not just "tell the AI to code."
+
+### Skills Are the Most Valuable Asset
+
+The custom skills encode months of trial and error into reproducible workflows. They're more valuable than the static documentation because they capture process, not just knowledge. The QA, release, and review-feedback skills in particular would take a new team member weeks to internalize — an agent gets them immediately.
+
+---
+
+## Prioritized Recommendations
+
+| Priority | Recommendation | Effort | Impact |
+|----------|---------------|--------|--------|
+| 1 | Add "Common Patterns" recipes to CLAUDE.md | Medium | High — reduces agent implementation errors |
+| 2 | Resolve roadmap.md staleness (deprecate or update) | Small | High — eliminates conflicting sources of truth |
+| 3 | Document the LLM tool pipeline and streaming architecture | Medium | High — protects most complex subsystem |
+| 4 | Add "Troubleshooting" recovery playbook to CLAUDE.md | Small | Medium — faster recovery from common failures |
+| 5 | Seed the memory system with project context | Small | Medium — reduces cold-start cost per session |
+| 6 | Add security implementation rules to CLAUDE.md | Small | Medium — prevents repeating known vulnerabilities |
+| 7 | Update docs/README.md to map full docs landscape | Small | Low — helps orientation |
+| 8 | Delete or archive stale QA_feedback.md | Trivial | Low — reduces noise |

--- a/docs/audits/documentation-audit-2026-03-14.md
+++ b/docs/audits/documentation-audit-2026-03-14.md
@@ -1,0 +1,153 @@
+# Documentation Audit — March 14, 2026
+
+**Scope:** Full codebase documentation coverage analysis
+**Prior audit:** `docs/audits/agentic-documentation-audit.md` (March 13, 2026)
+**Methodology:** Deep codebase exploration (152 source files, 45+ IPC channels, 10 stores, 8 extensions, 15 tools, 8 workflows, 15 skills)
+
+---
+
+## Status of Prior Audit Recommendations
+
+The March 13 audit identified 8 gaps. Here's what's been addressed:
+
+| # | Recommendation | Status |
+|---|---------------|--------|
+| 1 | Add "Common Patterns" recipes to CLAUDE.md | **Not addressed** |
+| 2 | Resolve roadmap.md staleness | **Not addressed** — still says "Last updated: December 2024" |
+| 3 | Document LLM tool pipeline and streaming | **Not addressed** |
+| 4 | Add troubleshooting/recovery playbook | **Not addressed** |
+| 5 | Seed the memory system | **Not addressed** |
+| 6 | Add security implementation rules | **Not addressed** |
+| 7 | Update docs/README.md | **Not addressed** |
+| 8 | Delete/archive stale QA_feedback.md | **Not addressed** |
+
+**Bottom line:** The prior audit's recommendations remain fully valid. This audit builds on them with additional findings from deeper code analysis.
+
+---
+
+## New Findings
+
+### 1. CLAUDE.md Architecture Section Is Out of Date (High Impact)
+
+CLAUDE.md describes the codebase accurately at a high level but has drifted from reality in several ways:
+
+**Stores:** CLAUDE.md lists 5 stores (editorStore, editorInstanceStore, chatStore, settingsStore, fileListStore). The codebase has **10**: the missing 5 are `tabStore`, `summaryStore`, `reviewStore`, `commandHistoryStore`, and `linkHoverStore`. The tab store in particular is critical — it manages the entire multi-tab interface. Any agent creating a new feature that involves document switching will miss the tab lifecycle unless they find this store independently.
+
+**IPC channels:** CLAUDE.md documents 4 categories (file, settings, llm, remarkable). The actual codebase has **7**: the missing categories are `google:*` (14 handlers for Google Docs), `mcp:*` (3 handlers for MCP server management), and `window:*` / utility handlers (emoji generation, shell:openExternal, file associations, recent files). The Google Docs channels are especially significant — they represent an entire integration that CLAUDE.md only mentions in the reMarkable section's OCR note.
+
+**Shared directory:** CLAUDE.md doesn't mention `src/shared/` at all. This directory contains the unified tool registry, Zod schemas for all tools, and shared LLM utilities. It's the architectural glue between the MCP server and the in-app chat, and an agent extending the tool system needs to know it exists.
+
+**MCP subsystem:** CLAUDE.md doesn't document `src/main/mcp/` (HTTP/socket bridge for Claude Desktop integration) or `src/mcp-stdio/` (standalone MCP server that auto-launches Prose). These represent a full integration surface that's invisible to agents working from CLAUDE.md alone.
+
+### 2. Google Docs Integration Is Undocumented (High Impact)
+
+Google Docs sync is a shipping feature (listed in MVP.md, has 14 IPC handlers, full OAuth flow, bidirectional sync with conflict resolution). Yet:
+
+- CLAUDE.md doesn't mention it in the Architecture section
+- There's no `docs/` page explaining the sync model or auth flow
+- The OAuth scope requirements aren't documented anywhere
+- The sync metadata format (`.google/sync-metadata.json`) isn't documented
+- The migration from frontmatter-based storage to metadata-file storage isn't documented
+
+An agent asked to fix a Google Docs sync bug would need to reverse-engineer the entire flow from three files in `src/main/google/`.
+
+### 3. MCP Server Architecture Is Undocumented (Medium Impact)
+
+Prose exposes itself as an MCP server to Claude Desktop through two mechanisms: a Unix socket bridge (`src/main/mcp/`) and a stdio server (`src/mcp-stdio/`). The stdio server auto-launches Prose if it's not running, exposes 5 tools (`read_document`, `get_outline`, `open_file`, `suggest_edit`, `create_and_open_file`), and has specific timeout/buffer constraints.
+
+None of this is documented in CLAUDE.md or anywhere else. The relationship between the two server types, how tools are dispatched, and the auto-launch mechanism are only discoverable by reading source code.
+
+### 4. Tool Registry Architecture Is Undocumented (Medium Impact)
+
+The `src/shared/tools/` directory contains a sophisticated tool system:
+
+- A registry (`registry.ts`) that manages 15+ tools across 3 categories (document, editor, file)
+- Zod schema validation for all tool inputs
+- Mode-based access control — tools are tagged with which modes they're available in (`null` = all, `'suggestions'`, `'plan'`, `'full'`)
+- Separate tool sets for LLM use vs. MCP use
+
+MVP.md mentions the three tool modes in passing. CLAUDE.md doesn't mention them at all. The access control logic (which tools are available when) is a critical architectural decision that affects every new tool added to the system.
+
+### 5. No SECURITY.md or CONTRIBUTING.md (Medium Impact)
+
+For an open-source project on GitHub with releases:
+
+- **SECURITY.md** — No responsible disclosure process. The security audit at `docs/issues/127/findings.md` found real vulnerabilities (path traversal in IPC handlers, missing input validation) but there's no public-facing security policy.
+- **CONTRIBUTING.md** — The README says "Contributions welcome! Please open an issue first" but there's no guide for setting up the dev environment, running the app, or understanding the PR process. The information exists in CLAUDE.md, but that's written for AI agents, not human contributors.
+
+### 6. Tab System Not Documented (Medium Impact)
+
+The multi-tab interface (managed by `tabStore.ts` at 8.1KB) is a core user-facing feature with session persistence, preview tabs, and lifecycle management. It's not mentioned in CLAUDE.md's architecture section. An agent implementing any feature that opens, closes, or switches documents needs to understand tab lifecycle to avoid bugs like state leaking between tabs.
+
+### 7. Stale Key Files Section in Roadmap (Low Impact)
+
+The "Key Files" section at the bottom of `docs/roadmap.md` references files that no longer exist or have moved. For example, it suggests creating `src/renderer/lib/documentEditor.ts` and `src/main/google.ts` — the former may not exist, and the latter has been refactored into `src/main/google/client.ts`, `auth.ts`, and `sync.ts`. Agents using the roadmap for file navigation will be misled.
+
+### 8. GitHub Workflows Undocumented (Low Impact)
+
+There are 8 workflows in `.github/workflows/` but only `claude.yml` and `review-feedback.yml` are documented in CLAUDE.md. The remaining 6 (`dispatch.yml`, `e2e.yml`, `web-e2e.yml`, `feature-request-triage.yml`, `pipeline-fix.yml`, `pipeline-triage.yml`) are unmentioned. The e2e workflows are particularly relevant — they represent a testing infrastructure that CLAUDE.md says doesn't exist ("No tests: This project has no test suite").
+
+### 9. Review System Undocumented (Low Impact)
+
+`reviewStore.ts` and the `src/renderer/components/review/` directory implement a document review system (quick review with inline diff, side-by-side diff, per-change accept/reject). This is mentioned in MVP.md but not in CLAUDE.md's architecture section. It's a non-trivial subsystem with its own store and component tree.
+
+---
+
+## Consolidated Recommendations
+
+### Tier 1 — Should Fix Soon (high impact, prevents agent mistakes)
+
+1. **Update CLAUDE.md Architecture section.** Add the 5 missing stores, the Google/MCP/utility IPC categories, the `src/shared/` directory, and the MCP subsystem. This is the single highest-ROI fix — every agent session reads this section.
+
+2. **Add "Common Patterns" recipes to CLAUDE.md** (carried from prior audit). The five most needed: how to add a new IPC channel end-to-end, how to add a new tool to the chat system, how to add a new settings tab, how to add a new TipTap extension, and how to add a new panel.
+
+3. **Document Google Docs integration.** Either a section in CLAUDE.md or a dedicated `docs/google-docs.md`. Must cover: auth flow, sync model, metadata format, and the migration story.
+
+4. **Document the tool registry and modes.** The three modes (suggestions/full/plan), how tools are registered, how access control works, and how to add a new tool. This is the subsystem agents are most likely to extend incorrectly.
+
+### Tier 2 — Should Fix When Convenient (medium impact)
+
+5. **Resolve roadmap staleness** (carried from prior audit). `docs/roadmap.md` contradicts CLAUDE.md and MVP.md in multiple places. Either deprecate it with a pointer to MVP.md, or bring it current.
+
+6. **Document the MCP server architecture.** How the stdio server and socket bridge relate, the 5 exposed tools, auto-launch behavior, timeout/buffer constraints.
+
+7. **Add a troubleshooting section to CLAUDE.md** (carried from prior audit). The 5 most common: build failures, port conflicts, stale LevelDB locks, IndexedDB version issues, Circuit Electron connection failures.
+
+8. **Create CONTRIBUTING.md.** Extract the human-relevant parts from CLAUDE.md (dev setup, build commands, PR process) into a contributor guide. Can be short.
+
+9. **Create SECURITY.md.** Standard responsible disclosure template plus a note about the path validation findings from the security audit.
+
+10. **Correct CLAUDE.md's "No tests" claim.** The e2e and web-e2e workflows exist. Either document the Playwright test infrastructure or clarify what "no tests" means (no unit test suite, but e2e exists).
+
+### Tier 3 — Nice to Have (low impact)
+
+11. **Update docs/README.md** (carried from prior audit). Map the full documentation landscape including spikes, research, audits, and skills.
+
+12. **Delete or archive QA_feedback.md** (carried from prior audit).
+
+13. **Seed the memory system** (carried from prior audit). A `projects/prose.md` file with vocabulary, current priorities, and canonical sources of truth.
+
+14. **Document the tab system and review system** in CLAUDE.md architecture.
+
+15. **Clean up roadmap.md Key Files section** or remove it entirely.
+
+---
+
+## Documentation Health Scorecard
+
+| Area | Coverage | Notes |
+|------|----------|-------|
+| README | Good | Clear, concise, covers quick start |
+| CLAUDE.md (process) | Excellent | Checklists, PID protocol, workflow rules |
+| CLAUDE.md (architecture) | Partial | Core is solid, but 5 stores, 3 IPC categories, and 2 subsystems missing |
+| Editor/TipTap | Minimal | Extensions undocumented beyond file existence |
+| Chat/Tool system | Poor | Most complex subsystem, least documented |
+| Google Docs | None | Shipping feature with zero documentation |
+| MCP integration | None | Two server types, completely undocumented |
+| reMarkable | Adequate | Covered in CLAUDE.md, sync model clear |
+| CI/CD workflows | Partial | 2 of 8 workflows documented |
+| Skills | Good | Self-documenting via skill files |
+| Issue plans | Excellent | Thorough, actionable, agent-ready |
+| Security | Poor | Audit exists but findings not integrated |
+
+**Overall: B.** Strong process documentation, but feature documentation hasn't kept pace with the codebase's growth. The gap between what CLAUDE.md describes and what the codebase actually contains has widened since the last audit.

--- a/docs/issues/327/self-healing-docs-proposal.md
+++ b/docs/issues/327/self-healing-docs-proposal.md
@@ -1,0 +1,211 @@
+# Self-Healing Documentation for Agent Pipeline v2
+
+**Issue:** [#327 — Agent Pipeline v2: Dual-Analysis Triage and Automated Fix Pipeline](https://github.com/solo-ist/prose/issues/327)
+**Date:** 2026-03-13
+**Status:** Proposal
+
+---
+
+## The Problem
+
+Documentation in this project has two failure modes, and they're both caused by the same thing: documentation is a separate artifact from the code and processes it describes, so it drifts silently.
+
+**Mode 1: Stale content.** `docs/roadmap.md` says multi-provider LLM chat is complete. `CLAUDE.md` says Anthropic is the only provider that matters. Both were accurate when written. Neither was updated when the other changed. An agent reading both gets contradictory instructions.
+
+**Mode 2: Missing content.** The LLM tool pipeline (three tool modes, streaming, suggestion workflow) is the most complex subsystem in the app. It has zero documentation. Not because anyone decided not to document it, but because it evolved through PRs that each seemed too small to warrant a docs update. No individual PR was the right time to write the docs. Collectively, the gap is now significant.
+
+The pipeline v2 proposed in #327 creates a natural intervention point for both failure modes. Every PR already passes through structured analysis (code review → triage → routing). Adding a documentation health check to this pipeline is architecturally free — it's just another signal the orchestrator consumes.
+
+---
+
+## How It Fits Into Pipeline v2
+
+The key insight is that self-healing documentation is not a separate system. It's a new dimension in the existing triage and auto-fix pipeline. Here's where it plugs in:
+
+```
+PR Event
+  → Code Review Agent (existing)
+  → [Gate: issues found?]
+      → Issues found: Fork to sub-agents (parallel)
+          ┌─────────────────────────┐
+          │ Sub-agent 1: Scorer     │  ← existing (quantitative)
+          ├─────────────────────────┤
+          │ Sub-agent 2: PE         │  ← existing (architectural)
+          ├─────────────────────────┤
+          │ Sub-agent 3: Doc Healer │  ← NEW (documentation drift)
+          └─────────────────────────┘
+          → Orchestrator merges all signals
+          → Routes: code fixes, doc fixes, or both
+```
+
+But — and this is important — the Doc Healer is not an Opus-class agent. It's a lightweight, deterministic check that runs in parallel with the existing sub-agents at minimal cost. Think of it as a linter, not a reviewer.
+
+### Why Not a Dedicated Security Agent (Same Reasoning)
+
+The comment on #327 already explains why a third Opus agent for security is overkill: "The Principal Engineer sub-agent already catches architectural security concerns." The same logic applies here. We don't need a third expensive agent. We need a cheap, focused check that produces a structured signal the orchestrator can act on.
+
+---
+
+## Design: The Doc Healer
+
+### What It Checks
+
+The Doc Healer runs against every PR and produces one of three verdicts: `docs-current`, `docs-drift-detected`, or `docs-update-required`. It checks four things:
+
+#### 1. CLAUDE.md Consistency (Static Analysis)
+
+Compare the PR's changed files against claims in `CLAUDE.md`:
+
+| PR touches... | CLAUDE.md claims... | Drift? |
+|---------------|---------------------|--------|
+| `src/main/ipc.ts` (adds new channel) | IPC channels list is `file:*`, `settings:*`, `llm:*`, `remarkable:*` | Yes — new channel not listed |
+| `src/renderer/stores/` (adds new store) | Stores are `editorStore`, `chatStore`, `settingsStore`, `fileListStore` | Yes — new store not listed |
+| `src/preload/index.ts` (exposes new API) | No mention of the new API surface | Yes |
+| `package.json` (adds build command) | Commands section doesn't include it | Yes |
+| `src/renderer/components/` (styling) | No architectural claims about components | No drift |
+
+This is a deterministic file-path check. If the PR modifies files that CLAUDE.md makes claims about, flag it. No LLM needed for detection — just a mapping of "CLAUDE.md sections → file paths they describe."
+
+**Implementation:** A JSON manifest (`docs/doc-file-map.json`) that maps CLAUDE.md sections to the file patterns they document:
+
+```json
+{
+  "## Commands": ["package.json"],
+  "### IPC Channels": ["src/main/ipc.ts", "src/preload/index.ts"],
+  "### State Management": ["src/renderer/stores/**"],
+  "### Electron Process Model": ["src/main/**", "src/preload/**"],
+  "### Editor": ["src/renderer/components/editor/**"],
+  "### reMarkable Integration": ["src/main/remarkable/**"],
+  "### Settings": ["src/renderer/types/index.ts", "src/main/ipc.ts"],
+  "## UI Conventions": ["src/renderer/components/**"]
+}
+```
+
+When a PR touches files matching a pattern, the corresponding CLAUDE.md section is flagged for review. This is cheap to maintain because the manifest itself becomes a documented relationship between code and docs.
+
+#### 2. Skill Freshness (Event-Driven)
+
+Skills reference specific file paths, commands, and behavioral contracts. When the underlying code changes, the skill may break silently. Check:
+
+- Do file paths referenced in skills still exist?
+- Do commands referenced in skills still work? (e.g., if a skill says `npm run build:mac`, does that script exist in package.json?)
+- Do MCP tool names referenced in skills still resolve?
+
+**Implementation:** Parse skill files for file paths and commands, cross-reference against the repo state post-PR. This is grep + file existence checks — no LLM needed.
+
+#### 3. Issue Doc Staleness (Lifecycle-Based)
+
+`docs/issues/<number>/` folders are created during planning and never updated or archived. When the issue is closed, the plan doc becomes historical — useful for context but potentially misleading if someone reads it as current guidance.
+
+**Implementation:** On PR merge, if the PR closes an issue that has a `docs/issues/<number>/` folder:
+- Add a header to the plan doc: `> **Status: Implemented** — Merged in PR #X on YYYY-MM-DD`
+- If the implementation diverged significantly from the plan (detectable by comparing plan.md file list vs. actual files changed in PR), add a note: `> **Note:** Implementation diverged from this plan. See PR #X for actual changes.`
+
+#### 4. Cross-Document Consistency (Periodic)
+
+Some documents make claims about each other. `MVP.md` lists features. `roadmap.md` lists phases. `CLAUDE.md` describes architecture. When these conflict, agents get confused.
+
+This is the only check that benefits from an LLM, and it doesn't need to run per-PR. Run it weekly (or on `/docs-audit` command) as a scheduled workflow:
+
+- Feed all documentation files to a Sonnet-class model
+- Ask: "Identify any contradictions between these documents"
+- Post results as a GitHub issue if contradictions found
+
+---
+
+## Integration With the Orchestrator
+
+The Doc Healer's output feeds into the existing routing matrix as an additional dimension:
+
+| Scorer | PE Risk | Doc Healer | Route |
+|--------|---------|------------|-------|
+| 1-3 | LOW | docs-current | Auto-fix code only |
+| 1-3 | LOW | docs-drift-detected | Auto-fix code + auto-update docs |
+| 1-3 | LOW | docs-update-required | Auto-fix code, flag docs for human |
+| Any | Any | docs-drift-detected | Add `docs-drift` label to PR |
+| Any | MEDIUM+ | docs-update-required | Add to human review checklist |
+
+The key principle: **doc drift never blocks a merge, but it always creates a tracking artifact.** Either the auto-fix agent updates the docs in the same PR, or a follow-up issue is created automatically.
+
+### Auto-Fix for Docs
+
+When the Doc Healer detects drift in CLAUDE.md (e.g., a new IPC channel was added but not listed), the auto-fix agent can handle this alongside code fixes. The fix is mechanical: read the new code, update the relevant CLAUDE.md section.
+
+For skill file fixes (broken file paths, outdated commands), the auto-fix is even simpler: update the path or command to match reality.
+
+For cross-document contradictions, auto-fix is not appropriate. These require human judgment about which document is the source of truth.
+
+---
+
+## Implementation Plan (Phased, Aligned With #327)
+
+### Phase 1: Doc-File Manifest (Ships With Pipeline v2 Phase 1)
+
+Create `docs/doc-file-map.json`. Add a simple check to the review workflow: if PR touches files in the manifest, add a comment noting which CLAUDE.md sections may need updating. This is a reminder, not automation — but it's zero-cost and immediately useful.
+
+**Effort:** ~2 hours. One JSON file, one shell script in the workflow.
+
+### Phase 2: Skill Path Validation (Ships With Pipeline v2 Phase 2)
+
+Add a CI step that validates all file paths and commands referenced in `.claude/skills/` files. Fails with a warning (not a block) if references are broken.
+
+**Effort:** ~4 hours. Script to parse skill files, cross-reference paths.
+
+### Phase 3: Issue Doc Lifecycle (Ships With Pipeline v2 Phase 3)
+
+On PR merge that closes an issue, auto-update `docs/issues/<number>/plan.md` with implementation status header. Create a GitHub Action that runs on `pull_request.closed` + merged.
+
+**Effort:** ~3 hours. Small workflow addition.
+
+### Phase 4: Full Doc Healer Sub-Agent (Ships With Pipeline v2 Phase 4)
+
+Integrate the doc-file manifest check, skill validation, and issue doc lifecycle into a single sub-agent that runs alongside the Scorer and PE. Output is a structured JSON signal consumed by the orchestrator. Auto-fix agent can now update CLAUDE.md and skill files mechanically.
+
+**Effort:** ~1 day. Orchestrator integration, auto-fix template for doc updates.
+
+### Phase 5: Cross-Document Audit (Ships With Pipeline v2 Phase 6)
+
+Scheduled weekly workflow that checks all documentation for internal contradictions. Posts a GitHub issue if drift is detected. Can also be triggered via `/docs-audit` comment command.
+
+**Effort:** ~4 hours. Scheduled workflow + Sonnet API call.
+
+---
+
+## What This Doesn't Solve
+
+This system handles documentation that describes code (architecture docs, agent instructions, skills). It does not handle:
+
+- **User-facing documentation** (help text, onboarding, feature descriptions) — these require product judgment, not code analysis
+- **Documentation that doesn't exist yet** — the system can detect drift in existing docs, but it can't decide that a new subsystem needs documentation in the first place (though the PE sub-agent could flag this as an architectural concern)
+- **Documentation quality** — it checks accuracy, not clarity or completeness
+
+---
+
+## Relationship to the Documentation Audit
+
+The [agentic documentation audit](../audits/agentic-documentation-audit.md) from earlier today identified 8 recommendations. Here's how the self-healing system addresses each:
+
+| Audit Recommendation | Addressed By |
+|---------------------|--------------|
+| 1. Add "Common Patterns" recipes | Not addressed — requires authoring, not healing |
+| 2. Resolve roadmap.md staleness | Phase 5 (cross-document audit) detects this automatically |
+| 3. Document LLM tool pipeline | Not addressed — requires authoring |
+| 4. Add troubleshooting playbook | Not addressed — requires authoring |
+| 5. Seed memory system | Not addressed — different system |
+| 6. Add security implementation rules | Phase 1 (doc-file manifest) ensures security-relevant code changes flag CLAUDE.md |
+| 7. Update docs/README.md | Phase 5 (cross-document audit) would flag incompleteness |
+| 8. Delete stale QA_feedback.md | Phase 3 (issue doc lifecycle) handles staleness marking |
+
+The honest answer: self-healing documentation solves the drift problem (recommendations 2, 6, 7, 8) but not the gap problem (recommendations 1, 3, 4). You still need a human (or a dedicated authoring session with an agent) to write the documentation that doesn't exist yet. What the system prevents is the documentation you write today becoming stale tomorrow.
+
+---
+
+## Open Questions
+
+1. **Manifest maintenance cost.** The doc-file manifest (`doc-file-map.json`) is itself a document that can drift. Should it be auto-generated from CLAUDE.md section headers + heuristic file matching, or manually maintained? Manual is more accurate but adds maintenance burden.
+
+2. **Noise threshold.** A PR that touches `src/renderer/stores/chatStore.ts` to fix a typo doesn't warrant a "State Management section may need updating" comment. How aggressive should the matching be? Suggestion: only flag when files are added or removed from a directory, not when existing files are modified.
+
+3. **Skill validation depth.** Should the skill path validator just check file existence, or should it also verify that code patterns referenced in skills (e.g., "use `evaluate` to dispatch KeyboardEvents") still appear in the referenced files? Deeper validation catches more drift but is harder to maintain.
+
+4. **Auto-fix trust level for docs.** Should the auto-fix agent be allowed to modify CLAUDE.md autonomously, or should doc changes always go through human review? CLAUDE.md is the agent's operating manual — an agent modifying its own instructions has obvious recursive trust implications.

--- a/docs/launch/deploy-checklist-launch.md
+++ b/docs/launch/deploy-checklist-launch.md
@@ -1,0 +1,274 @@
+# Deploy Checklist: Prose v1.0.0 — Mac App Store + Open Source Launch
+
+**Date:** March 18, 2026 | **Deployer:** Angel
+**Current Version:** 0.1.0-alpha.4 | **Target Version:** 1.0.0
+**Distribution:** Mac App Store ($0.99 BYOK) + Direct Download (signed DMG via GitHub Releases)
+
+---
+
+## Phase 0 — Human Gates (longest lead times, start immediately)
+
+### 0A: Apple Developer Portal
+
+- [ ] Create "Developer ID Application" certificate (for DMG notarization)
+- [ ] Create "Apple Distribution" certificate (for MAS submission)
+- [ ] Create Mac App Store provisioning profile for `com.prose.app`
+- [ ] Export both certificates as `.p12` files
+- [ ] Generate app-specific password at appleid.apple.com (for notarization)
+- [ ] Record Team ID: `_______________`
+- [ ] Create app record in App Store Connect:
+  - Bundle ID: `com.prose.app` *(already matches `electron-builder.yml`)*
+  - Category: Productivity
+  - Price: $0.99
+- [ ] Add GitHub Actions secrets:
+  - `CSC_LINK` (base64-encoded .p12)
+  - `CSC_KEY_PASSWORD`
+  - `APPLE_ID`
+  - `APPLE_APP_SPECIFIC_PASSWORD`
+  - `APPLE_TEAM_ID`
+
+### 0B: Privacy Policy
+
+- [ ] Draft privacy policy covering:
+  - No data collected by developer (BYOK model)
+  - No analytics, no telemetry (Sentry is opt-in, disclose if keeping)
+  - Document content sent to `api.anthropic.com` only when user initiates AI chat
+  - API keys stored via OS `safeStorage` (never plaintext)
+  - Files stay local on device
+- [ ] Host at stable URL (e.g., `prose.so/privacy` or GitHub Pages)
+- [ ] Verify URL is live and accessible
+
+---
+
+## Phase 1 — Foundation (3 parallel agent worktrees)
+
+### 1A: Open-Source Prep (issue #197)
+
+**Status:** Not started. No `LICENSE` file exists. No branch created yet.
+
+- [ ] Create branch `issue-197-open-source-prep` in worktree
+- [ ] Create `LICENSE` file (MIT)
+- [ ] Add `"license": "MIT"` to `package.json`
+- [ ] Update `README.md`:
+  - Remove unsigned app warning
+  - Add privacy section
+  - Add build-from-source instructions
+- [ ] Verify no secrets in git history (confirmed clean — all credentials are env vars)
+- [ ] PR created and merged
+
+### 1B: Auto-Update (issue #191)
+
+**Status:** Branch `issue-191-auto-update` exists with 3 commits (updater.ts, MAS gating, error recovery). Needs rebase onto main (30+ commits behind).**
+
+- [ ] Rebase `issue-191-auto-update` onto current `main`
+- [ ] Verify `src/main/updater.ts` has `__IS_MAS_BUILD__` gate
+- [ ] Verify `src/renderer/components/layout/UpdateBanner.tsx` renders correctly
+- [ ] Fix `afterPack.js` path reference (branch may reference `scripts/`, main has `build/`)
+- [ ] Add `__IS_MAS_BUILD__` define to `electron-vite.config.ts`
+- [ ] Add `publish: github` + `zip` target to `electron-builder.yml`
+- [ ] Create `.github/workflows/release.yml` stub (extended in Phase 2)
+- [ ] Verify `npm run build` succeeds after rebase
+- [ ] PR created and merged
+
+### 1C: Google Docs → Beta Waitlist (issue #120)
+
+**Status:** Not started. `GoogleDocsIntegration.tsx` exists with full sync UI. 13 `google:*` IPC handlers in `ipc.ts`.**
+
+- [ ] Create branch `issue-120-google-docs-waitlist` in worktree
+- [ ] Replace `GoogleDocsIntegration.tsx` content with "Coming in v1.1" + waitlist link
+- [ ] Gate `google:startAuth` IPC handler behind `__IS_MAS_BUILD__` (OAuth callback starts HTTP server — needs `network.server` entitlement, incompatible with MAS sandbox)
+- [ ] Leave remaining 12 `google:*` IPC handlers intact (harmless, reduces risk)
+- [ ] Verify Settings panel renders correctly with waitlist UI
+- [ ] PR created and merged
+
+### Phase 1 Merge Order
+
+```
+1A (LICENSE, README) → 1B (auto-update) → 1C (Google waitlist)
+```
+
+Known conflict: `src/renderer/types/index.ts` — 1B adds updater types, 1C touches google types. Sequential merge resolves this.
+
+- [ ] All three merged to `main` in correct order
+- [ ] `npm run build` succeeds on `main` after all merges
+- [ ] App launches and runs correctly
+- [ ] LICENSE file present at repo root
+- [ ] Google Docs settings shows waitlist (not sync UI)
+- [ ] Auto-update banner renders (test with mock)
+
+---
+
+## Phase 2 — Code Signing + Release Pipeline (after Phase 1 + 0A certs)
+
+### 2A: Signing, Notarization, CI Release (issues #26, #247)
+
+**Status:** Not started. No `release.yml` workflow exists. Current `entitlements.mac.plist` only has `allow-unsigned-executable-memory`. `electron-builder.yml` has `identity: null`.
+
+- [ ] Create branch `issue-247-signing-release-pipeline` in worktree
+- [ ] Update `electron-builder.yml`:
+  ```yaml
+  mac:
+    identity: "Developer ID Application"
+    notarize:
+      teamId: ${APPLE_TEAM_ID}
+    hardenedRuntime: true
+    entitlements: build/entitlements.mac.plist
+    entitlementsInherit: build/entitlements.mac.plist
+    target: [dmg, zip, dir]
+  ```
+- [ ] Extend `build/entitlements.mac.plist` (currently only has `allow-unsigned-executable-memory`):
+  - `com.apple.security.cs.allow-unsigned-executable-memory` ✅ (exists)
+  - `com.apple.security.network.client` (Anthropic API, reMarkable, Google)
+  - `com.apple.security.network.server` (MCP HTTP on 9877 — DMG only, NOT MAS)
+  - `com.apple.security.files.user-selected.read-write` (file dialogs)
+- [ ] Create/extend `.github/workflows/release.yml`:
+  - Trigger on `v*` tags
+  - macOS runner with signing env vars
+  - `npm run build:mac` step
+  - Notarization step (`notarytool`)
+  - Publish to GitHub Releases (DMG + ZIP)
+- [ ] Test: `npm run build:mac` produces DMG locally
+- [ ] Test: `spctl --assess dist/mac-arm64/Prose.app` passes (requires cert)
+- [ ] PR created and merged
+- [ ] Test: CI release workflow creates GitHub Release on tag push
+
+---
+
+## Phase 3 — MAS Submission Build (after Phase 2)
+
+### 3A: MAS Entitlements + Sandbox Adaptations (issue #138)
+
+**Status:** Not started. No MAS entitlements files exist. No `__IS_MAS_BUILD__` references in source code yet (will be added by Phase 1B).
+
+- [ ] Create branch `issue-138-mas-submission` in worktree
+- [ ] Create `build/entitlements.mas.plist`:
+  - `com.apple.security.app-sandbox` (required for MAS)
+  - `com.apple.security.cs.allow-unsigned-executable-memory` (V8 JIT)
+  - `com.apple.security.network.client` (API calls)
+  - `com.apple.security.files.user-selected.read-write` (file dialogs)
+  - `com.apple.security.files.bookmarks.app-scope` (remember file locations)
+  - **NO** `com.apple.security.network.server`
+- [ ] Create `build/entitlements.mas.inherit.plist`:
+  - `com.apple.security.app-sandbox`
+  - `com.apple.security.inherit`
+- [ ] Add MAS stanza to `electron-builder.yml`:
+  ```yaml
+  mas:
+    category: public.app-category.productivity
+    entitlements: build/entitlements.mas.plist
+    entitlementsInherit: build/entitlements.mas.inherit.plist
+    target: [mas]
+  ```
+- [ ] Gate HTTP MCP server in `src/main/index.ts`:
+  ```typescript
+  if (!__IS_MAS_BUILD__) {
+    mcpServer.setAuthToken(mcpAuthToken)
+    await mcpServer.start()
+  }
+  ```
+- [ ] Gate MCP install handler in `src/main/ipc.ts`:
+  ```typescript
+  if (__IS_MAS_BUILD__) {
+    return { success: false, error: 'MCP auto-install is only available in the direct download version' }
+  }
+  ```
+- [ ] Add `"build:mas": "MAS_BUILD=1 npm run build && electron-builder --mac mas"` to `package.json`
+- [ ] Bump version to `1.0.0` in `package.json`
+- [ ] Test: `npm run build:mas` produces MAS package
+- [ ] Test: HTTP MCP server does NOT start in MAS build
+- [ ] Test: Unix socket MCP still works in MAS build
+- [ ] Test: MCP install handler returns error in MAS build
+- [ ] Test: File open/save works through sandbox
+- [ ] PR created and merged
+
+---
+
+## Phase 4 — App Store Submission (Human)
+
+### 4A: Upload and Submit
+
+- [ ] Build MAS package: `npm run build:mas` (or CI tag push)
+- [ ] Upload via Transporter or `xcrun altool`
+- [ ] App Store Connect metadata:
+  - App name: Prose
+  - Subtitle: "AI-powered markdown editor"
+  - Description: Focus on BYOK, privacy, local-first
+  - Keywords: markdown, editor, AI, writing, anthropic, claude
+  - Category: Productivity
+  - Price: $0.99
+  - Privacy policy URL: (from 0B)
+  - Support URL
+- [ ] Screenshots (5 required at 2560×1600):
+  - [ ] Editor with document open (light or dark theme)
+  - [ ] AI chat panel in action
+  - [ ] File explorer sidebar
+  - [ ] Settings / API key configuration
+  - [ ] Review mode (side-by-side diff)
+- [ ] Review notes for Apple:
+  - Explain `allow-unsigned-executable-memory` (Electron/Chromium V8 JIT — standard for all Electron apps)
+  - Explain `network.client` (user-initiated API calls to Anthropic only)
+  - Note: app requires user's own Anthropic API key (BYOK model)
+- [ ] Submit for App Review (expect 1–3 business days)
+
+### 4B: Post-Approval
+
+- [ ] Make repo public (if not already done in Phase 1)
+- [ ] Create GitHub Release with v1.0.0 tag (triggers signed DMG pipeline)
+- [ ] Verify DMG auto-update works for existing alpha users
+- [ ] Announce launch
+
+---
+
+## Rollback Plan
+
+| Scenario | Action |
+|---|---|
+| MAS rejection | Fix cited issues, resubmit. DMG channel unaffected. |
+| Signed DMG crashes | Revert to unsigned alpha DMG via GitHub Release rollback |
+| Auto-update breaks | Users can manually download from GitHub Releases |
+| Sandbox breaks file access | Emergency patch to entitlements, resubmit |
+
+---
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| MAS rejection on first submission | 3–5 day delay | Document every entitlement in review notes. Pre-test with `altool --validate-app` |
+| HTTP MCP + MAS sandbox | Build rejection | Disabled in MAS builds; Unix socket only |
+| `allow-unsigned-executable-memory` in MAS | Possible concern | Standard for Electron/Chromium apps; include explanation in review notes |
+| Auto-update needs public repo | Blocks direct-download updates | Repo goes public in Phase 1 |
+| Google OAuth verification (deferred) | v1.1 delay | Not a launch blocker — replaced with waitlist UI |
+| Sentry opt-in disclosure | MAS privacy review | Disclose in privacy policy or remove before submission |
+
+---
+
+## Critical File Map
+
+| File | Phase | Status |
+|---|---|---|
+| `LICENSE` | 1A | **Missing — needs creation** |
+| `package.json` | 1A, 1B, 3A | Exists (v0.1.0-alpha.4) |
+| `electron-builder.yml` | 1B, 2A, 3A | Exists (`identity: null`, no MAS stanza) |
+| `electron-vite.config.ts` | 1B | Exists (no `__IS_MAS_BUILD__` define) |
+| `src/main/updater.ts` | 1B | **On branch only** (issue-191) |
+| `src/renderer/components/layout/UpdateBanner.tsx` | 1B | **On branch only** (issue-191) |
+| `src/renderer/components/settings/GoogleDocsIntegration.tsx` | 1C | Exists (full sync UI) |
+| `src/main/ipc.ts` | 1C, 3A | Exists (13 google handlers, no MAS gates) |
+| `src/main/index.ts` | 3A | Exists (no MAS gates) |
+| `build/entitlements.mac.plist` | 2A | Exists (only `allow-unsigned-executable-memory`) |
+| `build/entitlements.mas.plist` | 3A | **Missing — needs creation** |
+| `build/entitlements.mas.inherit.plist` | 3A | **Missing — needs creation** |
+| `.github/workflows/release.yml` | 1B, 2A | **Missing — needs creation** |
+| `build/afterPack.js` | Exists | ✅ Fuses configured correctly |
+
+---
+
+## Sentry Decision (Pre-Launch)
+
+The app has opt-in Sentry error tracking (merged on `main`). Decide before MAS submission:
+
+- [ ] **Option A:** Keep Sentry, disclose in privacy policy as opt-in crash reporting
+- [ ] **Option B:** Remove Sentry before v1.0.0 to simplify MAS privacy review
+
+If keeping: update privacy policy to mention optional, opt-in crash reporting via Sentry. Apple may ask about it during review.

--- a/docs/launch/prose-1.0.0-launch-checklists.md
+++ b/docs/launch/prose-1.0.0-launch-checklists.md
@@ -1,0 +1,351 @@
+# Prose 1.0.0 Launch Checklists
+
+Comprehensive pre-launch checklists covering Mac App Store submission, Electron production release, BYOK security considerations, and open source readiness. Each section includes Prose-specific callouts where the dual-build (MAS + OSS), Sentry integration, and feature-flagged integrations (reMarkable, Google Docs) require special attention.
+
+---
+
+## 1. Mac App Store — First Submission
+
+### Apple Developer Account & App Store Connect
+
+- [ ] Enrolled in Apple Developer Program (annual fee, currently $99/yr)
+- [ ] Created App ID (Bundle ID) in Apple Developer portal — must match `MAS_BUILD=1` bundle ID
+- [ ] Created app record in App Store Connect (name, bundle ID, SKU, primary language)
+- [ ] Selected app category (Productivity? Developer Tools?)
+- [ ] Set pricing and availability (free with BYOK, or paid?)
+- [ ] Chosen countries/regions for distribution
+- [ ] Accepted any required Apple agreements (paid apps agreement, etc.)
+
+### Certificates & Provisioning
+
+- [ ] Generated **Mac App Distribution** certificate (for signing the MAS build)
+- [ ] Generated **Mac Installer Distribution** certificate (for signing the .pkg)
+- [ ] Created Mac App Store **provisioning profile** tied to your App ID
+- [ ] Verified electron-builder is configured to use MAS-specific certs (not Developer ID)
+- [ ] Confirmed the provisioning profile is embedded in the .app bundle
+
+### Code Signing & Entitlements
+
+- [ ] Main app has `com.apple.security.app-sandbox` set to `true`
+- [ ] All helper apps (GPU, Renderer, Plugin) have sandbox entitlement with `com.apple.security.inherit` set to `true`
+- [ ] Entitlements plist covers all required capabilities:
+  - [ ] `com.apple.security.network.client` (outbound network for API calls)
+  - [ ] `com.apple.security.files.user-selected.read-write` (file open/save dialogs)
+  - [ ] `com.apple.security.files.bookmarks.app-scope` (if persisting file access across launches)
+- [ ] No overly broad entitlements (absolute path read-write will be rejected)
+- [ ] Verified that `npm run build:mas` signs all binaries (check with `codesign --verify --deep --strict`)
+- [ ] Tested the MAS build actually launches under sandbox (don't just build — run it)
+
+### Sentry Compatibility (MAS-Specific)
+
+- [ ] **Native crash reporting is auto-disabled in MAS builds** — Sentry cannot collect Minidumps under App Store sandbox. Verified this doesn't cause errors or unexpected behavior.
+- [ ] JavaScript-level error reporting still works in MAS sandbox (confirm in testing)
+- [ ] Sentry DSN is not exposed in a way that violates App Store data collection rules
+- [ ] Sentry is opt-in only (your current Settings toggle) — this is required for App Store compliance
+
+### Privacy & Data Collection
+
+- [ ] **Privacy Nutrition Labels** completed in App Store Connect:
+  - [ ] Sentry crash data (if opted in): "Crash Data" under Diagnostics, linked to user? Probably "Not Linked to User" if you're not associating with user identity
+  - [ ] API key storage: "Not Collected" if keys stay on-device (Keychain/safeStorage)
+  - [ ] Document content: "Not Collected" if documents never leave the device (LLM calls go direct from user's device to Anthropic with their own key)
+  - [ ] Usage data / analytics: declare or confirm you collect none
+- [ ] **Privacy manifests** for any third-party SDKs (Apple requires these as of 2024+)
+- [ ] Privacy policy URL added in App Store Connect metadata
+- [ ] Privacy policy accessible within the app itself
+- [ ] Privacy policy accurately describes: Sentry opt-in crash reporting, BYOK model (keys stored locally), no server-side data collection
+
+### Export Compliance (Encryption)
+
+- [ ] Determined encryption classification:
+  - If app only uses HTTPS (via Node/Chromium built-in TLS) and OS-level encryption (safeStorage/Keychain), this qualifies as **exempt encryption**
+  - [ ] Marked as "Yes, but exempt" in App Store Connect export compliance
+- [ ] If using any non-exempt encryption: file for CCATS with BIS (unlikely for Prose)
+- [ ] Set `ITSAppUsesNonExemptEncryption` to `false` in Info.plist to skip the compliance prompt on each submission (if exempt)
+
+### App Store Review Readiness
+
+- [ ] Screenshots at required resolutions (at least 1280x800 and 2560x1600 for Retina)
+- [ ] App description, keywords, subtitle, and promotional text filled in
+- [ ] Support URL provided
+- [ ] "What's New" text for version 1.0.0
+- [ ] App icon as `.icns` with full icon set AND an **Asset Catalog** (`.car` file) — electron-builder may not generate this automatically; this is a known gotcha
+- [ ] **Demo/test account not needed** (BYOK means reviewer needs an Anthropic API key — provide one in review notes, or clearly explain the BYOK model and what the app does without a key)
+- [ ] Review notes explaining: what the app does, that it's BYOK (user provides their own Anthropic API key), and that reMarkable/Google Docs features are intentionally hidden behind feature flags for a future release
+- [ ] Tested on both Apple Silicon and Intel Macs (or confirmed Universal Binary)
+- [ ] No references to "beta", "test", or placeholder content in the UI
+- [ ] No broken links or dead-end screens
+- [ ] App doesn't crash on first launch with no settings configured
+
+### Feature Flags (MAS-Specific)
+
+- [ ] reMarkable integration is fully hidden when `featureFlags.remarkable` is `false` (default)
+- [ ] Google Docs integration is fully hidden when `featureFlags.googleDocs` is `false` (default)
+- [ ] No traces of these features in UI, menus, settings, or help text when flags are off
+- [ ] Feature-flagged code doesn't attempt network calls, OAuth flows, or filesystem access when disabled
+- [ ] App Review won't stumble onto these features accidentally
+
+### Common Rejection Reasons to Pre-Check
+
+- [ ] No private API usage (Electron's MAS build should handle this, but verify)
+- [ ] No loading remote code that changes app functionality (LLM responses that drive UI actions could be scrutinized — ensure tools/actions are clearly user-initiated)
+- [ ] App provides meaningful functionality without an API key (users should be able to write, edit, and manage documents even without LLM features)
+- [ ] No misleading App Store metadata (don't promise features that are behind flags)
+- [ ] Minimum functionality guideline: app must not be a thin wrapper around a website
+
+### Auto-Update
+
+- [ ] MAS builds use Apple's built-in update mechanism (not Squirrel/electron-updater) — verify no auto-update code runs in MAS builds
+- [ ] `autoUpdater` module is disabled or not imported in MAS builds
+
+---
+
+## 2. Electron App — Production Release
+
+### Build & Distribution
+
+- [ ] Production builds tested on all target platforms (macOS ARM, macOS Intel, Windows, Linux)
+- [ ] **macOS (direct distribution)**: Signed with Developer ID certificate and notarized with Apple
+- [ ] **macOS (MAS)**: Separate build path via `npm run build:mas` with MAS-specific signing
+- [ ] **Windows**: Code-signed with EV or Azure Trusted Signing certificate (unsigned = SmartScreen warnings that will tank adoption)
+- [ ] **Linux**: AppImage, .deb, and/or Snap packages as appropriate
+- [ ] Verified the release workflow (`release.yml`) produces correct artifacts for each platform
+- [ ] Version number is `1.0.0` everywhere: `package.json`, About dialog, any hardcoded strings
+
+### Code Signing & Notarization (Non-MAS macOS)
+
+- [ ] Developer ID Application certificate active and valid
+- [ ] Developer ID Installer certificate (if distributing .pkg)
+- [ ] Notarization succeeds (test with `xcrun notarytool` or check build logs)
+- [ ] Stapled notarization ticket to the .app and .dmg
+- [ ] Gatekeeper test: download the .dmg from the internet, open it, verify no scary warnings
+
+### Hardened Runtime
+
+- [ ] Hardened runtime enabled (required for notarization)
+- [ ] Necessary exceptions declared (JIT for V8, unsigned memory access if needed)
+- [ ] App still functions correctly with hardened runtime enabled
+
+### Auto-Update (Direct Distribution)
+
+- [ ] Auto-update mechanism tested end-to-end (Squirrel.Mac or electron-updater)
+- [ ] Update feed URL configured and serving correct JSON format
+- [ ] Fallback behavior if update server is unreachable (app still works, no crash)
+- [ ] Code signature validation of downloaded updates
+- [ ] Update channel strategy decided (stable, beta, etc.)
+
+### Electron-Specific Security
+
+- [ ] `contextIsolation: true` (already in your security rules)
+- [ ] `nodeIntegration: false` (already in your security rules)
+- [ ] `webSecurity` is not disabled in production
+- [ ] No `allowRunningInsecureContent`
+- [ ] CSP (Content Security Policy) headers configured for renderer
+- [ ] `shell.openExternal` validates URLs (already limited to http/https in your codebase)
+- [ ] Preload scripts expose minimal API surface
+- [ ] No `remote` module usage (deprecated and dangerous)
+
+### Performance & Stability
+
+- [ ] Cold start time acceptable (< 3 seconds to interactive on modern hardware)
+- [ ] Memory usage reasonable after extended use (no leaks from editor, chat, or stores)
+- [ ] Large document handling tested (50+ page documents)
+- [ ] Graceful behavior when Anthropic API is unreachable
+- [ ] LevelDB lock conflicts handled (your troubleshooting docs mention this)
+- [ ] IndexedDB schema migration tested (fresh install AND upgrade from any prior version)
+
+### Sentry Configuration (Production)
+
+- [ ] Production Sentry DSN is correct and receiving events
+- [ ] Source maps uploaded to Sentry for this release version (via `@sentry/vite-plugin`)
+- [ ] Release version tag in Sentry matches the app version
+- [ ] Verified Sentry is disabled by default (opt-in only)
+- [ ] Dev mode sends no events to production Sentry project
+- [ ] Sentry doesn't capture API keys, document content, or PII in breadcrumbs/context
+- [ ] Tested the opt-in/opt-out toggle works correctly in production builds
+
+---
+
+## 3. BYOK (Bring Your Own Key) App
+
+### Key Storage & Security
+
+- [ ] API keys stored via `safeStorage` / OS Keychain (already implemented via `credentialStore`)
+- [ ] Keys are never written to plaintext files, localStorage, or IndexedDB
+- [ ] If `safeStorage` is unavailable, keys are stripped and not saved (already in your security rules)
+- [ ] Keys never appear in log files, Sentry reports, console output, or crash dumps
+- [ ] Keys never leave the device — API calls go directly from main process to Anthropic (no proxy server)
+- [ ] Keys are not included in IPC messages between main and renderer (renderer never sees the raw key)
+
+### User Experience
+
+- [ ] Clear onboarding flow explaining: what an API key is, where to get one (link to Anthropic console), and that the key stays on their device
+- [ ] API key test/validation before saving (your `settings:testApiKey` IPC handler)
+- [ ] Clear error messages when: key is invalid, key has insufficient permissions, key has been revoked, rate limit hit, billing issue on user's Anthropic account
+- [ ] Easy way to update or remove the API key
+- [ ] App is fully functional for writing/editing without an API key (LLM features gracefully degrade)
+- [ ] No confusion about who is being billed — make it clear the user pays Anthropic directly
+
+### Transparency & Trust
+
+- [ ] Documentation or in-app explanation of the BYOK model
+- [ ] Privacy policy explicitly states: "Your API key is stored locally using your operating system's secure credential storage. It is never transmitted to our servers."
+- [ ] No telemetry or analytics that could inadvertently capture key material
+- [ ] If Sentry is enabled, verified that API keys are scrubbed from any error context
+- [ ] Open source codebase (see section 4) allows users to verify these claims
+
+### API Key Lifecycle
+
+- [ ] Key rotation: user can change their key at any time
+- [ ] Key deletion: user can remove their key, and it's actually purged from Keychain
+- [ ] Multiple keys: if supporting multiple providers in the future, architecture supports it (though 1.0.0 is Anthropic-only)
+- [ ] Session handling: what happens if the key becomes invalid mid-session? (graceful error, not crash)
+
+### Cost Transparency
+
+- [ ] Users understand that LLM usage incurs costs on their Anthropic account
+- [ ] Consider showing token usage or estimated cost per interaction (nice-to-have, not blocking)
+- [ ] Link to Anthropic's pricing page in settings or onboarding
+- [ ] Streaming responses can be aborted to avoid unnecessary token usage (your `llm:stream:abort` handler)
+
+### Legal Considerations
+
+- [ ] Terms of service cover: you provide the software, user provides the API key, you are not responsible for their API usage costs
+- [ ] No guarantees about API availability (Anthropic's uptime is not your SLA)
+- [ ] Compliance with Anthropic's usage policies (your app doesn't enable prohibited uses)
+- [ ] BYOK model means you likely don't need a BAA or data processing agreement for user content (it goes directly to Anthropic under the user's own relationship)
+
+---
+
+## 4. Open Source Project Launch
+
+### Repository Hygiene
+
+- [ ] **Secrets scan the entire git history** — use `trufflehog`, `gitleaks`, or `detect-secrets` to find any accidentally committed API keys, tokens, passwords, or credentials across all branches and all time
+- [ ] Sentry DSN in source: acceptable (DSNs are designed to be public — they only allow sending events, not reading data). But confirm it's a separate project from any internal/private Sentry project
+- [ ] No hardcoded test API keys, internal URLs, or developer-specific paths
+- [ ] `.gitignore` covers: `.env`, `*.pem`, credentials files, OS files (`.DS_Store`), build output
+- [ ] No proprietary assets (fonts, icons, images) that aren't properly licensed for redistribution
+- [ ] IBM Plex Mono font: SIL Open Font License — fine for open source distribution
+
+### License
+
+- [ ] License chosen and `LICENSE` file in repo root
+- [ ] Recommendation: **Apache 2.0** — provides explicit patent grant (protects contributors), requires modification notices, well-understood by enterprises. Better than MIT for a full application (as opposed to a library)
+- [ ] All source files have license headers (or rely on root LICENSE file — either convention is fine, be consistent)
+- [ ] Third-party license compliance: all dependencies' licenses are compatible (run `license-checker` or `licensee` against `node_modules`)
+- [ ] No GPL-licensed dependencies that would force copyleft on the entire project (or if so, acknowledge and comply)
+
+### Documentation
+
+- [ ] `README.md` covers: what Prose is, screenshots/demo, installation instructions, how to build from source, BYOK explanation, link to MAS listing
+- [ ] `CONTRIBUTING.md` with: how to set up the dev environment, coding standards, PR process, branch naming convention, issue labeling
+- [ ] `CODE_OF_CONDUCT.md` (Contributor Covenant is the standard)
+- [ ] `SECURITY.md` with: how to report vulnerabilities (email, not public issue), response time expectations, scope of what's considered a vulnerability
+- [ ] `CHANGELOG.md` for 1.0.0 (or use GitHub Releases for changelog)
+- [ ] Existing `docs/` folder: review for internal-only content that shouldn't be public
+
+### Repository Setup
+
+- [ ] Branch protection on `main`: require PR reviews, require status checks, no force push
+- [ ] Issue templates: bug report, feature request (with labels)
+- [ ] PR template with checklist
+- [ ] GitHub Actions workflows reviewed: no secrets exposed in logs, workflows don't run untrusted code from forks without approval
+- [ ] `CODEOWNERS` file if you want automatic review assignment
+- [ ] GitHub Discussions enabled (for community Q&A vs. issues for bugs)
+- [ ] Labels organized: `bug`, `enhancement`, `good first issue`, `help wanted`, `documentation`
+
+### CI/CD for Open Source
+
+- [ ] CI runs on PRs from forks (but with appropriate permissions — forks shouldn't have access to secrets)
+- [ ] `claude.yml` workflow: does it run on fork PRs? Does it expose your Anthropic API key? Review carefully.
+- [ ] Build workflow passes on a clean clone (no hidden dependencies on local state)
+- [ ] Artifact publishing: GitHub Releases with pre-built binaries for each platform
+
+### Security for Open Source
+
+- [ ] GitHub secret scanning enabled on the repository
+- [ ] Dependabot or Renovate configured for dependency updates
+- [ ] No internal infrastructure references (server URLs, deployment targets, private registries)
+- [ ] MAS-specific signing certificates and provisioning profiles are NOT in the repo (stored in CI secrets only)
+- [ ] `~/.prose/settings.json` path is documented but the file itself is in `.gitignore`
+- [ ] Sentry auth token is in CI environment, not in code
+
+### Community Readiness
+
+- [ ] At least two maintainers with admin access (bus factor > 1)
+- [ ] Decide on governance model: BDFL, small maintainer team, or open governance
+- [ ] Triage process defined: how quickly will you respond to issues? Set expectations in README
+- [ ] "Good first issue" labels on a few accessible issues to attract contributors
+- [ ] Decision on whether to accept external feature PRs or keep the roadmap closed
+- [ ] Communication channel chosen: GitHub Discussions, Discord, or similar
+
+### Dual-Build Considerations (MAS + OSS)
+
+- [ ] Build instructions clearly explain: OSS build (direct distribution, `npm run build:mac`) vs MAS build (`npm run build:mas` requires Apple Developer certs)
+- [ ] Contributors can build and run the app without Apple Developer Program membership
+- [ ] MAS-specific entitlements files are in the repo (they're not secret) but documented as MAS-only
+- [ ] Feature flags documented: contributors understand that reMarkable and Google Docs are gated for 1.0.0
+
+### Pre-Public Checklist
+
+- [ ] README doesn't reference private infrastructure, internal Slack channels, or non-public URLs
+- [ ] All TODO/FIXME/HACK comments reviewed — remove any that reference internal context
+- [ ] Git history doesn't contain embarrassing commit messages (this is less critical but worth a glance)
+- [ ] Verify the project builds and runs from a completely clean clone in a fresh environment (Docker or a fresh VM)
+
+---
+
+## Cross-Cutting Concerns
+
+### Sentry Across All Builds
+
+- [ ] MAS build: native crash reporting disabled (auto-handled by Sentry), JS error reporting works under sandbox
+- [ ] Direct distribution build: full Sentry functionality including native crashes
+- [ ] Open source: DSN is public-safe, but consider whether you want to receive crash reports from self-built versions (you probably do — more signal is better)
+- [ ] Privacy nutrition label accurately reflects Sentry's data collection when opt-in is enabled
+- [ ] Sentry `beforeSend` hook scrubs any PII, API keys, or document content from events
+
+### Feature Flags Across All Builds
+
+- [ ] Both MAS and direct builds respect the same feature flag defaults (`false` for reMarkable and Google Docs)
+- [ ] Feature-flagged UI is completely absent (not just disabled/grayed out) when flags are off
+- [ ] Open source contributors can enable flags locally for development and testing
+- [ ] Documentation explains the flag system and what each flag controls
+
+### Legal Across All Distribution Channels
+
+- [ ] Privacy policy (single document covering all distribution methods)
+- [ ] Terms of service / EULA (MAS may use Apple's Standard License Agreement or your own)
+- [ ] Third-party notices / open source attribution page (in-app or in docs)
+- [ ] Anthropic trademark usage: verify you're allowed to mention "Claude" and "Anthropic" in your app and marketing (check Anthropic's brand guidelines)
+
+---
+
+## Launch Day
+
+- [ ] MAS build uploaded via Transporter and submitted for review (allow 1–7 days for first review)
+- [ ] Direct distribution .dmg available on GitHub Releases
+- [ ] Repository set to public
+- [ ] Announce on relevant channels (Hacker News, Twitter/X, relevant communities)
+- [ ] Monitor Sentry for first-hour crash reports
+- [ ] Monitor GitHub Issues for first community reports
+- [ ] Have a hotfix plan ready (how quickly can you push a 1.0.1?)
+
+---
+
+## Sources
+
+- [Electron Mac App Store Submission Guide](https://www.electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide)
+- [Electron Code Signing](https://www.electronjs.org/docs/latest/tutorial/code-signing)
+- [Apple: Complying with Encryption Export Regulations](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations)
+- [Apple: App Privacy Details](https://developer.apple.com/app-store/app-privacy-details/)
+- [Apple: App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [Sentry Electron Native Crash Reporting](https://docs.sentry.io/platforms/javascript/guides/electron/features/native-crash-reporting/)
+- [GitHub Open Source Guides: Starting a Project](https://opensource.guide/starting-a-project/)
+- [Linux Foundation: Starting an Open Source Project](https://www.linuxfoundation.org/resources/open-source-guides/starting-an-open-source-project)
+- [TruffleHog — Git Secret Scanner](https://github.com/trufflesecurity/trufflehog)
+- [BYOK Tools Guide (Rilna)](https://www.rilna.net/blog/bring-your-own-api-key-byok-tools-guide-examples)
+- [Apache 2.0 License Overview (FOSSA)](https://fossa.com/blog/open-source-licenses-101-apache-license-2-0/)
+- [Electron Auto-Update Documentation](https://www.electronjs.org/docs/latest/tutorial/updates)
+- [DoltHub: How to Submit an Electron App to MAS](https://www.dolthub.com/blog/2024-10-02-how-to-submit-an-electron-app-to-mac-app-store/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -210,7 +211,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -907,6 +907,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -1144,68 +1145,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2241,6 +2180,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -2253,6 +2193,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2261,6 +2202,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -2323,7 +2265,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2345,7 +2286,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
       "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -2358,7 +2298,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2782,7 +2721,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
       "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2799,7 +2737,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
       "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/resources": "2.6.0",
@@ -2817,7 +2754,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3971,6 +3907,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3984,6 +3921,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3997,6 +3935,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4010,6 +3949,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4023,6 +3963,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4036,6 +3977,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4049,6 +3991,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4062,6 +4005,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4075,6 +4019,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4088,6 +4033,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4101,6 +4047,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4114,6 +4061,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4127,6 +4075,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4140,6 +4089,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4153,6 +4103,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4166,6 +4117,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4179,6 +4131,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4192,6 +4145,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4205,6 +4159,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4218,6 +4173,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4231,6 +4187,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4244,6 +4201,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4257,6 +4215,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4270,6 +4229,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4283,6 +4243,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4798,6 +4759,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -4814,6 +4776,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -4825,7 +4788,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.1.tgz",
       "integrity": "sha512-nkerkl8syHj44ZzAB7oA2GPmmZINKBKCa79FuNvmGJrJ4qyZwlkDzszud23YteFZEytbc87kVd/fP76ROS6sLg==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5238,7 +5200,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.1.tgz",
       "integrity": "sha512-ijKo3+kIjALthYsnBmkRXAuw2Tswd9gd7BUR5OMfIcjGp8v576vKxOxrRfuYiUM78GPt//P0sVc1WV82H5N0PQ==",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -5363,6 +5324,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -5392,7 +5354,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -5407,7 +5370,8 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
@@ -5419,6 +5383,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5511,14 +5476,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "devOptional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5528,8 +5492,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5538,6 +5501,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5575,6 +5539,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -5689,7 +5654,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5748,7 +5712,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5838,12 +5801,14 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6131,7 +6096,8 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6288,6 +6254,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -6352,6 +6319,7 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
       "optional": true
     },
     "node_modules/brace-expansion": {
@@ -6370,6 +6338,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -6395,7 +6364,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6439,6 +6407,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -6607,6 +6576,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -6615,6 +6585,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -6678,6 +6649,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -6722,6 +6694,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -6745,6 +6718,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -6875,6 +6849,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -7074,14 +7049,6 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7099,6 +7066,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -7110,7 +7078,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7132,6 +7100,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -7146,6 +7115,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7170,6 +7140,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -7194,6 +7165,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -7238,6 +7210,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
       "optional": true
     },
     "node_modules/detect-node-es": {
@@ -7248,7 +7221,8 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
@@ -7264,7 +7238,8 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/dmg-builder": {
       "version": "26.8.1",
@@ -7272,7 +7247,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -7445,9 +7419,9 @@
       "version": "40.8.5",
       "resolved": "https://registry.npmjs.org/electron/-/electron-40.8.5.tgz",
       "integrity": "sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -7484,19 +7458,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
-      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
-        "electron-winstaller": "5.4.0"
       }
     },
     "node_modules/electron-builder/node_modules/fs-extra": {
@@ -7697,46 +7658,11 @@
         }
       }
     },
-    "node_modules/electron-winstaller": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
-      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/asar": "^3.2.1",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.21",
-        "temp": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@electron/windows-sign": "^1.1.2"
-      }
-    },
-    "node_modules/electron-winstaller/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/electron/node_modules/@types/node": {
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -7746,6 +7672,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -7764,10 +7691,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -7787,6 +7726,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7843,6 +7783,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/esbuild": {
@@ -8075,6 +8016,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -8110,6 +8052,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -8125,6 +8068,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8159,6 +8103,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -8167,6 +8112,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -8185,6 +8131,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -8359,6 +8306,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -8392,6 +8340,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -8517,6 +8466,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8553,6 +8503,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -8564,6 +8515,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -8581,6 +8533,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -8593,6 +8546,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -8695,6 +8649,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -8834,7 +8789,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8875,7 +8829,8 @@
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -8915,6 +8870,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -8965,7 +8921,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9062,6 +9018,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -9073,6 +9030,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -9095,6 +9053,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9113,6 +9072,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -9134,6 +9094,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -9231,7 +9192,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "peer": true,
+      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9285,7 +9246,8 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -9328,6 +9290,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/json5": {
@@ -9345,6 +9308,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9436,6 +9400,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -9467,6 +9432,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -9477,7 +9443,8 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
@@ -9548,6 +9515,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -9559,6 +9527,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9648,6 +9617,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
@@ -9694,6 +9664,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -9702,6 +9673,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -9756,6 +9728,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -9937,19 +9910,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -9980,6 +9940,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -9990,6 +9951,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10196,6 +10158,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10204,6 +10167,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10223,6 +10187,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10316,6 +10281,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10415,7 +10381,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -10469,7 +10436,8 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -10511,6 +10479,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10523,6 +10492,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10531,6 +10501,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10610,6 +10581,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10624,7 +10596,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10638,6 +10609,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -10654,6 +10626,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10678,6 +10651,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10719,6 +10693,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10743,6 +10718,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10754,7 +10730,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -10793,34 +10770,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/proc-log": {
@@ -10974,7 +10923,6 @@
       "version": "1.25.4",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11001,7 +10949,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11046,7 +10993,6 @@
       "version": "1.41.4",
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
       "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -11076,6 +11022,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -11118,6 +11065,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11137,6 +11085,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -11188,7 +11137,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11200,7 +11149,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11310,6 +11259,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -11333,6 +11283,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -11394,6 +11345,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -11412,12 +11364,14 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
     },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -11453,23 +11407,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/rmapi-js": {
@@ -11490,6 +11431,7 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -11507,8 +11449,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11573,6 +11515,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11638,6 +11581,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -11666,6 +11610,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
       "optional": true
     },
     "node_modules/send": {
@@ -11723,6 +11668,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
@@ -11975,6 +11921,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11994,6 +11941,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/ssri": {
@@ -12114,6 +12062,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -12135,6 +12084,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -12143,6 +12093,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.0"
       },
@@ -12167,6 +12118,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12187,7 +12139,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -12255,20 +12207,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/temp-file": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
@@ -12322,6 +12260,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -12330,6 +12269,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -12367,6 +12307,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -12382,6 +12323,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -12398,8 +12340,8 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12472,6 +12414,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -12506,7 +12449,8 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "node_modules/tsconfck": {
       "version": "3.1.6",
@@ -12546,6 +12490,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -12598,7 +12543,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12647,6 +12591,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -12810,7 +12755,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13407,7 +13351,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13575,6 +13518,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -13596,7 +13540,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -907,7 +906,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -1145,6 +1143,72 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2180,7 +2244,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -2193,7 +2256,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2202,7 +2264,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -3907,7 +3968,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3921,7 +3981,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3935,7 +3994,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3949,7 +4007,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3963,7 +4020,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3977,7 +4033,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3991,7 +4046,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4005,7 +4059,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4019,7 +4072,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4033,7 +4085,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4047,7 +4098,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4061,7 +4111,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4075,7 +4124,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4089,7 +4137,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4103,7 +4150,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4117,7 +4163,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4131,7 +4176,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4145,7 +4189,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4159,7 +4202,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4173,7 +4215,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4187,7 +4228,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,7 +4241,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4215,7 +4254,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4229,7 +4267,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4243,7 +4280,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4759,7 +4795,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -4776,7 +4811,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dev": true,
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -5324,7 +5358,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -5354,8 +5387,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -5370,8 +5402,7 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
@@ -5383,7 +5414,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5476,13 +5506,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5492,7 +5522,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5501,7 +5531,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5539,7 +5568,6 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -5801,14 +5829,12 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6096,8 +6122,7 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6254,7 +6279,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -6319,7 +6343,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
       "optional": true
     },
     "node_modules/brace-expansion": {
@@ -6338,7 +6361,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -6407,7 +6429,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -6576,7 +6597,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -6585,7 +6605,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dev": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -6649,7 +6668,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -6694,7 +6712,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -6718,7 +6735,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -6849,7 +6865,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -7049,6 +7064,15 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7066,7 +7090,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -7078,7 +7101,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7100,7 +7123,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -7115,7 +7137,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7140,7 +7161,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -7165,7 +7185,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -7210,7 +7229,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
       "optional": true
     },
     "node_modules/detect-node-es": {
@@ -7221,8 +7239,7 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
@@ -7238,8 +7255,7 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/dmg-builder": {
       "version": "26.8.1",
@@ -7419,7 +7435,6 @@
       "version": "40.8.5",
       "resolved": "https://registry.npmjs.org/electron/-/electron-40.8.5.tgz",
       "integrity": "sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -7458,6 +7473,19 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "electron-winstaller": "5.4.0"
       }
     },
     "node_modules/electron-builder/node_modules/fs-extra": {
@@ -7658,11 +7686,48 @@
         }
       }
     },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/electron/node_modules/@types/node": {
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -7672,7 +7737,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -7695,7 +7759,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7706,7 +7769,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -7726,7 +7788,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7783,7 +7844,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/esbuild": {
@@ -8016,7 +8076,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -8052,7 +8111,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -8068,7 +8126,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8103,7 +8160,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -8112,7 +8168,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -8131,7 +8186,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -8306,7 +8360,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -8340,7 +8393,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -8466,7 +8518,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8503,7 +8554,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -8515,7 +8565,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -8533,7 +8582,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -8546,7 +8594,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -8649,7 +8696,6 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -8829,8 +8875,7 @@
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -8870,7 +8915,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -8921,7 +8965,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9018,7 +9062,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -9030,7 +9073,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -9053,7 +9095,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9072,7 +9113,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -9094,7 +9134,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -9192,7 +9231,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9246,8 +9284,7 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -9290,7 +9327,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "optional": true
     },
     "node_modules/json5": {
@@ -9308,7 +9344,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9400,7 +9435,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -9432,7 +9466,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -9443,8 +9476,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
@@ -9515,7 +9547,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -9527,7 +9558,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9617,7 +9647,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
@@ -9664,7 +9693,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -9673,7 +9701,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -9728,7 +9755,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -9910,6 +9936,20 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -9940,7 +9980,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -9951,7 +9990,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10158,7 +10196,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10167,7 +10204,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10187,7 +10223,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10281,7 +10316,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10381,8 +10415,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -10436,8 +10469,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -10479,7 +10511,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10492,7 +10523,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10501,7 +10531,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10581,7 +10610,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10609,7 +10637,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -10626,7 +10653,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10651,7 +10677,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10693,7 +10718,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10718,7 +10742,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10730,8 +10753,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -10770,6 +10792,36 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/proc-log": {
@@ -11022,7 +11074,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -11065,7 +11116,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11085,7 +11135,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -11137,7 +11186,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11149,7 +11197,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11259,7 +11306,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -11283,7 +11329,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -11345,7 +11390,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -11364,14 +11408,12 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dev": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -11407,10 +11449,24 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/rmapi-js": {
@@ -11431,7 +11487,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -11449,7 +11504,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -11515,7 +11569,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11581,7 +11634,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -11610,7 +11662,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
       "optional": true
     },
     "node_modules/send": {
@@ -11668,7 +11719,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
@@ -11921,7 +11971,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11941,7 +11990,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
       "optional": true
     },
     "node_modules/ssri": {
@@ -12062,7 +12110,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -12084,7 +12131,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -12093,7 +12139,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.1.0"
       },
@@ -12118,7 +12163,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12139,7 +12183,6 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -12207,6 +12250,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/temp-file": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
@@ -12260,7 +12318,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -12269,7 +12326,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -12307,7 +12363,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -12323,7 +12378,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -12340,7 +12394,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12414,7 +12467,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -12449,8 +12501,7 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/tsconfck": {
       "version": "3.1.6",
@@ -12490,7 +12541,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -12591,7 +12641,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -13518,7 +13567,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"


### PR DESCRIPTION
Cleans up long-drifting untracked files and adds a rule to CLAUDE.md so they stop accumulating.

## Changes

**Gitignore:**
- `.zed/` (parallel to existing `.vscode/` / `.idea/`)
- `.skills/` and `*.plugin` — Claude Cowork per-session artifacts

**Docs (newly committed as historical record):**
- `docs/audits/agentic-documentation-audit.md`
- `docs/audits/documentation-audit-2026-03-14.md`
- `docs/issues/327/self-healing-docs-proposal.md`
- `docs/launch/deploy-checklist-launch.md` (moved from repo root)
- `docs/launch/prose-1.0.0-launch-checklists.md` (moved from repo root)

**Deleted:**
- `index.html` — standalone landing-page prototype, belongs in a separate marketing repo

**CLAUDE.md:**
- New "Working Tree Hygiene" section mapping each category of untracked file to its destination. Distinguishes `.claude/` (committed) from Cowork outputs (gitignored).

**Deps:**
- `package-lock.json` sync from the earlier `npm install` that resolved missing `@tiptap/extension-task-list`.

## Why

Every session we'd open `git status` and find the same ~8 untracked files drifting — audit docs from March, launch checklists, plus Cowork artifacts. The hygiene section in CLAUDE.md makes the handling explicit so this doesn't keep happening.

## Test plan

- [ ] `git status` on this branch shows a clean working tree
- [ ] `.skills/`, `.zed/`, `*.plugin` no longer appear in `git status`
- [ ] Historical docs are accessible at their new `docs/` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)