### PR TITLE
fix(mcp): resolve full node path for Claude Desktop install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./out/main/index.js",
   "scripts": {
-    "dev": "npm run build:env && npm run build:buildinfo && npm run build:preload && electron-vite dev",
+    "dev": "npm run build:env && npm run build:buildinfo && npm run build:mcp-stdio && npm run build:preload && electron-vite dev",
     "dev:kill": "kill $(cat .dev.pid 2>/dev/null) 2>/dev/null || true; lsof -ti:9222 | xargs kill -9 2>/dev/null || true; lsof -ti:5173 | xargs kill -9 2>/dev/null || true",
     "dev:restart": "npm run dev:kill && sleep 2 && npm run dev",
     "build:env": "node -e \"require('fs').writeFileSync('src/main/env.ts', '// Auto-generated — do not edit\\nexport const IS_MAS_BUILD = ' + (process.env.MAS_BUILD === '1') + '\\n')\"",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1346,9 +1346,19 @@ export function setupIpcHandlers(): void {
         delete config.mcpServers.prose
       }
 
+      // Resolve full path to node so Claude Desktop can find it
+      // (version managers like fnm/nvm aren't on Claude Desktop's default PATH)
+      let nodePath = 'node'
+      try {
+        const { execSync } = await import('child_process')
+        nodePath = execSync('which node', { encoding: 'utf-8' }).trim() || 'node'
+      } catch {
+        // Fall back to bare 'node' if which fails
+      }
+
       // Add Prose entry (capitalized key)
       config.mcpServers.Prose = {
-        command: 'node',
+        command: nodePath,
         args: [MCP_SERVER_PATH]
       }
 


### PR DESCRIPTION
## Summary

Resolve the absolute path of `node` (via `which node`) when writing Prose's entry into `claude_desktop_config.json`. Without this, version-managed node installs (fnm, nvm) aren't on Claude Desktop's default PATH and the MCP server fails to launch.

Also: add `build:mcp-stdio` to the `dev` script so the stdio bridge is always built after a clean checkout.

## Origin

This was originally drafted as commit `694a714` on `issue-369-remarkable-early-access` but was orthogonal to that branch's reMarkable feature work. Cherry-picked to its own branch so it can ship on its own merits without coupling to the reMarkable rollup. The original commit is dropped from `issue-369-remarkable-early-access` in a follow-up step.

Fixes #427

## Test plan

- [ ] Build succeeds (verified locally)
- [ ] Install MCP from Settings → Integrations → Claude Desktop with fnm/nvm-managed node; confirm `claude_desktop_config.json` contains the full node path, not bare `node`
- [ ] Restart Claude Desktop; confirm Prose MCP server connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)