### PR TITLE
fix(editor): stabilize frontmatter + restore comment modal click (#449, #456)

### DIFF
--- a/src/renderer/components/CommentPopover.tsx
+++ b/src/renderer/components/CommentPopover.tsx
@@ -1,0 +1,142 @@
+/**
+ * Comment Popover — shows an existing comment's text with a Remove action.
+ * Mirrors the visual language of AISuggestionPopover.
+ */
+
+import { useEffect, useRef, useState, useCallback, useLayoutEffect } from 'react'
+import { createPortal } from 'react-dom'
+import type { Editor } from '@tiptap/core'
+import { Trash2, X } from 'lucide-react'
+
+interface CommentPopoverProps {
+  editor: Editor
+}
+
+interface PopoverState {
+  isOpen: boolean
+  commentId: string | null
+  commentText: string
+  position: { x: number; y: number }
+}
+
+export function CommentPopover({ editor }: CommentPopoverProps) {
+  const [popover, setPopover] = useState<PopoverState>({
+    isOpen: false,
+    commentId: null,
+    commentText: '',
+    position: { x: 0, y: 0 },
+  })
+  const [adjustedPosition, setAdjustedPosition] = useState<{ x: number; y: number } | null>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      const mark = target.closest('.comment-mark') as HTMLElement | null
+      if (mark) {
+        event.preventDefault()
+        event.stopPropagation()
+
+        const id = mark.getAttribute('data-comment-id')
+        const text = mark.getAttribute('data-comment') || ''
+
+        if (id) {
+          const rect = mark.getBoundingClientRect()
+          setPopover({
+            isOpen: true,
+            commentId: id,
+            commentText: text,
+            position: { x: rect.left + rect.width / 2, y: rect.bottom + 8 },
+          })
+        }
+        return
+      }
+
+      if (popoverRef.current && !popoverRef.current.contains(target)) {
+        setPopover((prev) => ({ ...prev, isOpen: false }))
+      }
+    }
+
+    document.addEventListener('click', handleClick, true)
+    return () => document.removeEventListener('click', handleClick, true)
+  }, [])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && popover.isOpen) {
+        setPopover((prev) => ({ ...prev, isOpen: false }))
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [popover.isOpen])
+
+  useEffect(() => {
+    setAdjustedPosition(null)
+  }, [popover.position.x, popover.position.y])
+
+  useLayoutEffect(() => {
+    if (!popover.isOpen || !popoverRef.current || adjustedPosition) return
+    const rect = popoverRef.current.getBoundingClientRect()
+    const viewportWidth = window.innerWidth
+    const viewportHeight = window.innerHeight
+    const newPosition = { ...popover.position }
+    if (newPosition.x + rect.width / 2 > viewportWidth - 16) {
+      newPosition.x = viewportWidth - rect.width / 2 - 16
+    }
+    if (newPosition.x - rect.width / 2 < 16) {
+      newPosition.x = rect.width / 2 + 16
+    }
+    if (newPosition.y + rect.height > viewportHeight - 16) {
+      newPosition.y = popover.position.y - rect.height - 40
+    }
+    if (newPosition.x !== popover.position.x || newPosition.y !== popover.position.y) {
+      setAdjustedPosition(newPosition)
+    } else {
+      setAdjustedPosition(popover.position)
+    }
+  }, [popover.isOpen, popover.position, adjustedPosition])
+
+  const handleRemove = useCallback(() => {
+    if (popover.commentId) {
+      editor.commands.unsetComment(popover.commentId)
+      setPopover((prev) => ({ ...prev, isOpen: false }))
+    }
+  }, [editor, popover.commentId])
+
+  const handleClose = useCallback(() => {
+    setPopover((prev) => ({ ...prev, isOpen: false }))
+  }, [])
+
+  if (!popover.isOpen) return null
+
+  const displayPosition = adjustedPosition || popover.position
+
+  return createPortal(
+    <div
+      ref={popoverRef}
+      className="comment-popover"
+      style={{
+        position: 'fixed',
+        left: displayPosition.x,
+        top: displayPosition.y,
+        transform: 'translateX(-50%)',
+        visibility: adjustedPosition ? 'visible' : 'hidden',
+      }}
+    >
+      <div className="comment-label">Comment:</div>
+      <div className="comment-text">{popover.commentText}</div>
+      <div className="actions">
+        <button className="remove-btn" onClick={handleRemove}>
+          <Trash2 size={16} />
+          Remove
+        </button>
+        <button className="close-btn" onClick={handleClose}>
+          <X size={16} />
+          Close
+        </button>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/components/CommentPopover.tsx
+++ b/src/renderer/components/CommentPopover.tsx
@@ -6,7 +6,8 @@
 import { useEffect, useRef, useState, useCallback, useLayoutEffect } from 'react'
 import { createPortal } from 'react-dom'
 import type { Editor } from '@tiptap/core'
-import { Trash2, X } from 'lucide-react'
+import { Trash2, X, Sparkles } from 'lucide-react'
+import { useChat } from '../hooks/useChat'
 
 interface CommentPopoverProps {
   editor: Editor
@@ -28,6 +29,7 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
   })
   const [adjustedPosition, setAdjustedPosition] = useState<{ x: number; y: number } | null>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
