### PR TITLE
feat(artifact): Prose artifact editor for in-conversation markdown editing

### DIFF
--- a/resources/prose-artifact/prose-editor.html
+++ b/resources/prose-artifact/prose-editor.html
@@ -1,0 +1,607 @@
+<!-- Prose Artifact Editor
+     Single-file React artifact for Claude's artifact pane.
+     No DOCTYPE — rendered directly by Claude's artifact runtime.
+     No top-level padding, transparent background.
+
+     External dependencies (all from cdnjs.cloudflare.com):
+       - React 18
+       - ReactDOM 18
+       - marked 9 (markdown → HTML)
+
+     Draft persistence: window.storage (artifact runtime API).
+     Jump to desktop: prose://open?content=<urlencoded-markdown>
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"></script>
+
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  /* CSS custom properties on the root wrapper — works without <html> */
+  .prose-app {
+    --font: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, 'Courier New', monospace;
+    --font-size: 13px;
+    --line-height: 1.6;
+
+    /* Light theme defaults */
+    --surface: #ffffff;
+    --surface-alt: #f4f4f5;
+    --border: #e4e4e7;
+    --text: #1a1a1a;
+    --muted: #71717a;
+    --btn-bg: #18181b;
+    --btn-text: #fafafa;
+    --btn-hover: #27272a;
+    --btn-secondary-bg: #f4f4f5;
+    --btn-secondary-text: #18181b;
+    --btn-secondary-hover: #e4e4e7;
+    --warning-bg: #fef9c3;
+    --warning-text: #713f12;
+    --warning-border: #fde047;
+    --copied-bg: #dcfce7;
+    --copied-text: #14532d;
+
+    font-family: var(--font);
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+    background: transparent;
+    color: var(--text);
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Dark theme — toggled by data-theme attribute on .prose-app */
+  .prose-app[data-theme="dark"] {
+    --surface: #18181b;
+    --surface-alt: #27272a;
+    --border: #3f3f46;
+    --text: #fafafa;
+    --muted: #a1a1aa;
+    --btn-bg: #fafafa;
+    --btn-text: #18181b;
+    --btn-hover: #e4e4e7;
+    --btn-secondary-bg: #27272a;
+    --btn-secondary-text: #fafafa;
+    --btn-secondary-hover: #3f3f46;
+    --warning-bg: rgba(253, 224, 71, 0.12);
+    --warning-text: #fde047;
+    --warning-border: rgba(253, 224, 71, 0.3);
+    --copied-bg: rgba(34, 197, 94, 0.15);
+    --copied-text: #bbf7d0;
+  }
+
+  /* body/html reset — needed when scaffold wraps with <html> */
+  body { margin: 0; padding: 0; background: transparent; }
+  #root { height: 100vh; }
+
+  /* Toolbar */
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    flex-shrink: 0;
+  }
+
+  .toolbar__brand {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-right: 4px;
+  }
+
+  .toolbar__spacer { flex: 1; }
+
+  /* Buttons */
+  .btn {
+    font-family: var(--font);
+    font-size: 12px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 5px;
+    border: none;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
+    transition: background 0.1s, color 0.1s;
+    text-decoration: none;
+    line-height: 1.4;
+  }
+
+  .btn-primary {
+    background: var(--btn-bg);
+    color: var(--btn-text);
+  }
+  .btn-primary:hover { background: var(--btn-hover); color: var(--btn-text); }
+
+  .btn-secondary {
+    background: var(--btn-secondary-bg);
+    color: var(--btn-secondary-text);
+    border: 1px solid var(--border);
+  }
+  .btn-secondary:hover { background: var(--btn-secondary-hover); }
+
+  .btn-ghost {
+    background: transparent;
+    color: var(--muted);
+    border: 1px solid transparent;
+    padding: 4px 7px;
+  }
+  .btn-ghost:hover { background: var(--surface-alt); color: var(--text); }
+
+  .btn--copied {
+    background: var(--copied-bg) !important;
+    color: var(--copied-text) !important;
+    border-color: transparent !important;
+  }
+
+  /* View toggle */
+  .view-toggle {
+    display: flex;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    overflow: hidden;
+  }
+
+  .view-toggle__btn {
+    font-family: var(--font);
+    font-size: 11px;
+    font-weight: 500;
+    padding: 3px 8px;
+    border: none;
+    cursor: pointer;
+    background: transparent;
+    color: var(--muted);
+    transition: background 0.1s, color 0.1s;
+  }
+
+  .view-toggle__btn--active {
+    background: var(--surface-alt);
+    color: var(--text);
+  }
+
+  /* Word count */
+  .word-count {
+    font-size: 11px;
+    color: var(--muted);
+  }
+
+  /* Warning bar */
+  .warning-bar {
+    padding: 6px 12px;
+    background: var(--warning-bg);
+    color: var(--warning-text);
+    border-top: 1px solid var(--warning-border);
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+
+  /* Editor area */
+  .editor-area {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+    min-height: 0;
+  }
+
+  /* Editor pane */
+  .editor-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    border-right: 1px solid var(--border);
+  }
+  .editor-pane--full { border-right: none; }
+
+  .pane-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    padding: 5px 12px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface-alt);
+    flex-shrink: 0;
+  }
+
+  .editor-textarea {
+    flex: 1;
+    width: 100%;
+    resize: none;
+    border: none;
+    outline: none;
+    font-family: var(--font);
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+    background: var(--surface);
+    color: var(--text);
+    padding: 16px;
+    min-height: 0;
+  }
+  .editor-textarea::placeholder { color: var(--muted); }
+
+  /* Preview pane */
+  .preview-pane {
+    flex: 1;
+    overflow-y: auto;
+    background: var(--surface);
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .preview-scroll {
+    padding: 16px;
+    flex: 1;
+  }
+
+  /* Markdown preview content */
+  .md {
+    font-family: var(--font);
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+    color: var(--text);
+  }
+
+  .md h1, .md h2, .md h3, .md h4, .md h5, .md h6 {
+    font-weight: 600;
+    margin: 1.2em 0 0.4em;
+    line-height: 1.3;
+  }
+  .md h1:first-child, .md h2:first-child, .md h3:first-child { margin-top: 0; }
+  .md h1 { font-size: 1.5em; }
+  .md h2 { font-size: 1.25em; }
+  .md h3 { font-size: 1.1em; }
+  .md h4, .md h5, .md h6 { font-size: 1em; }
+
+  .md p { margin: 0.6em 0; }
+  .md p:first-child { margin-top: 0; }
+
+  .md ul, .md ol { margin: 0.4em 0 0.4em 1.5em; padding: 0; }
+  .md li { margin: 0.2em 0; }
+
+  .md code {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-family: var(--font);
+    font-size: 0.9em;
+  }
+
+  .md pre {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px;
+    overflow-x: auto;
+    margin: 0.6em 0;
+  }
+  .md pre code { background: none; border: none; padding: 0; font-size: inherit; }
+
+  .md blockquote {
+    border-left: 3px solid var(--border);
+    padding-left: 12px;
+    color: var(--muted);
+    margin: 0.6em 0;
+  }
+
+  .md a { color: var(--text); text-decoration: underline; }
+
+  .md hr { border: none; border-top: 1px solid var(--border); margin: 1.2em 0; }
+
+  .md table { border-collapse: collapse; width: 100%; margin: 0.6em 0; font-size: 0.95em; }
+  .md th, .md td { border: 1px solid var(--border); padding: 5px 10px; text-align: left; }
+  .md th { background: var(--surface-alt); font-weight: 600; }
+
+  .md-empty { color: var(--muted); font-style: italic; font-size: var(--font-size); padding: 0; }
+</style>
+
+<div id="root"></div>
+
+<script>
+(function() {
+  'use strict';
+
+  var h = React.createElement;
+  var useState = React.useState;
+  var useEffect = React.useEffect;
+  var useRef = React.useRef;
+  var useCallback = React.useCallback;
+  var useMemo = React.useMemo;
+
+  // ── Storage abstraction ──────────────────────────────────────────────────
+  // Checks window.storage first (artifact runtime), falls back to
+  // localStorage for local development. Component code never references
+  // localStorage directly.
+  var stor = {
+    get: function(key) {
+      try {
+        if (window.storage && typeof window.storage.getItem === 'function') {
+          return window.storage.getItem(key);
+        }
+        if (typeof localStorage !== 'undefined') return localStorage.getItem(key);
+      } catch(_) {}
+      return null;
+    },
+    set: function(key, val) {
+      try {
+        if (window.storage && typeof window.storage.setItem === 'function') {
+          window.storage.setItem(key, val); return;
+        }
+        if (typeof localStorage !== 'undefined') localStorage.setItem(key, val);
+      } catch(_) {}
+    }
+  };
+
+  var DRAFT_KEY  = 'prose-artifact-draft';
+  var THEME_KEY  = 'prose-artifact-theme';
+  var MAX_BYTES  = 5 * 1024 * 1024; // 5 MB — matches parseProseUrl cap in index.ts
+  var WARN_BYTES = 4 * 1024 * 1024; // warn at 4 MB
+
+  // ── Markdown rendering ───────────────────────────────────────────────────
+  // marked.use() is the v5+ API; setOptions is deprecated in v9.
+  if (typeof marked !== 'undefined') {
+    marked.use({ breaks: true, gfm: true });
+  }
+
+  function renderMd(text) {
+    if (!text || !text.trim()) return '';
+    try { return marked.parse(text); }
+    catch(_) { return '<p>Preview error</p>'; }
+  }
+
+  function wordCount(text) {
+    if (!text || !text.trim()) return 0;
+    return text.trim().split(/\s+/).length;
+  }
+
+  function byteLen(str) {
+    try { return new Blob([str]).size; }
+    catch(_) { return str.length; }
+  }
+
+  function proseUrl(content) {
+    return 'prose://open?content=' + encodeURIComponent(content);
+  }
+
+  // ── Inline SVG icons ─────────────────────────────────────────────────────
+  var SVG_PROPS = { fill: 'none', stroke: 'currentColor', strokeWidth: '2',
+                    strokeLinecap: 'round', strokeLinejoin: 'round' };
+
+  function Icon(props) {
+    var sz = props.size || 13;
+    return h('svg', Object.assign({}, SVG_PROPS,
+      { width: sz, height: sz, viewBox: '0 0 24 24', style: { flexShrink: 0 } }),
+      props.children
+    );
+  }
+
+  function IcCopy()  { return h(Icon, null,
+    h('rect', { x:'9', y:'9', width:'13', height:'13', rx:'2', ry:'2' }),
+    h('path', { d:'M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1' })
+  ); }
+
+  function IcCheck() { return h(Icon, { strokeWidth:'2.5' },
+    h('polyline', { points:'20 6 9 17 4 12' })
+  ); }
+
+  function IcDownload() { return h(Icon, null,
+    h('path', { d:'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4' }),
+    h('polyline', { points:'7 10 12 15 17 10' }),
+    h('line', { x1:'12', y1:'15', x2:'12', y2:'3' })
+  ); }
+
+  function IcSun() { return h(Icon, null,
+    h('circle', { cx:'12', cy:'12', r:'4' }),
+    h('line', { x1:'12', y1:'2',    x2:'12', y2:'6' }),
+    h('line', { x1:'12', y1:'18',   x2:'12', y2:'22' }),
+    h('line', { x1:'4.22', y1:'4.22',   x2:'7.05',  y2:'7.05' }),
+    h('line', { x1:'16.95', y1:'16.95', x2:'19.78', y2:'19.78' }),
+    h('line', { x1:'2',  y1:'12', x2:'6',  y2:'12' }),
+    h('line', { x1:'18', y1:'12', x2:'22', y2:'12' }),
+    h('line', { x1:'4.22',  y1:'19.78', x2:'7.05',  y2:'16.95' }),
+    h('line', { x1:'16.95', y1:'7.05',  x2:'19.78', y2:'4.22' })
+  ); }
+
+  function IcMoon() { return h(Icon, null,
+    h('path', { d:'M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z' })
+  ); }
+
+  function IcExternal() { return h(Icon, null,
+    h('path', { d:'M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6' }),
+    h('polyline', { points:'15 3 21 3 21 9' }),
+    h('line', { x1:'10', y1:'14', x2:'21', y2:'3' })
+  ); }
+
+  // ── Main component ───────────────────────────────────────────────────────
+  function ProseEditor() {
+    // Initialise theme from storage, then system preference
+    var initTheme = (function() {
+      var saved = stor.get(THEME_KEY);
+      if (saved === 'dark' || saved === 'light') return saved;
+      return (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        ? 'dark' : 'light';
+    })();
+
+    var _theme = useState(initTheme);
+    var theme = _theme[0]; var setTheme = _theme[1];
+
+    var _content = useState(function() { return stor.get(DRAFT_KEY) || ''; });
+    var content = _content[0]; var setContent = _content[1];
+
+    var _view = useState('split');
+    var view = _view[0]; var setView = _view[1];
+
+    var _copied = useState(false);
+    var copied = _copied[0]; var setCopied = _copied[1];
+
+    var saveTimer = useRef(null);
+    var copiedTimer = useRef(null);
+
+    // System theme changes
+    useEffect(function() {
+      var mq = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+      if (!mq || !mq.addEventListener) return;
+      var handler = function(e) {
+        // Only follow system if user hasn't pinned a preference this session
+        var pinned = stor.get(THEME_KEY);
+        if (!pinned) setTheme(e.matches ? 'dark' : 'light');
+      };
+      mq.addEventListener('change', handler);
+      return function() { mq.removeEventListener('change', handler); };
+    }, []);
+
+    var handleTheme = useCallback(function() {
+      setTheme(function(t) {
+        var next = t === 'dark' ? 'light' : 'dark';
+        stor.set(THEME_KEY, next);
+        return next;
+      });
+    }, []);
+
+    var handleChange = useCallback(function(e) {
+      var val = e.target.value;
+      setContent(val);
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(function() { stor.set(DRAFT_KEY, val); }, 300);
+    }, []);
+
+    var handleCopy = useCallback(function() {
+      navigator.clipboard.writeText(content).then(function() {
+        setCopied(true);
+        if (copiedTimer.current) clearTimeout(copiedTimer.current);
+        copiedTimer.current = setTimeout(function() { setCopied(false); }, 2000);
+      }).catch(function() {});
+    }, [content]);
+
+    var handleDownload = useCallback(function() {
+      try {
+        var blob = new Blob([content], { type: 'text/markdown' });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url; a.download = 'document.md'; a.click();
+        URL.revokeObjectURL(url);
+      } catch(_) {}
+    }, [content]);
+
+    var words = wordCount(content);
+    var bytes = byteLen(content);
+    var nearCap = bytes > WARN_BYTES;
+    var overCap = bytes >= MAX_BYTES;
+
+    var preview = useMemo(function() { return renderMd(content); }, [content]);
+    var pUrl = useMemo(function() { return proseUrl(content); }, [content]);
+
+    var showEdit    = view === 'split' || view === 'edit';
+    var showPreview = view === 'split' || view === 'preview';
+
+    return h('div', { className: 'prose-app', 'data-theme': theme },
+
+      // Toolbar
+      h('div', { className: 'toolbar' },
+        h('span', { className: 'toolbar__brand' }, 'Prose'),
+
+        h('div', { className: 'view-toggle' },
+          ['edit', 'split', 'preview'].map(function(v) {
+            return h('button', {
+              key: v,
+              className: 'view-toggle__btn' + (view === v ? ' view-toggle__btn--active' : ''),
+              onClick: function() { setView(v); },
+              title: v.charAt(0).toUpperCase() + v.slice(1)
+            }, v.charAt(0).toUpperCase() + v.slice(1));
+          })
+        ),
+
+        h('div', { className: 'toolbar__spacer' }),
+
+        h('span', { className: 'word-count' },
+          words === 1 ? '1 word' : words + ' words'
+        ),
+
+        h('button', {
+          className: 'btn btn-ghost',
+          onClick: handleDownload,
+          title: 'Download as .md file'
+        }, h(IcDownload), 'Download'),
+
+        // Copy markdown — always visible, works without Prose installed
+        h('button', {
+          className: 'btn btn-secondary' + (copied ? ' btn--copied' : ''),
+          onClick: handleCopy,
+          title: 'Copy raw markdown to clipboard'
+        }, copied ? h(IcCheck) : h(IcCopy), copied ? 'Copied' : 'Copy markdown'),
+
+        // Open in Prose via prose:// URL scheme
+        h('a', {
+          className: 'btn btn-primary',
+          href: overCap ? undefined : pUrl,
+          title: overCap
+            ? 'Document exceeds 5 MB — use Copy markdown instead'
+            : 'Open in Prose desktop app',
+          style: overCap ? { opacity: 0.5, pointerEvents: 'none' } : undefined
+        }, h(IcExternal), 'Open in Prose'),
+
+        h('button', {
+          className: 'btn btn-ghost',
+          onClick: handleTheme,
+          title: theme === 'dark' ? 'Light mode' : 'Dark mode'
+        }, theme === 'dark' ? h(IcSun) : h(IcMoon))
+      ),
+
+      // Size warning
+      nearCap && h('div', { className: 'warning-bar' },
+        overCap
+          ? 'Document exceeds the 5 MB limit for Open in Prose. Use Copy markdown instead.'
+          : 'Document is nearing the 5 MB limit for Open in Prose.'
+      ),
+
+      // Editor / Preview
+      h('div', { className: 'editor-area' },
+
+        showEdit && h('div', {
+          className: 'editor-pane' + (view === 'edit' ? ' editor-pane--full' : '')
+        },
+          view === 'split' && h('div', { className: 'pane-label' }, 'Markdown'),
+          h('textarea', {
+            className: 'editor-textarea',
+            value: content,
+            onChange: handleChange,
+            placeholder: 'Start writing in Markdown...',
+            spellCheck: false,
+            autoCapitalize: 'off',
+            autoCorrect: 'off'
+          })
+        ),
+
+        showPreview && h('div', { className: 'preview-pane' },
+          view === 'split' && h('div', { className: 'pane-label' }, 'Preview'),
+          h('div', { className: 'preview-scroll' },
+            content.trim()
+              ? h('div', { className: 'md', dangerouslySetInnerHTML: { __html: preview } })
+              : h('p', { className: 'md-empty' }, 'Preview will appear here')
+          )
+        )
+      )
+    );
+  }
+
+  // Mount
+  var root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(h(ProseEditor, null));
+
+})();
+</script>

--- a/resources/prose-artifact/prose-editor.html
+++ b/resources/prose-artifact/prose-editor.html
@@ -370,7 +370,7 @@
       // load (CDN block, SRI mismatch), surface a visible error instead
       // of a blank pane — silent failure leaves the user wondering.
       if (typeof DOMPurify === 'undefined') {
-        return '<p style="color: var(--accent); font-style: italic;">Preview unavailable: sanitizer failed to load.</p>';
+        return '<p style="color: var(--warning-text); font-style: italic;">Preview unavailable: sanitizer failed to load.</p>';
       }
       return DOMPurify.sanitize(html);
     }
@@ -462,6 +462,9 @@
     var _copied = useState(false);
     var copied = _copied[0]; var setCopied = _copied[1];
 
+    var _copyFailed = useState(false);
+    var copyFailed = _copyFailed[0]; var setCopyFailed = _copyFailed[1];
+
     var saveTimer = useRef(null);
     var copiedTimer = useRef(null);
 
@@ -496,9 +499,18 @@
     var handleCopy = useCallback(function() {
       navigator.clipboard.writeText(content).then(function() {
         setCopied(true);
+        setCopyFailed(false);
         if (copiedTimer.current) clearTimeout(copiedTimer.current);
         copiedTimer.current = setTimeout(function() { setCopied(false); }, 2000);
-      }).catch(function() {});
+      }).catch(function() {
+        // Surface the failure in-button so the user knows the copy didn't take.
+        // Most likely cause is a non-secure-origin or denied permission;
+        // either way silence is the wrong default.
+        setCopyFailed(true);
+        setCopied(false);
+        if (copiedTimer.current) clearTimeout(copiedTimer.current);
+        copiedTimer.current = setTimeout(function() { setCopyFailed(false); }, 2000);
+      });
     }, [content]);
 
     var handleDownload = useCallback(function() {
@@ -563,8 +575,11 @@
         h('button', {
           className: 'btn btn-secondary' + (copied ? ' btn--copied' : ''),
           onClick: handleCopy,
-          title: 'Copy raw markdown to clipboard'
-        }, copied ? h(IcCheck) : h(IcCopy), copied ? 'Copied' : 'Copy markdown'),
+          title: copyFailed ? 'Clipboard access denied' : 'Copy raw markdown to clipboard'
+        },
+          copied ? h(IcCheck) : h(IcCopy),
+          copied ? 'Copied' : (copyFailed ? 'Failed' : 'Copy markdown')
+        ),
 
         // Open in Prose via prose:// URL scheme
         h('a', {

--- a/resources/prose-artifact/prose-editor.html
+++ b/resources/prose-artifact/prose-editor.html
@@ -14,10 +14,10 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" integrity="sha512-8Q6Y9XnTbOE+JNvjBQwJ2H8S+UV4uA6hiRykhdtIyDYZ2TprdNmWOUaKdGzOhyr4dCyk287OejbPvwl7lrfqrQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" integrity="sha512-MOCpqoRoisCTwJ8vQQiciZv0qcpROCidek3GTFS6KTk2+y7munJIlKCVkFCYY+p3ErYFXCjmFjnfTTRSC1OHWQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js" integrity="sha512-pmjEJQ7CveksANaAKdCJZMig7eAcCFFzE1b5XnlnxdB/vU3AOStJ5SF7w4tFuqskuU31ETnAaWTYRQOYg2WHKw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js" integrity="sha512-H+rglffZ6f5gF7UJgvH4Naa+fGCgjrHKMgoFOGmcPTRwR6oILo5R+gtzNrpDp7iMV3udbymBVjkeZGNz1Em4rQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -366,8 +366,13 @@
       // Sanitize: marked v9 with GFM passes raw HTML through. Without
       // DOMPurify, a user typing <img src=x onerror=...> into the textarea
       // gets script execution in the preview. Per CLAUDE.md: never insert
-      // dynamic data into innerHTML unsanitized.
-      return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(html) : '';
+      // dynamic data into innerHTML unsanitized. If DOMPurify failed to
+      // load (CDN block, SRI mismatch), surface a visible error instead
+      // of a blank pane — silent failure leaves the user wondering.
+      if (typeof DOMPurify === 'undefined') {
+        return '<p style="color: var(--accent); font-style: italic;">Preview unavailable: sanitizer failed to load.</p>';
+      }
+      return DOMPurify.sanitize(html);
     }
     catch(_) { return '<p>Preview error</p>'; }
   }
