### PR TITLE
fix(mas): silent menu actions, New Document, dock-click hardening, support URL (#429)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "20"
+buildVersion: "21"
 directories:
   buildResources: build
   output: dist

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -419,7 +419,10 @@ app.whenReady().then(async () => {
     if (windows.length === 0) {
       createWindow()
     } else {
-      windows[0].show()
+      const win = windows[0]
+      if (win.isMinimized()) win.restore()
+      win.show()
+      win.focus()
     }
   })
 })

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -6,12 +6,23 @@ import { loadRecentFiles, clearRecentFiles } from './recentFiles'
 // Store mainWindow reference so we can rebuild the menu after adding recent files
 let _menuWindow: BrowserWindow | null = null
 
-// Helper to safely send menu actions to the focused window
+// Helper to safely send menu actions to the focused window.
+// Falls back to _menuWindow when no window is focused (window hidden via
+// hide-on-close or minimized) — otherwise menu items would silently no-op,
+// which Apple cited in MAS rejection of build 20 (see issue #429).
 function sendMenuAction(action: string): void {
-  const win = BrowserWindow.getFocusedWindow()
-  if (win && !win.isDestroyed()) {
-    win.webContents.send('menu:action', action)
+  let win = BrowserWindow.getFocusedWindow()
+  if (!win || win.isDestroyed()) {
+    if (_menuWindow && !_menuWindow.isDestroyed()) {
+      if (_menuWindow.isMinimized()) _menuWindow.restore()
+      _menuWindow.show()
+      _menuWindow.focus()
+      win = _menuWindow
+    } else {
+      return
+    }
   }
+  win.webContents.send('menu:action', action)
 }
 
 export function createMenu(mainWindow: BrowserWindow): void {
@@ -88,6 +99,13 @@ export function createMenu(mainWindow: BrowserWindow): void {
     {
       label: 'File',
       submenu: [
+        {
+          label: 'New Document',
+          accelerator: 'CmdOrCtrl+N',
+          click: (): void => {
+            sendMenuAction('new')
+          }
+        },
         {
           label: 'New Tab',
           accelerator: 'CmdOrCtrl+T',

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -48,6 +48,7 @@ import {
   Timer,
   CircleUserRound,
   Bug,
+  LifeBuoy,
   MessageSquarePlus,
   MessagesSquare,
   FilePlus,
@@ -508,10 +509,17 @@ export function Toolbar() {
                 Settings
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => window.open('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml', '_blank', 'noopener,noreferrer')}>
-                <Bug className="mr-2 h-4 w-4" />
-                Report a Bug
-              </DropdownMenuItem>
+              {window.api?.isMasBuild ? (
+                <DropdownMenuItem onClick={() => window.open('https://solo.ist/prose/support', '_blank', 'noopener,noreferrer')}>
+                  <LifeBuoy className="mr-2 h-4 w-4" />
+                  Request Support
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={() => window.open('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml', '_blank', 'noopener,noreferrer')}>
+                  <Bug className="mr-2 h-4 w-4" />
+                  Report a Bug
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem onClick={() => window.open('https://github.com/solo-ist/prose/issues/new?template=feature-request.yml', '_blank', 'noopener,noreferrer')}>
                 <MessageSquarePlus className="mr-2 h-4 w-4" />
                 Request a Feature


### PR DESCRIPTION
Closes #429.

## Summary

Fixes Apple's recurring rejection (guideline 4.0.0 Design) of MAS Builds 17, 18, and 20: *"when the user closes the main application window there is no menu item to re-open it."* Plus an in-app surface for Apple's 1.5 Safety Support URL citation from the Build 20 rejection.

Phase 1 in-conversation investigation established that the Build 18 menu fix shipped intact (asar inspection of Build 20 binary), but a separate latent bug rendered ~30 menu items silently dead when the window was hidden. Plus a standard-placement violation: Prose's only menu reopen path was `Window → Prose`, while macOS convention puts reopen under `File → New Window` / `File → New Document`.

## Changes

| File | Change |
|---|---|
| `src/main/menu.ts:9-15` | `sendMenuAction` now surfaces `_menuWindow` (restore + show + focus) before dispatching when `getFocusedWindow()` returns null. Eliminates ~30 dead menu items in hidden / minimized states. |
| `src/main/menu.ts` File submenu | Add `File → New Document` (Cmd+N) calling existing `'new'` action. Mirrors Apple's Notes-app pattern (single-window, Cmd+N for new content). Keep existing `New Tab` (Cmd+T) for muscle memory. |
| `src/main/index.ts:417-424` | Harden `app.on('activate', ...)` to `restore() + show() + focus()` (mirrors Window → Prose). Latent asymmetry from PR #420. |
| `electron-builder.yml:3` | Bump `buildVersion: "20"` → `"21"`. |
| `src/renderer/components/layout/Toolbar.tsx` | MAS-only: swap "Report a Bug" → "Request Support" (https://solo.ist/prose/support). OSS unchanged. Uses established `window.api?.isMasBuild` gate. |

## Spec evolution mid-investigation

Original plan was `File → New Window` (Cmd+N) with reopen-only / no-op-when-visible semantics. Replaced with `File → New Document` after recognizing the reviewer-risk: a label promising a new window that never appears could fail us on a fourth rejection cycle. Apple's Notes app is the strongest precedent for the corrected pattern.

Original 1.5 Safety scope said the Support URL fix was a marketing-repo work stream only. This PR adds the in-app surface as a second front; the App Store Connect Support URL field is still being fielded separately.

## Verification matrix (run on local Build 21 dev .app, Apr 24)

Notes:
- MAS .pkg cannot run locally (App Store container provisioning blocks `open -a` with launchd error 163). Verified against the non-MAS dev .app built from the same commit — identical menu/window code paths; sandbox doesn't affect `BrowserWindow.show()` semantics.
- AppleScript `keystroke "n" using command down` is unreliable on this system (some other app intercepts it before it reaches Prose's menu accelerator). Re-verified Cmd+N rows using `key code 45 using command down`. User confirmed real keyboard Cmd+N works.

| Action sequence | Expected | Status |
|---|---|---|
| Red close → Cmd+T | Window appears, new tab created | ✅ PASS (windowCount 0→1) |
| Red close → Cmd+N (key code 45) | Window appears, new tab created | ✅ PASS |
| Red close → File → New Document (menu click) | Window appears, new tab created | ✅ PASS |
| Red close → File → New Tab (menu click) | Window appears, new tab created | ✅ PASS |
| Red close → File → Open | Window appears, file picker opens | ✅ PASS (windowCount 0→2 = main + dialog) |
| Red close → Cmd+, | Window appears, settings open | ✅ PASS (visually confirmed Settings opened) |
| Red close → Window → Prose | Window appears (Build 18 regression check) | ✅ PASS |
| Red close → dock click | Window appears with focus | ✅ PASS |
| Cmd+H → Cmd+N | Window appears, new tab created | ✅ PASS |
| Cmd+H → Cmd+T | Window appears, new tab created | ✅ PASS |
| Cmd+H → dock click | Window appears with focus | ✅ PASS |
| Minimize → Cmd+T | Window appears, new tab created | ✅ PASS (user manually verified) |
| Minimize → Cmd+N | Window appears, new tab created | ⚠️ SPOT-CHECK during install verification (same `sendMenuAction` path as verified cells) |
| Minimize → Window → Prose | Window restored | ⚠️ SPOT-CHECK (Build 18 handler, regression-low risk) |
| Minimize → dock click | Window restored | ⚠️ SPOT-CHECK (hardened activate handler, hidden-state path verified) |
| Cmd+Q from visible state | App quits cleanly | ✅ PASS |
| Cmd+Q from hidden state | App quits cleanly | ✅ PASS |
| Visible+focused → Cmd+N | New tab created (no Space switch, no focus theft) | ✅ PASS (no second window, position/size unchanged) |
| Visible+focused → File → New Document | New tab created (no Space switch, no focus theft) | ✅ PASS |

3 cells flagged for spot-check during local-install verification — all share verified code paths, so risk is low.

## MAS version pinned to 1.0.0 (matches existing ASC version record)

`package.json` is at `v1.0.1` (bumped by OSS release commit 58f0049, PR #426). The MAS submission still tracks the **`v1.0.0` ASC version record** that Builds 17/18/20 were attached to. To avoid creating a needless v1.0.1 record in ASC for a build that should attach to the existing rejection cycle, the MAS .pkg is built with an explicit version override:

```bash
npx electron-builder --mac mas -c.extraMetadata.version=1.0.0
```

Resulting artifact: `dist/mas-arm64/Prose-1.0.0-arm64.pkg`, `CFBundleShortVersionString: 1.0.0`, `CFBundleVersion: 21`.

This is a one-time override for the Build 20 rejection cycle. Future MAS submissions can drop the override and naturally track the OSS `package.json` version once Build 21 is approved.

## Test plan

- [ ] Reviewer: visually verify the toolbar dropdown swap by inspecting Toolbar.tsx diff (no easy way to test runtime branch locally without a TestFlight install)
- [ ] Reviewer: spot-check the 3 ⚠️ minimize cells during local install verification
- [ ] After merge: rebuild MAS .pkg with version override:
  ```bash
  npm run build:mas && npx electron-builder --mac mas -c.extraMetadata.version=1.0.0
  ```
  (Or skip rebuild and reuse `dist/mas-arm64/Prose-1.0.0-arm64.pkg` from this PR's local run — already signed and version-pinned.)
- [ ] Upload via `xcrun altool --upload-app --type macos --file dist/mas-arm64/Prose-1.0.0-arm64.pkg --apiKey 73DLM4525G --apiIssuer <issuer-id>`
- [ ] Wait for App Store Connect processing (~10 min – 2 hrs)
- [ ] Attach Build 21 to the **existing v1.0.0 version record** in App Store Connect (no new version record needed)
- [ ] Reply in Resolution Center referencing the verification matrix and submit for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)