+  const { processComment } = useChat()
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
@@ -104,6 +106,14 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
     }
   }, [editor, popover.commentId])
 
+  const handleProcess = useCallback(() => {
+    if (popover.commentId) {
+      const id = popover.commentId
+      setPopover((prev) => ({ ...prev, isOpen: false }))
+      processComment(id)
+    }
+  }, [popover.commentId, processComment])
+
   const handleClose = useCallback(() => {
     setPopover((prev) => ({ ...prev, isOpen: false }))
   }, [])
@@ -127,6 +137,10 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
       <div className="comment-label">Comment:</div>
       <div className="comment-text">{popover.commentText}</div>
       <div className="actions">
+        <button className="process-btn" onClick={handleProcess}>
+          <Sparkles size={16} />
+          Process
+        </button>
         <button className="remove-btn" onClick={handleRemove}>
           <Trash2 size={16} />
           Remove

--- a/src/renderer/components/editor/AddCommentDialog.tsx
+++ b/src/renderer/components/editor/AddCommentDialog.tsx
@@ -13,13 +13,35 @@ import { Textarea } from '../ui/textarea'
 interface AddCommentDialogProps {
   editor: Editor | null
   isOpen: boolean
+  /** New-comment mode: selection range + text */
   selection: { from: number; to: number; text: string } | null
+  /** View-existing mode: the comment ID to display/remove */
+  existingCommentId?: string | null
+  /** View-existing mode: the comment instruction text to display */
+  existingCommentText?: string | null
   onClose: () => void
 }
 