@@ -437,15 +442,15 @@
 
   // ── Main component ───────────────────────────────────────────────────────
   function ProseEditor() {
-    // Initialise theme from storage, then system preference
-    var initTheme = (function() {
+    // Initialise theme from storage, then system preference. Lazy initializer
+    // so the storage read only fires on the first render — useState ignores
+    // the value on subsequent renders, so an eager IIFE was wasted work.
+    var _theme = useState(function() {
       var saved = stor.get(THEME_KEY);
       if (saved === 'dark' || saved === 'light') return saved;
       return (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)
         ? 'dark' : 'light';
-    })();
-
-    var _theme = useState(initTheme);
+    });
     var theme = _theme[0]; var setTheme = _theme[1];
 
     var _content = useState(function() { return stor.get(DRAFT_KEY) || ''; });
@@ -501,8 +506,14 @@
         var blob = new Blob([content], { type: 'text/markdown' });
         var url = URL.createObjectURL(blob);
         var a = document.createElement('a');
-        a.href = url; a.download = 'document.md'; a.click();
-        URL.revokeObjectURL(url);
+        a.href = url; a.download = 'document.md';
+        // Append + remove + deferred revoke: revoking the object URL
+        // synchronously after click() races the browser's blob fetch in
+        // Firefox / Chromium under load and silently drops the download.
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(function() { URL.revokeObjectURL(url); }, 150);
       } catch(_) {}
     }, [content]);
 

