### PR TITLE
fix(mas): hide Google Docs in menu, add Help menu support links (#433)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "21"
+buildVersion: "22"
 directories:
   buildResources: build
   output: dist

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,7 +1,8 @@
-import { Menu, BrowserWindow, app } from 'electron'
+import { Menu, BrowserWindow, app, shell } from 'electron'
 import { basename } from 'path'
 import { is } from '@electron-toolkit/utils'
 import { loadRecentFiles, clearRecentFiles } from './recentFiles'
+import { IS_MAS_BUILD } from './env'
 
 // Store mainWindow reference so we can rebuild the menu after adding recent files
 let _menuWindow: BrowserWindow | null = null
@@ -161,7 +162,7 @@ export function createMenu(mainWindow: BrowserWindow): void {
             sendMenuAction('convertToMarkdown')
           }
         },
-        ...(isGoogleConfigured
+        ...(!IS_MAS_BUILD && isGoogleConfigured
           ? [
               { type: 'separator' as const },
               {
@@ -319,9 +320,38 @@ export function createMenu(mainWindow: BrowserWindow): void {
         { type: 'separator' },
         {
           label: 'Learn More',
-          click: async (): Promise<void> => {
-            const { shell } = await import('electron')
-            await shell.openExternal('https://github.com/solo-ist/prose')
+          click: (): void => {
+            shell.openExternal('https://github.com/solo-ist/prose')
+          }
+        },
+        { type: 'separator' },
+        ...(IS_MAS_BUILD
+          ? [
+              {
+                label: 'Request Support',
+                click: (): void => {
+                  shell.openExternal('https://solo.ist/prose/support')
+                }
+              }
+            ]
+          : [
+              {
+                label: 'Report a Bug',
+                click: (): void => {
+                  shell.openExternal('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml')
+                }
+              }
+            ]),
+        {
+          label: 'Request a Feature',
+          click: (): void => {
+            shell.openExternal('https://github.com/solo-ist/prose/issues/new?template=feature-request.yml')
+          }
+        },
+        {
+          label: 'Discuss Ideas',
+          click: (): void => {
+            shell.openExternal('https://github.com/solo-ist/prose/discussions/categories/ideas')
           }
         },
         ...(!isMac

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -7,6 +7,14 @@ import { IS_MAS_BUILD } from './env'
 // Store mainWindow reference so we can rebuild the menu after adding recent files
 let _menuWindow: BrowserWindow | null = null
 
+// Helper to open an external URL without leaking an unhandled promise
+// rejection if the OS can't open the URL (e.g., no default browser).
+function openExternalUrl(url: string): void {
+  shell.openExternal(url).catch((err) => {
+    console.warn('[Menu] Failed to open external URL:', url, err)
+  })
+}
+
 // Helper to safely send menu actions to the focused window.
 // Falls back to _menuWindow when no window is focused (window hidden via
 // hide-on-close or minimized) — otherwise menu items would silently no-op,
@@ -321,7 +329,7 @@ export function createMenu(mainWindow: BrowserWindow): void {
         {
           label: 'Learn More',
           click: (): void => {
-            shell.openExternal('https://github.com/solo-ist/prose')
+            openExternalUrl('https://github.com/solo-ist/prose')
           }
         },
         { type: 'separator' },
@@ -330,7 +338,7 @@ export function createMenu(mainWindow: BrowserWindow): void {
               {
                 label: 'Request Support',
                 click: (): void => {
-                  shell.openExternal('https://solo.ist/prose/support')
+                  openExternalUrl('https://solo.ist/prose/support')
                 }
               }
             ]
@@ -338,20 +346,20 @@ export function createMenu(mainWindow: BrowserWindow): void {
               {
                 label: 'Report a Bug',
                 click: (): void => {
-                  shell.openExternal('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml')
+                  openExternalUrl('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml')
                 }
               }
             ]),
         {
           label: 'Request a Feature',
           click: (): void => {
-            shell.openExternal('https://github.com/solo-ist/prose/issues/new?template=feature-request.yml')
+            openExternalUrl('https://github.com/solo-ist/prose/issues/new?template=feature-request.yml')
           }
         },
         {
           label: 'Discuss Ideas',
           click: (): void => {
-            shell.openExternal('https://github.com/solo-ist/prose/discussions/categories/ideas')
+            openExternalUrl('https://github.com/solo-ist/prose/discussions/categories/ideas')
           }
         },
         ...(!isMac


### PR DESCRIPTION
Closes #433.

## Summary

Two MAS-facing menu issues found post-Build 21 upload:

1. **Google Docs menu items showed in MAS builds.** \`File → Sync with Google Docs\` and \`File → Import from Google Docs...\` are gated on \`isGoogleConfigured\` (env-var check at build time). Since GOOGLE_CLIENT_ID/SECRET are set in local \`.env\`, items showed in MAS builds — but Google Docs is not part of the MAS feature surface.

2. **Help menu lacked the support / community links** that already exist in the Toolbar's More dropdown. Apple's reviewer (and macOS users) naturally look for these in the Help menu bar.

## Changes

| File | Change |
|---|---|
| \`src/main/menu.ts\` | Import \`IS_MAS_BUILD\` from \`./env\`. |
| \`src/main/menu.ts\` File submenu | Gate Google Docs items on \`!IS_MAS_BUILD && isGoogleConfigured\` (was just \`isGoogleConfigured\`). |
| \`src/main/menu.ts\` Help submenu | Add Report a Bug (OSS-only), Request Support (MAS-only), Request a Feature, Discuss Ideas. Mirrors the Toolbar dropdown's MAS conditional pattern from PR #432. Switched Learn More from dynamic \`shell\` import to top-level for consistency. |
| \`electron-builder.yml:3\` | Bump \`buildVersion: \"21\"\` → \`\"22\"\`. |

## Test plan

- [ ] Visually verify Help menu in built MAS .app shows: Keyboard Shortcuts, Learn More, Request Support, Request a Feature, Discuss Ideas (no Report a Bug)
- [ ] Visually verify Help menu in dev (OSS) .app shows: Keyboard Shortcuts, Learn More, Report a Bug, Request a Feature, Discuss Ideas (no Request Support)
- [ ] Visually verify File menu in MAS .app has no Google Docs items
- [ ] Visually verify File menu in dev (OSS) .app still has Google Docs items (env vars still set in .env)

## Build 21 disposition (your call)

Build 21 was uploaded to ASC at the end of the previous session but **not yet submitted for review**. Two options:

**(a) Recommended:** Don't submit Build 21. Once this PR merges, build + upload Build 22 to ASC. Submit Build 22 as the version 1.0.0 build under review. Cleaner — one review cycle, ships everything (menu reopen fix + support URL + Google Docs hide + Help menu polish) in one go.

**(b) Submit Build 21 now**, then ship Build 22 as a follow-up update once Build 21 is approved. Riskier — Apple could cite the Google Docs items as a "feature you don't have entitlements for" issue (low probability but non-zero), which would mean another rejection cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)