### PR TITLE
chore(build): bump MAS buildVersion 19 -> 20

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "19"
+buildVersion: "20"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
Bumps MAS \`buildVersion\` for the TestFlight resubmission. Rolls up menu fix (#420), About dialog fix (#423), and EmptyState shortcut label fix (#424) into Build 20, which supersedes the already-uploaded Build 19.

Refs: App Store submission \`c3ddd1bf-4034-417d-b492-58d5e09cd598\` (repeat Guideline 4 rejection, April 13 2026)

## Test plan

- [ ] \`npm run build:mas\` succeeds
- [ ] CFBundleVersion in packaged \`.app\` reads \`20\`
- [ ] \`xcrun altool\` upload to App Store Connect succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)