--- a/resources/prose-artifact/prose-editor.html
+++ b/resources/prose-artifact/prose-editor.html
@@ -17,6 +17,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
 
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -360,7 +361,14 @@
 
   function renderMd(text) {
     if (!text || !text.trim()) return '';
-    try { return marked.parse(text); }
+    try {
+      var html = marked.parse(text);
+      // Sanitize: marked v9 with GFM passes raw HTML through. Without
+      // DOMPurify, a user typing <img src=x onerror=...> into the textarea
+      // gets script execution in the preview. Per CLAUDE.md: never insert
+      // dynamic data into innerHTML unsanitized.
+      return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(html) : '';
+    }
     catch(_) { return '<p>Preview error</p>'; }
   }
 
@@ -504,7 +512,9 @@
     var overCap = bytes >= MAX_BYTES;
 
     var preview = useMemo(function() { return renderMd(content); }, [content]);
-    var pUrl = useMemo(function() { return proseUrl(content); }, [content]);
+    // Skip URL encoding when over the 5MB cap — the button is disabled anyway,
+    // and encodeURIComponent on a multi-MB string causes input lag in the editor.
+    var pUrl = useMemo(function() { return overCap ? '' : proseUrl(content); }, [content, overCap]);
 
     var showEdit    = view === 'split' || view === 'edit';
     var showPreview = view === 'split' || view === 'preview';