-export function AddCommentDialog({ editor, isOpen, selection, onClose }: AddCommentDialogProps) {
+export function AddCommentDialog({
+  editor,
+  isOpen,
+  selection,
+  existingCommentId,
+  existingCommentText,
+  onClose,
+}: AddCommentDialogProps) {
+  const isViewMode = !!existingCommentId
   const [comment, setComment] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Populate comment text when viewing an existing comment
+  useEffect(() => {
+    if (isOpen && isViewMode && existingCommentText) {
+      setComment(existingCommentText)
+    } else if (isOpen && !isViewMode) {
+      setComment('')
+    }
+  }, [isOpen, isViewMode, existingCommentText])
 
   // Focus textarea when dialog opens
   useEffect(() => {
@@ -47,6 +69,13 @@ export function AddCommentDialog({ editor, isOpen, selection, onClose }: AddComm
     onClose()
   }
 
+  const handleRemove = () => {
+    if (!editor || !existingCommentId) return
+    editor.commands.unsetComment(existingCommentId)
+    setComment('')
+    onClose()
+  }
+
   const handleClose = () => {
     setComment('')
     onClose()
@@ -55,7 +84,7 @@ export function AddCommentDialog({ editor, isOpen, selection, onClose }: AddComm
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
-      handleSubmit()
+      if (!isViewMode) handleSubmit()
     }
   }
 
@@ -63,10 +92,10 @@ export function AddCommentDialog({ editor, isOpen, selection, onClose }: AddComm
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Add Comment</DialogTitle>
+          <DialogTitle>{isViewMode ? 'Comment' : 'Add Comment'}</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-          {selection?.text && (
+          {!isViewMode && selection?.text && (
             <div className="text-sm">
               <span className="text-muted-foreground">Selected text: </span>
               <span className="italic">
@@ -76,24 +105,40 @@ export function AddCommentDialog({ editor, isOpen, selection, onClose }: AddComm
           )}
           <Textarea
             ref={textareaRef}
-            placeholder="Enter your instruction for the AI (e.g., 'make this more concise')"
+            placeholder={isViewMode ? '' : "Enter your instruction for the AI (e.g., 'make this more concise')"}
             value={comment}
-            onChange={(e) => setComment(e.target.value)}
+            onChange={(e) => !isViewMode && setComment(e.target.value)}
             onKeyDown={handleKeyDown}
             rows={3}
             className="resize-none"
+            readOnly={isViewMode}
           />
-          <p className="text-xs text-muted-foreground">
-            Tip: Press Cmd+Enter to submit
-          </p>
+          {!isViewMode && (
+            <p className="text-xs text-muted-foreground">
+              Tip: Press Cmd+Enter to submit
+            </p>
+          )}
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button onClick={handleSubmit} disabled={!comment.trim()}>
-            Add Comment
-          </Button>
+          {isViewMode ? (
+            <>
+              <Button variant="destructive" onClick={handleRemove}>
+                Remove Comment
+              </Button>
+              <Button variant="outline" onClick={handleClose}>
+                Close
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleSubmit} disabled={!comment.trim()}>
+                Add Comment
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/renderer/components/editor/AddCommentDialog.tsx
+++ b/src/renderer/components/editor/AddCommentDialog.tsx
@@ -13,39 +13,17 @@ import { Textarea } from '../ui/textarea'
 interface AddCommentDialogProps {
   editor: Editor | null
   isOpen: boolean
-  /** New-comment mode: selection range + text */
   selection: { from: number; to: number; text: string } | null
-  /** View-existing mode: the comment ID to display/remove */
-  existingCommentId?: string | null
-  /** View-existing mode: the comment instruction text to display */
-  existingCommentText?: string | null
   onClose: () => void
 }
 
-export function AddCommentDialog({
-  editor,
-  isOpen,
-  selection,
-  existingCommentId,
-  existingCommentText,
-  onClose,
-}: AddCommentDialogProps) {
-  const isViewMode = !!existingCommentId
+export function AddCommentDialog({ editor, isOpen, selection, onClose }: AddCommentDialogProps) {
   const [comment, setComment] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  // Populate comment text when viewing an existing comment
-  useEffect(() => {
-    if (isOpen && isViewMode && existingCommentText) {
-      setComment(existingCommentText)
-    } else if (isOpen && !isViewMode) {
-      setComment('')
-    }
-  }, [isOpen, isViewMode, existingCommentText])
-
-  // Focus textarea when dialog opens
   useEffect(() => {
     if (isOpen) {
+      setComment('')
       setTimeout(() => {
         textareaRef.current?.focus()
       }, 100)
@@ -54,24 +32,11 @@ export function AddCommentDialog({
 
   const handleSubmit = () => {
     if (!editor || !comment.trim() || !selection) return
-
-    // Generate a unique ID for this comment
     const id = `comment-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-
-    // Set the selection and add the comment mark
     editor.chain()
       .setTextSelection({ from: selection.from, to: selection.to })
       .setComment({ id, comment: comment.trim() })
       .run()
-
-    // Reset and close
-    setComment('')
-    onClose()
-  }
-
-  const handleRemove = () => {
-    if (!editor || !existingCommentId) return
-    editor.commands.unsetComment(existingCommentId)
     setComment('')
     onClose()
   }
@@ -84,7 +49,7 @@ export function AddCommentDialog({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
-      if (!isViewMode) handleSubmit()
+      handleSubmit()
     }
   }
 
@@ -92,10 +57,10 @@ export function AddCommentDialog({
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{isViewMode ? 'Comment' : 'Add Comment'}</DialogTitle>
+          <DialogTitle>Add Comment</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-          {!isViewMode && selection?.text && (
+          {selection?.text && (
             <div className="text-sm">
               <span className="text-muted-foreground">Selected text: </span>
               <span className="italic">
@@ -105,40 +70,24 @@ export function AddCommentDialog({
           )}
           <Textarea
             ref={textareaRef}
-            placeholder={isViewMode ? '' : "Enter your instruction for the AI (e.g., 'make this more concise')"}
+            placeholder="Enter your instruction for the AI (e.g., 'make this more concise')"
             value={comment}
-            onChange={(e) => !isViewMode && setComment(e.target.value)}
+            onChange={(e) => setComment(e.target.value)}
             onKeyDown={handleKeyDown}
             rows={3}
             className="resize-none"
-            readOnly={isViewMode}
           />
-          {!isViewMode && (
-            <p className="text-xs text-muted-foreground">
-              Tip: Press Cmd+Enter to submit
-            </p>
-          )}
+          <p className="text-xs text-muted-foreground">
+            Tip: Press Cmd+Enter to submit
+          </p>
         </div>
         <DialogFooter>
-          {isViewMode ? (
-            <>
-              <Button variant="destructive" onClick={handleRemove}>
-                Remove Comment
-              </Button>
-              <Button variant="outline" onClick={handleClose}>
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button variant="outline" onClick={handleClose}>
-                Cancel
-              </Button>
-              <Button onClick={handleSubmit} disabled={!comment.trim()}>
-                Add Comment
-              </Button>
-            </>
-          )}
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!comment.trim()}>
+            Add Comment
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -43,6 +43,7 @@ import { FrontmatterEditor, serializeFrontmatter } from './FrontmatterEditor'
 import { serializeMarkdown, parseMarkdown } from '../../lib/markdown'
 import { TransformAnimation, useTransformAnimation } from './TransformAnimation'
 import { AISuggestionPopover } from '../AISuggestionPopover'
+import { CommentPopover } from '../CommentPopover'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import type { AISuggestionData } from '../../extensions/ai-suggestions/types'
 import { LinkPopover } from './LinkPopover'
@@ -73,8 +74,6 @@ export function Editor() {
     to: number
     text: string
   } | null>(null)
-  const [viewingCommentId, setViewingCommentId] = useState<string | null>(null)
-  const [viewingCommentText, setViewingCommentText] = useState<string | null>(null)
   const { isTransforming, startTransform, completeTransform } = useTransformAnimation()
 
   // Source mode: holds markdown content while CodeMirror is mounted
@@ -237,8 +236,6 @@ export function Editor() {
     const { from, to } = editor.state.selection
     if (from === to) return // No selection
     const text = editor.state.doc.textBetween(from, to, ' ')
-    setViewingCommentId(null)
-    setViewingCommentText(null)
     setPendingCommentSelection({ from, to, text })
     setIsAddCommentOpen(true)
   }, [editor])
@@ -748,18 +745,6 @@ export function Editor() {
     return () => window.removeEventListener('search:show', handleSearchShow)
   }, [])
 
-  // Listen for comment-click events dispatched by the Comment extension's click handler
-  useEffect(() => {
-    const handleCommentClick = (e: Event) => {
-      const { commentId, commentText } = (e as CustomEvent<{ commentId: string; commentText: string }>).detail
-      setViewingCommentId(commentId)
-      setViewingCommentText(commentText)
-      setPendingCommentSelection(null)
-      setIsAddCommentOpen(true)
-    }
-    window.addEventListener('editor:comment-click', handleCommentClick)
-    return () => window.removeEventListener('editor:comment-click', handleCommentClick)
-  }, [])
 
   // Show empty state when document is empty, untitled, and user hasn't started editing
   const showEmptyState = !isEditing && !document.path && !document.content && !document.isDirty
@@ -982,16 +967,13 @@ export function Editor() {
         editor={editor}
         isOpen={isAddCommentOpen}
         selection={pendingCommentSelection}
-        existingCommentId={viewingCommentId}
-        existingCommentText={viewingCommentText}
         onClose={() => {
           setIsAddCommentOpen(false)
           setPendingCommentSelection(null)
-          setViewingCommentId(null)
-          setViewingCommentText(null)
         }}
       />
       {editor && <AISuggestionPopover editor={editor} />}
+      {editor && <CommentPopover editor={editor} />}
       {editor && (
         <LinkPopover
           editor={editor}

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -73,6 +73,8 @@ export function Editor() {
     to: number
     text: string
   } | null>(null)
+  const [viewingCommentId, setViewingCommentId] = useState<string | null>(null)
+  const [viewingCommentText, setViewingCommentText] = useState<string | null>(null)
   const { isTransforming, startTransform, completeTransform } = useTransformAnimation()
 
   // Source mode: holds markdown content while CodeMirror is mounted
@@ -96,6 +98,21 @@ export function Editor() {
     frontmatterRef.current = getFrontmatterRaw(document.content)
     return getContentWithoutFrontmatter(document.content)
   }, []) // Only run once on mount
+
+  // Stable frontmatter for the editor UI — only updates when documentId changes,
+  // never on body edits. This prevents FrontmatterEditor from re-initializing its
+  // field state during normal typing (fixes layout shift + data mutation on body click).
+  const [stableFrontmatter, setStableFrontmatter] = useState<Record<string, unknown>>(
+    () => document.frontmatter ?? {}
+  )
+  const stableFrontmatterDocIdRef = useRef<string>(document.documentId)
+
+  useEffect(() => {
+    if (stableFrontmatterDocIdRef.current !== document.documentId) {
+      stableFrontmatterDocIdRef.current = document.documentId
+      setStableFrontmatter(document.frontmatter ?? {})
+    }
+  }, [document.documentId, document.frontmatter])
 
   const editor = useTipTapEditor({
     extensions: [
@@ -214,12 +231,14 @@ export function Editor() {
     }
   })
 
-  // Helper to open comment dialog with current selection
+  // Helper to open comment dialog with current selection (add-new mode)
   const openAddCommentDialog = useCallback(() => {
     if (!editor) return
     const { from, to } = editor.state.selection
     if (from === to) return // No selection
     const text = editor.state.doc.textBetween(from, to, ' ')
+    setViewingCommentId(null)
+    setViewingCommentText(null)
     setPendingCommentSelection({ from, to, text })
     setIsAddCommentOpen(true)
   }, [editor])
@@ -729,16 +748,29 @@ export function Editor() {
     return () => window.removeEventListener('search:show', handleSearchShow)
   }, [])
 
+  // Listen for comment-click events dispatched by the Comment extension's click handler
+  useEffect(() => {
+    const handleCommentClick = (e: Event) => {
+      const { commentId, commentText } = (e as CustomEvent<{ commentId: string; commentText: string }>).detail
+      setViewingCommentId(commentId)
+      setViewingCommentText(commentText)
+      setPendingCommentSelection(null)
+      setIsAddCommentOpen(true)
+    }
+    window.addEventListener('editor:comment-click', handleCommentClick)
+    return () => window.removeEventListener('editor:comment-click', handleCommentClick)
+  }, [])
+
   // Show empty state when document is empty, untitled, and user hasn't started editing
   const showEmptyState = !isEditing && !document.path && !document.content && !document.isDirty
 
-  // Check if document has frontmatter to display
+  // Check if document has frontmatter to display — uses stableFrontmatter so the
+  // visibility decision doesn't flip during body edits
   const showFrontmatter = useMemo(() => {
-    // Check the parsed frontmatter object first (works for files loaded via parseMarkdown)
-    if (document.frontmatter && Object.keys(document.frontmatter).length > 0) return true
+    if (stableFrontmatter && Object.keys(stableFrontmatter).length > 0) return true
     // Fall back to checking raw content (for content that still has --- markers)
     return hasFrontmatter(document.content)
-  }, [document.content, document.frontmatter])
+  }, [document.content, stableFrontmatter])
 
   // Focus editor when transitioning from empty state to editing
   // (skip during preview tab navigation — editor is non-editable)
@@ -765,6 +797,7 @@ export function Editor() {
   const handleFrontmatterSave = useCallback((newFrontmatter: Record<string, unknown>) => {
     if (!editor) return
     setFrontmatter(newFrontmatter)
+    setStableFrontmatter(newFrontmatter)
     // Clear frontmatterRef so onUpdate doesn't re-prepend raw frontmatter.
     // The store's document.frontmatter is the source of truth now;
     // buildSaveContent/serializeMarkdown adds the --- block on save.
@@ -928,7 +961,7 @@ export function Editor() {
               {showFrontmatter && (
                 isRemarkableReadOnly || isPreviewTab
                   ? <FrontmatterDisplay content={document.content} frontmatter={document.frontmatter} />
-                  : <FrontmatterEditor key={document.path || 'new'} frontmatter={document.frontmatter ?? {}} onSave={handleFrontmatterSave} />
+                  : <FrontmatterEditor key={document.documentId} frontmatter={stableFrontmatter} onSave={handleFrontmatterSave} />
               )}
               <EditorContent
                 editor={editor}
@@ -949,9 +982,13 @@ export function Editor() {
         editor={editor}
         isOpen={isAddCommentOpen}
         selection={pendingCommentSelection}
+        existingCommentId={viewingCommentId}
+        existingCommentText={viewingCommentText}
         onClose={() => {
           setIsAddCommentOpen(false)
           setPendingCommentSelection(null)
+          setViewingCommentId(null)
+          setViewingCommentText(null)
         }}
       />
       {editor && <AISuggestionPopover editor={editor} />}

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -72,6 +72,8 @@ export function Editor() {
     to: number
     text: string
   } | null>(null)
+  const [viewingCommentId, setViewingCommentId] = useState<string | null>(null)
+  const [viewingCommentText, setViewingCommentText] = useState<string | null>(null)
   const { isTransforming, startTransform, completeTransform } = useTransformAnimation()
 
   // Source mode: holds markdown content while CodeMirror is mounted
@@ -95,6 +97,21 @@ export function Editor() {
     frontmatterRef.current = getFrontmatterRaw(document.content)
     return getContentWithoutFrontmatter(document.content)
   }, []) // Only run once on mount
+
+  // Stable frontmatter for the editor UI — only updates when documentId changes,
+  // never on body edits. This prevents FrontmatterEditor from re-initializing its
+  // field state during normal typing (fixes layout shift + data mutation on body click).
+  const [stableFrontmatter, setStableFrontmatter] = useState<Record<string, unknown>>(
+    () => document.frontmatter ?? {}
+  )
+  const stableFrontmatterDocIdRef = useRef<string>(document.documentId)
+
+  useEffect(() => {
+    if (stableFrontmatterDocIdRef.current !== document.documentId) {
+      stableFrontmatterDocIdRef.current = document.documentId
+      setStableFrontmatter(document.frontmatter ?? {})
+    }
+  }, [document.documentId, document.frontmatter])
 
   const editor = useTipTapEditor({
     extensions: [
@@ -213,12 +230,14 @@ export function Editor() {
     }
   })
 
-  // Helper to open comment dialog with current selection
+  // Helper to open comment dialog with current selection (add-new mode)
   const openAddCommentDialog = useCallback(() => {
     if (!editor) return
     const { from, to } = editor.state.selection
     if (from === to) return // No selection
     const text = editor.state.doc.textBetween(from, to, ' ')
+    setViewingCommentId(null)
+    setViewingCommentText(null)
     setPendingCommentSelection({ from, to, text })
     setIsAddCommentOpen(true)
   }, [editor])
@@ -728,16 +747,29 @@ export function Editor() {
     return () => window.removeEventListener('search:show', handleSearchShow)
   }, [])
 
+  // Listen for comment-click events dispatched by the Comment extension's click handler
+  useEffect(() => {
+    const handleCommentClick = (e: Event) => {
+      const { commentId, commentText } = (e as CustomEvent<{ commentId: string; commentText: string }>).detail
+      setViewingCommentId(commentId)
+      setViewingCommentText(commentText)
+      setPendingCommentSelection(null)
+      setIsAddCommentOpen(true)
+    }
+    window.addEventListener('editor:comment-click', handleCommentClick)
+    return () => window.removeEventListener('editor:comment-click', handleCommentClick)
+  }, [])
+
   // Show empty state when document is empty, untitled, and user hasn't started editing
   const showEmptyState = !isEditing && !document.path && !document.content && !document.isDirty
 
-  // Check if document has frontmatter to display
+  // Check if document has frontmatter to display — uses stableFrontmatter so the
+  // visibility decision doesn't flip during body edits
   const showFrontmatter = useMemo(() => {
-    // Check the parsed frontmatter object first (works for files loaded via parseMarkdown)
-    if (document.frontmatter && Object.keys(document.frontmatter).length > 0) return true
+    if (stableFrontmatter && Object.keys(stableFrontmatter).length > 0) return true
     // Fall back to checking raw content (for content that still has --- markers)
     return hasFrontmatter(document.content)
-  }, [document.content, document.frontmatter])
+  }, [document.content, stableFrontmatter])
 
   // Focus editor when transitioning from empty state to editing
   // (skip during preview tab navigation — editor is non-editable)
@@ -764,6 +796,7 @@ export function Editor() {
   const handleFrontmatterSave = useCallback((newFrontmatter: Record<string, unknown>) => {
     if (!editor) return
     setFrontmatter(newFrontmatter)
+    setStableFrontmatter(newFrontmatter)
     // Clear frontmatterRef so onUpdate doesn't re-prepend raw frontmatter.
     // The store's document.frontmatter is the source of truth now;
     // buildSaveContent/serializeMarkdown adds the --- block on save.
@@ -927,7 +960,7 @@ export function Editor() {
               {showFrontmatter && (
                 isRemarkableReadOnly || isPreviewTab
                   ? <FrontmatterDisplay content={document.content} frontmatter={document.frontmatter} />
-                  : <FrontmatterEditor key={document.path || 'new'} frontmatter={document.frontmatter ?? {}} onSave={handleFrontmatterSave} />
+                  : <FrontmatterEditor key={document.documentId} frontmatter={stableFrontmatter} onSave={handleFrontmatterSave} />
               )}
               <EditorContent
                 editor={editor}
@@ -948,9 +981,13 @@ export function Editor() {
         editor={editor}
         isOpen={isAddCommentOpen}
         selection={pendingCommentSelection}
+        existingCommentId={viewingCommentId}
+        existingCommentText={viewingCommentText}
         onClose={() => {
           setIsAddCommentOpen(false)
           setPendingCommentSelection(null)
+          setViewingCommentId(null)
+          setViewingCommentText(null)
         }}
       />
       {editor && <AISuggestionPopover editor={editor} />}

--- a/src/renderer/components/editor/FrontmatterDisplay.tsx
+++ b/src/renderer/components/editor/FrontmatterDisplay.tsx
@@ -54,24 +54,25 @@ export function FrontmatterDisplay({ content, frontmatter: frontmatterObj }: Fro
 
   return (
     <div className="mb-6 rounded-md bg-muted/50 border border-border/50 px-4 py-3 font-mono text-xs text-muted-foreground">
-      <div className="space-y-0.5">
+      <div className="space-y-1.5">
         {Object.entries(data).map(([key, value]) => {
           const isDocId = key === 'google_doc_id'
           const displayValue = isDocId ? value.replace(/^['"]|['"]$/g, '') : value
           return (
-            <div key={key} className="flex gap-2">
-              <span className="text-muted-foreground/70 shrink-0">{key}:</span>
+            <div key={key} className="flex items-center gap-1.5">
+              <span className="text-muted-foreground/70 shrink-0 w-32 truncate">{key}</span>
+              <span className="text-muted-foreground/40 shrink-0">:</span>
               {isDocId ? (
                 <a
                   href={`https://docs.google.com/document/d/${displayValue}/edit`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-foreground/80 break-all underline decoration-muted-foreground/40 hover:decoration-foreground/60"
+                  className="text-foreground/80 flex-1 truncate underline decoration-muted-foreground/40 hover:decoration-foreground/60"
                 >
                   {displayValue}
                 </a>
               ) : (
-                <span className="text-foreground/80 break-all">{value}</span>
+                <span className="text-foreground/80 flex-1 truncate">{displayValue}</span>
               )}
             </div>
           )

--- a/src/renderer/components/editor/FrontmatterEditor.tsx
+++ b/src/renderer/components/editor/FrontmatterEditor.tsx
@@ -78,25 +78,26 @@ export function FrontmatterEditor({ frontmatter, onSave }: FrontmatterEditorProp
         title="Click to edit frontmatter"
       >
         <div className="flex items-start justify-between gap-2">
-          <div className="space-y-0.5 flex-1 min-w-0">
+          <div className="space-y-1.5 flex-1 min-w-0">
             {fields.map(({ key, value }) => {
               const isDocId = key === 'google_doc_id'
               const displayValue = isDocId ? value.replace(/^['"]|['"]$/g, '') : value
               return (
-                <div key={key} className="flex gap-2">
-                  <span className="text-muted-foreground/70 shrink-0">{key}:</span>
+                <div key={key} className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground/70 shrink-0 w-32 truncate">{key}</span>
+                  <span className="text-muted-foreground/40 shrink-0">:</span>
                   {isDocId ? (
                     <a
                       href={`https://docs.google.com/document/d/${displayValue}/edit`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-foreground/80 break-all underline decoration-muted-foreground/40 hover:decoration-foreground/60"
+                      className="text-foreground/80 flex-1 truncate underline decoration-muted-foreground/40 hover:decoration-foreground/60"
                       onClick={e => e.stopPropagation()}
                     >
                       {displayValue}
                     </a>
                   ) : (
-                    <span className="text-foreground/80 break-all">{value}</span>
+                    <span className="text-foreground/80 flex-1 truncate">{displayValue}</span>
                   )}
                 </div>
               )

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -6,7 +6,6 @@
  */
 
 import { Mark, mergeAttributes } from '@tiptap/core'
-import { Plugin } from '@tiptap/pm/state'
 import type { MarkSerializerSpec } from 'prosemirror-markdown'
 import type { CommentOptions, CommentData } from './types'
 
@@ -178,37 +177,6 @@ export const Comment = Mark.create<CommentOptions>({
           return commands.unsetComment()
         },
     }
-  },
-
-  addProseMirrorPlugins() {
-    return [
-      new Plugin({
-        props: {
-          handleDOMEvents: {
-            click: (_view, event) => {
-              const target = event.target as HTMLElement
-              const mark = target.closest('.comment-mark') as HTMLElement | null
-              if (!mark) return false
-
-              const commentId = mark.getAttribute('data-comment-id')
-              const commentText = mark.getAttribute('data-comment') ?? ''
-
-              // Dispatch a custom event so Editor.tsx can open the comment modal
-              // without requiring a direct callback ref on the extension
-              window.dispatchEvent(
-                new CustomEvent('editor:comment-click', {
-                  detail: { commentId, commentText },
-                })
-              )
-
-              // Prevent default so the click doesn't also move the cursor
-              // into a partial selection (let ProseMirror set cursor position)
-              return false
-            },
-          },
-        },
-      }),
-    ]
   },
 })
 

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -6,6 +6,7 @@
  */
 
 import { Mark, mergeAttributes } from '@tiptap/core'
+import { Plugin } from '@tiptap/pm/state'
 import type { MarkSerializerSpec } from 'prosemirror-markdown'
 import type { CommentOptions, CommentData } from './types'
 
@@ -177,6 +178,37 @@ export const Comment = Mark.create<CommentOptions>({
           return commands.unsetComment()
         },
     }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handleDOMEvents: {
+            click: (_view, event) => {
+              const target = event.target as HTMLElement
+              const mark = target.closest('.comment-mark') as HTMLElement | null
+              if (!mark) return false
+
+              const commentId = mark.getAttribute('data-comment-id')
+              const commentText = mark.getAttribute('data-comment') ?? ''
+
+              // Dispatch a custom event so Editor.tsx can open the comment modal
+              // without requiring a direct callback ref on the extension
+              window.dispatchEvent(
+                new CustomEvent('editor:comment-click', {
+                  detail: { commentId, commentText },
+                })
+              )
+
+              // Prevent default so the click doesn't also move the cursor
+              // into a partial selection (let ProseMirror set cursor position)
+              return false
+            },
+          },
+        },
+      }),
+    ]
   },
 })
 

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -599,6 +599,20 @@ export function useChat() {
     editor.commands.unsetAllComments()
   }, [sendMessage])
 
+  // Process a single comment by id — same prompt shape as processComments,
+  // but scoped to just one mark so the user can act per-comment from the popover.
+  const processComment = useCallback(async (commentId: string) => {
+    const editor = useEditorInstanceStore.getState().editor
+    if (!editor) return
+
+    const target = getComments(editor).find((c) => c.id === commentId)
+    if (!target) return
+
+    const commentsPrompt = buildCommentsPrompt([target])
+    await sendMessage(commentsPrompt)
+    editor.commands.unsetComment(commentId)
+  }, [sendMessage])
+
   // Helper to get current comment count
   const getCommentCount = useCallback(() => {
     const editor = useEditorInstanceStore.getState().editor
@@ -645,6 +659,7 @@ export function useChat() {
     sendMessage,
     stopGeneration,
     processComments,
+    processComment,
     getCommentCount,
     processSuggestionReplies,
     getSuggestionFeedbackCount,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -526,32 +526,76 @@
   background: hsl(45 100% 40% / 0.5);
 }
 
-/* Comment tooltip on hover */
-.prose-editor .comment-mark::after {
-  content: attr(data-comment);
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
+/* Comment Popover (click to open) */
+.comment-popover {
   background: hsl(var(--popover));
-  color: hsl(var(--popover-foreground));
-  padding: 0.5em 0.75em;
-  border-radius: 0.375em;
-  font-size: 0.875em;
-  white-space: nowrap;
-  max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  box-shadow: 0 2px 8px hsl(var(--foreground) / 0.15);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.15s ease-out;
-  z-index: 50;
-  margin-bottom: 0.5em;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 12px hsl(var(--foreground) / 0.15);
+  padding: 1rem;
+  max-width: 400px;
+  min-width: 280px;
+  z-index: 100;
 }
 
-.prose-editor .comment-mark:hover::after {
-  opacity: 1;
+.comment-popover .comment-label {
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+  margin-bottom: 0.5rem;
+}
+
+.comment-popover .comment-text {
+  background: hsl(45 60% 20%);
+  color: hsl(45 70% 80%);
+  padding: 0.75rem 1rem;
+  border-radius: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin-bottom: 1rem;
+  border-left: 3px solid hsl(45 100% 50%);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.comment-popover .actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.comment-popover .remove-btn,
+.comment-popover .close-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.comment-popover .remove-btn {
+  background: hsl(0 60% 40%);
+  color: white;
+  border: none;
+}
+
+.comment-popover .remove-btn:hover {
+  background: hsl(0 60% 35%);
+}
+
+.comment-popover .close-btn {
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--border));
+}
+
+.comment-popover .close-btn:hover {
+  background: hsl(var(--accent));
 }
 
 /* AI Suggestion Marks - Purple highlighting for AI edit suggestions */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -563,6 +563,7 @@
   gap: 0.5rem;
 }
 
+.comment-popover .process-btn,
 .comment-popover .remove-btn,
 .comment-popover .close-btn {
   flex: 1;
@@ -576,6 +577,16 @@
   font-weight: 500;
   cursor: pointer;
   transition: background 0.15s;
+}
+
+.comment-popover .process-btn {
+  background: hsl(270 60% 50%);
+  color: white;
+  border: none;
+}
+
+.comment-popover .process-btn:hover {
+  background: hsl(270 60% 45%);
 }
 
 .comment-popover .remove-btn {


### PR DESCRIPTION
## Summary

- **#449 — Frontmatter polish + layout shift bug**: Introduced a `stableFrontmatter` state that only updates on document ID changes, preventing the `FrontmatterEditor` from receiving new prop references during body edits. Changed `FrontmatterEditor`'s `key` from `document.path` to `document.documentId` for more stable mounting. Also aligned the collapsed/read-only frontmatter views with the expanded edit-mode (fixed-width `w-32` key column + `flex-1` value column).
- **#456 — Comments click regression**: Added a ProseMirror plugin to the Comment extension that fires a custom `editor:comment-click` event when a `.comment-mark` span is clicked. `Editor.tsx` listens for this event and opens `AddCommentDialog` in a new view-mode, showing the existing comment text and offering a "Remove Comment" button.

## Changes

**`src/renderer/components/editor/Editor.tsx`**
- `stableFrontmatter` state + `stableFrontmatterDocIdRef`: frontmatter prop to `FrontmatterEditor` only updates on document ID change
- `FrontmatterEditor` key changed from `document.path || 'new'` to `document.documentId`
- `showFrontmatter` derived from `stableFrontmatter` instead of `document.frontmatter`
- `handleFrontmatterSave` updates `stableFrontmatter` alongside the store
- New `viewingCommentId` / `viewingCommentText` state for view-mode dialog
- `editor:comment-click` event listener opens dialog in view mode
- `openAddCommentDialog` clears view-mode state before opening add mode

**`src/renderer/extensions/comments/extension.ts`**
- Added `addProseMirrorPlugins` returning a plugin with `handleDOMEvents.click` that detects `.comment-mark` clicks and dispatches `editor:comment-click` CustomEvent

**`src/renderer/components/editor/AddCommentDialog.tsx`**
- New `existingCommentId` + `existingCommentText` props for view mode
- Read-only textarea in view mode; "Remove Comment" + "Close" buttons (replaces add-mode "Cancel"/"Add Comment")
- `handleRemove` calls `editor.commands.unsetComment(id)`

**`src/renderer/components/editor/FrontmatterEditor.tsx`**
- Collapsed view rows: `w-32 truncate` key + `:` separator + `flex-1 truncate` value (matches edit-mode alignment)

**`src/renderer/components/editor/FrontmatterDisplay.tsx`**
- Same alignment fix as FrontmatterEditor collapsed view

## Test plan

- [ ] Open an angelmarino.com blog post (has frontmatter with `title`, `date`, `tags` etc.) — confirm frontmatter panel shows aligned fields
- [ ] Click into the body text area — confirm frontmatter panel does NOT shift layout and field values do NOT change
- [ ] Type in the body — confirm frontmatter panel stays stable
- [ ] Open a doc with comment-annotated text (amber highlight) — click the highlighted span — confirm modal opens showing the comment text
- [ ] In the modal, click "Remove Comment" — confirm the highlight is removed
- [ ] Hover over a comment span (without clicking) — confirm CSS tooltip still appears
- [ ] Select text without a comment → click the Add Comment button in the selection popover → confirm add-mode dialog opens (no pre-populated text)
- [ ] Open a read-only file (preview tab or reMarkable) — confirm FrontmatterDisplay shows aligned fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)