### PR TITLE
fix(ui): align EmptyState shortcut labels with real bindings

### DIFF
--- a/src/renderer/components/layout/EmptyState.tsx
+++ b/src/renderer/components/layout/EmptyState.tsx
@@ -32,12 +32,12 @@ export function EmptyState() {
           <p className="mb-2 font-medium">Keyboard shortcuts:</p>
           <div className="space-y-1">
             <p>
-              <kbd className="rounded bg-muted px-1.5 py-0.5">⌘N</kbd> New &nbsp;
+              <kbd className="rounded bg-muted px-1.5 py-0.5">⌘T</kbd> New &nbsp;
               <kbd className="rounded bg-muted px-1.5 py-0.5">⌘O</kbd> Open &nbsp;
               <kbd className="rounded bg-muted px-1.5 py-0.5">⌘S</kbd> Save
             </p>
             <p>
-              <kbd className="rounded bg-muted px-1.5 py-0.5">⌘\</kbd> Chat &nbsp;
+              <kbd className="rounded bg-muted px-1.5 py-0.5">⇧⌘L</kbd> Chat &nbsp;
               <kbd className="rounded bg-muted px-1.5 py-0.5">⇧⌘H</kbd> Files &nbsp;
               <kbd className="rounded bg-muted px-1.5 py-0.5">F1</kbd> All shortcuts
             </p>


### PR DESCRIPTION
## Problem

The "Keyboard shortcuts:" panel on the empty-state "Start Writing" screen advertised two stale/wrong labels:

1. **`⌘\` Chat** — no such binding exists in \`src/main/menu.ts\` or anywhere in the renderer. Pressing ⌘\\ does nothing.
2. **`⌘N` New** — works (there's a renderer-level handler at \`Editor.tsx:491\`), but it disagrees with both the canonical File menu ("New Tab" → ⌘T at \`menu.ts:93\`) and the authoritative \`KeyboardShortcutsDialog\` ("New tab" → ⌘T at \`KeyboardShortcutsDialog.tsx:32\`).

## Fix

- \`⌘\` → \`⇧⌘L\` (matches \`Toggle Chat Panel\` at \`menu.ts:258\`)
- \`⌘N\` → \`⌘T\` (matches \`New Tab\` at \`menu.ts:93\`)

## Test plan

- [ ] Launch app, close all tabs to reach EmptyState
- [ ] Verify the keyboard-shortcut strip shows: \`⌘T New | ⌘O Open | ⌘S Save\` / \`⇧⌘L Chat | ⇧⌘H Files | F1 All shortcuts\`
- [ ] Press each to confirm they perform their labeled action

🤖 Generated with [Claude Code](https://claude.com/claude-code)