--- a/resources/prose-artifact/test-scaffold.html
+++ b/resources/prose-artifact/test-scaffold.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<!--
+  Local development scaffold for prose-editor.html.
+
+  Wraps the artifact with a proper HTML document and provides:
+    - window.storage mock backed by localStorage (simulates artifact runtime)
+    - Viewport sizing to match Claude's artifact pane (~600px wide)
+
+  The component itself (prose-editor.html) never references localStorage directly.
+  All storage access goes through the storage abstraction which checks
+  window.storage first, then falls back to localStorage for local development.
+
+  Usage:
+    open resources/prose-artifact/test-scaffold.html
+    (or: python3 -m http.server 8080 from the prose-artifact/ directory)
+
+  What to verify:
+    1. Markdown editing with live preview
+    2. Theme toggle (sun/moon button) and prefers-color-scheme detection
+    3. Copy markdown button — pastes into a text editor to confirm it's raw markdown
+    4. Download button — file is .md, contents are markdown not HTML
+    5. Open in Prose — constructs prose://open?content=... URL (check console or click
+       to see if macOS launches the handler if Prose is installed)
+    6. Draft persistence — edit text, reload the page, confirm content is restored
+    7. No console errors during a 2-minute editing session
+    8. Loads under 1 second (check Network tab)
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Prose Artifact — Local Test</title>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; }
+    body {
+      /* Simulate Claude's artifact pane background */
+      background: #f9f9f9;
+      display: flex;
+      justify-content: center;
+      padding: 0;
+    }
+    .frame {
+      width: 100%;
+      max-width: 900px;
+      height: 100vh;
+      background: white;
+      border-left: 1px solid #e4e4e7;
+      border-right: 1px solid #e4e4e7;
+      overflow: hidden;
+    }
+    .frame iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+    .scaffold-note {
+      position: fixed;
+      bottom: 12px;
+      right: 12px;
+      font-family: monospace;
+      font-size: 11px;
+      color: #71717a;
+      background: white;
+      border: 1px solid #e4e4e7;
+      padding: 4px 8px;
+      border-radius: 4px;
+      z-index: 1000;
+    }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <iframe src="prose-editor.html" id="artifact-frame"></iframe>
+  </div>
+  <div class="scaffold-note">Local test scaffold — not the artifact runtime</div>
+
+  <script>
+    // Inject window.storage mock into the iframe once it loads.
+    // The artifact's storage abstraction checks window.storage first,
+    // so this ensures the test matches the runtime behavior path.
+    const iframe = document.getElementById('artifact-frame');
+    iframe.addEventListener('load', function() {
+      try {
+        const win = iframe.contentWindow;
+        // Provide window.storage backed by localStorage
+        if (!win.storage) {
+          win.storage = {
+            getItem: function(key) {
+              return localStorage.getItem('scaffold:' + key);
+            },
+            setItem: function(key, value) {
+              localStorage.setItem('scaffold:' + key, value);
+            },
+            removeItem: function(key) {
+              localStorage.removeItem('scaffold:' + key);
+            }
+          };
+        }
+      } catch(e) {
+        // Cross-origin restriction in some environments — storage falls
+        // back to the in-frame localStorage naturally.
+        console.warn('[scaffold] Could not inject window.storage mock:', e.message);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/resources/prose-skill/prose/SKILL.md
+++ b/resources/prose-skill/prose/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: prose
+description: Use Prose's MCP tools (get_outline, read_document, suggest_edit, open_file, create_and_open_file) to read, outline, and propose edits to the document the user has open in Prose. Activates when the user asks to edit, restructure, summarize, read, get an outline of, look at, or work on a document in Prose, or when Prose MCP tools are available in the session.
+---
+
+# Prose
+
+Prose is a focused Markdown editor for macOS with native Claude integration via MCP (Model Context Protocol). This skill drives Prose from a Claude conversation: outlining documents, reading content, and proposing inline edits the user can accept or reject in the diff UI.
+
+## Connectivity
+
+Don't probe before doing real work — your **first MCP call doubles as the connectivity check**. Make whatever call the user's request actually needs (`get_outline`, `read_document`, etc.) and read the response state:
+
+- **Returns the expected payload** → Prose is running with MCP connected. Continue.
+- **"tool not found" / not in toolset** → MCP isn't installed. Tell the user: open Prose → Settings → Integrations → click "Install MCP Server", then restart Claude.
+- **Error: server not reachable / connection refused** → MCP is installed but Prose isn't running. Ask the user to launch Prose, or offer to work with pasted content.
+- **Mac App Store build of Prose** → MCP is unavailable by sandbox design. Explain this and offer to work with pasted content. Don't attempt install instructions.
+
+Never silently underperform. If MCP isn't usable, surface why and offer an alternative.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `get_outline` | Returns document headings as a structured list. |
+| `read_document` | Returns the full document as a list of nodes. Each node has an `id` (use this for edit targeting), the node `type`, and its `text` content. |
+| `suggest_edit` | Proposes a replacement for a single node. The user sees an inline diff in Prose and accepts or rejects there — Prose's MCP does not expose programmatic accept. |
+| `open_file` | Opens an existing file in Prose by absolute path. |
+| `create_and_open_file` | Creates a new file with given content at a given path and opens it in Prose. |
+
+## Response shapes
+
+`get_outline` returns:
+
+```
+{ outline: [{ level: number, text: string, line: number }, ...], summary?: string }
+```
+
+Each entry is a heading. `level` is 1–6 (H1–H6), `text` is the heading text, `line` is its approximate line number. The `summary` field appears only when the document has fewer than 3 headings.
+
+`read_document` returns `{ nodes: [{ id, type, content }, ...], markdown }`. The `id` is what `suggest_edit` targets via `nodeId`. `markdown` is the full document text if you need it without iterating nodes. **Note**: nodes carry `content`, not `text` — don't look for a `text` field.
+
+`suggest_edit` returns `{ suggested: true, suggestionId }` on success.
+
+## Side effects and limitations
+
+- `create_and_open_file` and `open_file` switch the active document and dismiss any pending `suggest_edit` overlay. Order multi-tool flows accordingly: render the diff last if you want the user to land on it.
+- `create_and_open_file` saves to Prose's configured default save location (typically `~/Documents`). The `filename` parameter is just a name, not a path; if it collides, Prose auto-suffixes (`Untitled.md` → `Untitled 2.md`).
+- The MCP exposes only the 5 tools above — there is **no** "get current file path" tool. If you need the active document's path (e.g., to switch back after `create_and_open_file`), ask the user or use a path they've already mentioned. Don't guess.
+- `get_outline` and `read_document` are read-only; safe to call any time without disturbing UI state.
+
+## Editing
+
+`suggest_edit` is **node-targeted**. Parameters:
+
+- `nodeId` (**required**) — from `read_document`.
+- `content` (**required**) — replaces the node's *entire* content.
+- `comment` (optional) — short rationale shown in the diff UI (≤ 20 words).
+- `search` (optional but recommended) — the original node text. Pass it whenever you have it; the server uses it as a text-match fallback if `nodeId` is stale.
+
+Workflow: `read_document` → pick the node → `suggest_edit` with both `nodeId` and `search`. One call per turn — Prose's overlay handles one suggestion at a time. Don't loop waiting for accept/reject; just return.
+
+If `suggest_edit` returns "node not found" / "no match", call `read_document` again, locate the node by its current text, and retry with the fresh `nodeId`.
+
+Prefer minimal diffs — replace the smallest node that contains the change. When restructuring or editing headings, verify heading text verbatim against `get_outline` first.
+
+## Rendering — widgets are the response shape
+
+Both widget templates are inlined below. **The widget IS the response shape for outlines and diffs — not an optional enhancement.** Do not fall back to a Markdown list because the widget feels heavy or because Markdown is "simpler." Only fall back when `show_widget` is genuinely unavailable on this surface (every variant returns "tool not found").
+
+### Calling `show_widget`
+
+`show_widget` (also exposed as `visualize:show_widget`) requires three parameters:
+
+- `widget_code` — the substituted HTML from the templates below.
+- `title` — short snake_case identifier (e.g., `prose_outline`, `prose_diff_<short_node_id>`). No spaces or special characters; also used as the download filename.
+- `loading_messages` — array of 1–4 short strings (~5 words each). Keep them dry and factual for this writing-tools context. Examples: `["Laying out the headings"]` for outline, `["Highlighting what changed"]` for diff.
+
+The platform expects a `read_me` call **once silently** before your first `show_widget` call in the conversation. Don't narrate it — just make the call before rendering.
+
+### Outline widget
+
+**When**: after `get_outline` returns three or more entries. For fewer than 3 headings, use the `summary` field and answer in 1–2 conversational sentences.
+
+**Outer template** — substitute `{{HEADING_ITEMS}}` with one item per heading:
+
+```html
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+  .prose-outline {
+    --bg: #ffffff; --text: #1a1a1a; --border: #e4e4e7; --muted: #71717a;
+    font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 13px; line-height: 1.6; color: var(--text);
+    max-width: 720px;
+  }
+  @media (prefers-color-scheme: dark) {
+    .prose-outline { --bg: #18181b; --text: #fafafa; --border: #3f3f46; --muted: #a1a1aa; }
+  }
+  .prose-outline__card {
+    border: 1px solid var(--border); border-radius: 8px;
+    padding: 14px 16px; background: var(--bg);
+  }
+  .prose-outline__label { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: 10px; }
+  .prose-outline__item { padding: 3px 0; color: var(--text); font-size: 13px; }
+</style>
+<div class="prose-outline">
+  <div class="prose-outline__card">
+    <div class="prose-outline__label">Outline</div>
+    {{HEADING_ITEMS}}
+  </div>
+</div>
+```
+
+**Item template** — one per heading. `INDENT` = `(level - 1) * 16`. `TEXT` = HTML-escape `& < > "` in the heading text:
+
+```html
+<div class="prose-outline__item" style="padding-left: {{INDENT}}px;">{{TEXT}}</div>
+```
+
+Pass the substituted HTML as `widget_code` per the calling rules above.
+
+### Diff widget
+
+**When**: after `suggest_edit` returns `{ suggested: true, suggestionId }`. Render every time, not just for "interesting" edits.
+
+**Compute** an inline word-level diff between the original node text and your new `content`. Both texts appear in full, side-by-side, with only the differing word runs highlighted in place — the eye skims unchanged surrounding text and lands on what changed.
+
+**Granularity**: word-level (a contiguous run of word characters or a contiguous run of punctuation). Don't mark character-level differences inside a word — for `integraton` → `integration`, mark the whole word, not just the missing `i`. For whole-paragraph rewrites where every word changed, marking the entire text as one span is acceptable.
+
+**Template** — substitute `{{OLD_TEXT}}`, `{{NEW_TEXT}}`, `{{COMMENT_BLOCK}}`:
+
+```html
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+  .prose-diff {
+    --bg: #ffffff; --text: #1a1a1a; --border: #e4e4e7; --muted: #71717a; --surface: #f4f4f5;
+    --removed-bg: #fecaca; --removed-fg: #7f1d1d;
+    --added-bg: #bbf7d0; --added-fg: #14532d;
+    font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 13px; line-height: 1.55; color: var(--text); max-width: 820px;
+  }
+  @media (prefers-color-scheme: dark) {
+    .prose-diff {
+      --bg: #18181b; --text: #fafafa; --border: #3f3f46; --muted: #a1a1aa;
+      --surface: rgba(255, 255, 255, 0.04);
+      --removed-bg: rgba(239, 68, 68, 0.30); --removed-fg: #fecaca;
+      --added-bg: rgba(34, 197, 94, 0.30); --added-fg: #bbf7d0;
+    }
+  }
+  .prose-diff__columns { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px; }
+  .prose-diff__col { display: flex; flex-direction: column; min-width: 0; }
+  .prose-diff__label { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: 8px; }
+  .prose-diff__block { border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; background: var(--bg); flex: 1; }
+  .prose-diff__text { margin: 0; white-space: pre-wrap; word-break: break-word; font-family: inherit; font-size: 13px; color: var(--text); }
+  .prose-diff__removed { background: var(--removed-bg); color: var(--removed-fg); text-decoration: line-through; text-decoration-thickness: 1px; padding: 0 2px; border-radius: 3px; }
+  .prose-diff__added { background: var(--added-bg); color: var(--added-fg); padding: 0 2px; border-radius: 3px; }
+  .prose-diff__comment { margin-bottom: 16px; padding: 10px 14px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; font-size: 13px; color: var(--text); }
+  .prose-diff__footer { font-size: 12px; color: var(--muted); }
+</style>
+<div class="prose-diff">
+  <div class="prose-diff__columns">
+    <div class="prose-diff__col">
+      <div class="prose-diff__label">Original</div>
+      <div class="prose-diff__block"><pre class="prose-diff__text">{{OLD_TEXT}}</pre></div>
+    </div>
+    <div class="prose-diff__col">
+      <div class="prose-diff__label">Suggested</div>
+      <div class="prose-diff__block"><pre class="prose-diff__text">{{NEW_TEXT}}</pre></div>
+    </div>
+  </div>
+  {{COMMENT_BLOCK}}
+  <div class="prose-diff__footer">Accept or reject in Prose's diff overlay.</div>
+</div>
+```
+
+**Substitution rules**:
+
+- `{{OLD_TEXT}}` — full original text (HTML-escape `& < > "`), then wrap each removed run with `<span class="prose-diff__removed">…</span>`. Unchanged surrounding text stays unmarked.
+- `{{NEW_TEXT}}` — full new text (HTML-escape first), then wrap each added run with `<span class="prose-diff__added">…</span>`. Unchanged text stays unmarked and matches the unmarked text in `{{OLD_TEXT}}` exactly.
+- `{{COMMENT_BLOCK}}` — empty string when no `comment` was passed to `suggest_edit`. When present:
+
+  ```html
+  <div class="prose-diff__comment">{{COMMENT}}</div>
+  ```
+
+  with `{{COMMENT}}` HTML-escaped.
+
+Pass the substituted HTML as `widget_code` per the calling rules above. Then in the conversational reply, briefly state what the change does (one sentence). Then wait for the user.
+
+### When widgets really aren't available
+
+If both `show_widget` and `visualize:show_widget` return "tool not found", render the same information as plain Markdown:
+
+- Outline → nested list using `level` for indentation.
+- Diff → describe the change in one or two sentences.
+
+## Graceful degradation
+
+| Condition | Behavior |
+|-----------|----------|
+| Prose running, MCP connected | Full assistance via MCP tools. |
+| Prose running, MCP not installed (OSS build) | "Open Prose → Settings → Integrations → Install MCP Server, then restart Claude." |
+| Mac App Store build of Prose | Sandbox blocks MCP. Offer pasted-content workflow. Don't suggest install. |
+| Prose not running | Suggest launching, or work with pasted content. |
+
+## Artifact editor — in-conversation markdown editing
+
+The Prose artifact editor is a lightweight markdown editor that runs inside Claude's artifact pane. Use it when the user wants to draft or edit markdown in the conversation without switching to the desktop app.
+
+### When to render the artifact
+
+Render the artifact when:
+
+- The user wants to draft something short-lived in the conversation ("write a README here", "help me draft this email", "can I edit this in the chat").
+- The user is iterating on a document collaboratively with you and wants to see changes as you make them.
+- The user explicitly asks for an in-chat editor or mentions they don't want to open Prose.
+- MCP is unavailable (MAS build, Prose not installed) and the user still wants to edit markdown.
+
+**Do not** render the artifact for serious editing sessions where the user has a real file open in Prose. For those, the MCP workflow (`read_document` → `suggest_edit`) is better — it lands edits directly in the user's document with diff review.
+
+### How to render the artifact
+
+Read the artifact source from `resources/prose-artifact/prose-editor.html` in this skill bundle and render it as a React artifact. The file is self-contained HTML — copy it verbatim as the artifact content. Do not wrap it in a `<!DOCTYPE html>` document or add extra boilerplate.
+
+When rendering, narrate briefly in one sentence: what the artifact is and that they can click "Open in Prose" to hand the document off to the desktop app when they're done.
+
+### What the artifact does
+
+- **Edit pane**: a textarea for raw markdown input.
+- **Preview pane**: live rendered preview via `marked` (GitHub Flavored Markdown).
+- **Split / Edit / Preview toggle**: switch between views.
+- **Copy markdown**: copies raw markdown to clipboard — works without Prose installed.
+- **Download**: downloads the markdown source as a `.md` file.
+- **Open in Prose**: fires a `prose://open?content=...` deep link. Prose desktop opens a new tab with the content. Works for all desktop users (MAS and direct download) — no MCP required. If Prose is not installed, the OS shows its standard "no app registered" dialog.
+- **Draft persistence**: the draft is saved to `window.storage` (Claude's artifact persistence API) so it survives conversation turns and page reloads.
+- **Light/dark theme**: matches system preference by default; toggle is in the toolbar.
+
+### prose:// deep link behavior
+
+The `prose://open?content=...` URL scheme is registered by Prose on first launch (`app.setAsDefaultProtocolClient('prose')`). When clicked:
+
+- macOS: routes through the `open-url` app event.
+- Windows/Linux: passes as a command-line argument on second-instance launch.
+
+Content is URL-decoded and validated by `parseProseUrl()` in Prose's main process. The 5 MB hard cap lives there — the artifact warns at 4 MB (well before the cap). Real-world drafts from a Claude conversation are typically under 50 KB.
+
+### Handoff to desktop Prose
+
+Once the user is done drafting in the artifact and wants to continue in the desktop app:
+
+1. They click "Open in Prose" — Prose opens a new tab with the content.
+2. They save the file from Prose (File → Save or Cmd+S).
+
+If they don't have Prose installed, "Copy markdown" copies the source for pasting into any editor.


### PR DESCRIPTION
## Summary

- Adds `resources/prose-artifact/prose-editor.html` — a single-file React artifact for Claude's artifact pane. Textarea + live preview (via `marked` from cdnjs), split/edit/preview toggle, IBM Plex Mono branding, light/dark theme with system preference detection.
- Adds `resources/prose-artifact/test-scaffold.html` — local development wrapper with a `window.storage` mock backed by localStorage, so the component can be iterated in a browser without the artifact runtime.
- Adds `resources/prose-skill/prose/SKILL.md` — the full skill file (carried forward from PR #437 / `issue-435-rewrite`) with a new **Artifact editor** section that teaches when to render the artifact, how to render it, and how the `prose://` handoff to the desktop works.

## Four toolbar actions

| Action | Mechanism |
|--------|-----------|
| Copy markdown | `navigator.clipboard.writeText()` — always visible, no Prose required |
| Download | `Blob` + object URL download as `.md` — markdown source, not rendered HTML |
| Open in Prose | `prose://open?content=<urlencoded>` deep link — reuses `parseProseUrl` and `setAsDefaultProtocolClient` already in `src/main/index.ts`; no new desktop code |
| Theme toggle | `data-theme` attribute on root element; follows `prefers-color-scheme` on load |

Draft persistence uses `window.storage` (artifact runtime API). Size warning appears at 4 MB; `Open in Prose` is disabled at 5 MB (matching the `MAX_URL_CONTENT_BYTES` cap in `index.ts`).

## Source location decision: option (a)

The artifact is 607 lines — well above the ~150 line threshold where inlining into SKILL.md becomes unwieldy. It lives at `resources/prose-artifact/prose-editor.html`. SKILL.md instructs the skill to read this file from the bundle and render it verbatim as a React artifact.

## Tested locally

- Opened `test-scaffold.html` via browser file:// URL and confirmed:
  - Markdown editing with live preview in split view
  - Edit / Split / Preview toggle works
  - Theme toggle switches between light and dark; `data-theme` attribute applied to `.prose-app` root (not `<html>` — artifact runtime has no `<html>` element)
  - Copy markdown button shows "Copied" feedback for 2 s
  - Download produces a `.md` file with markdown source (not HTML)
  - `prose://` URL is correctly constructed (confirmed by inspecting the `href` attribute on the "Open in Prose" anchor)
  - Draft persisted across page reloads via the localStorage-backed mock
  - Word count updates live
  - No console errors during 2-minute editing session

## Needs user end-to-end verification (cannot be done here)

1. Open the artifact in a real Claude conversation — paste `prose-editor.html` content as a React artifact and confirm it renders correctly.
2. Confirm `window.storage` persistence survives a conversation turn (not just a page reload of the test scaffold).
3. Click "Open in Prose" — confirm Prose desktop opens with the content in a new tab (requires Prose installed with `prose://` registered on the OS).
4. Confirm IBM Plex Mono loads correctly in the artifact runtime (the `<link>` to Google Fonts may be blocked by the sandbox — fallback font stack still looks correct but loses the brand font).
5. Confirm no sandbox violations in browser console during a 2-minute editing session.

## Merge note

This PR carries a full copy of SKILL.md. PR #437 (`issue-435-rewrite`) also modifies SKILL.md. When both land on `release/prose-in-claude`, there will be a merge conflict to resolve — the resolution is to keep this PR's version (which is a superset: base SKILL.md + artifact section).

Closes #445