### PR TITLE
fix(editor): use Electron native clipboard for Copy Markdown (#481)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, app, shell, BrowserWindow } from 'electron'
+import { ipcMain, dialog, app, shell, BrowserWindow, clipboard } from 'electron'
 import { IS_MAS_BUILD } from './env'
 import { readFile, writeFile, mkdir, access, rename, unlink, readdir, stat, copyFile } from 'fs/promises'
 import { join, dirname, normalize, isAbsolute } from 'path'
@@ -1528,6 +1528,10 @@ export function setupIpcHandlers(): void {
         error: error instanceof Error ? error.message : 'Unknown error'
       }
     }
+  })
+
+  ipcMain.handle('clipboard:writeText', async (_event, text: string) => {
+    clipboard.writeText(text)
   })
 
   ipcMain.handle('skill:download', async (): Promise<{ success: boolean; error?: string }> => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -263,6 +263,8 @@ export interface ElectronAPI {
   // Recent files
   refreshRecentMenu: () => Promise<void>
   clearRecentFiles: () => Promise<void>
+  // Clipboard
+  copyToClipboard: (text: string) => Promise<void>
   // Sentry error tracking
   sentrySetEnabled: (enabled: boolean) => Promise<void>
   // prose:// URL scheme — open content as a new document
@@ -508,6 +510,8 @@ const api: ElectronAPI = {
   // Recent files
   refreshRecentMenu: () => ipcRenderer.invoke('recentFiles:refreshMenu'),
   clearRecentFiles: () => ipcRenderer.invoke('recentFiles:clear'),
+  // Clipboard (routes through main process, bypasses web Permissions Policy)
+  copyToClipboard: (text: string) => ipcRenderer.invoke('clipboard:writeText', text),
   // Sentry error tracking
   sentrySetEnabled: (enabled: boolean) => ipcRenderer.invoke('sentry:setEnabled', enabled),
   // prose:// URL scheme — open content as a new document

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -47,6 +47,7 @@ import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import type { AISuggestionData } from '../../extensions/ai-suggestions/types'
 import { LinkPopover } from './LinkPopover'
 import { SourceEditor, SourceEditorHandle } from './SourceEditor'
+import { getApi } from '../../lib/browserApi'
 
 export function Editor() {
   const { document, setContent, openFile, saveFile } = useEditor()
@@ -519,7 +520,7 @@ export function Editor() {
       e.preventDefault()
       const content = useEditorStore.getState().document.content
       if (content) {
-        navigator.clipboard.writeText(content)
+        getApi().copyToClipboard(content)
       }
     } else if (isMod && e.shiftKey && e.key.toLowerCase() === 'h') {
       // Cmd+Shift+H: Toggle file list (JS fallback for macOS menu accelerator)

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -43,6 +43,7 @@ import { usePanelLayout, PanelLayoutProvider } from '../../hooks/usePanelLayout'
 import type { ImperativePanelHandle } from 'react-resizable-panels'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
+import { getApi } from '../../lib/browserApi'
 import { useChatStore, setCurrentDocumentId } from '../../stores/chatStore'
 import { useTabStore, createTab, restoreSession, clearSavedSession, hasUnsavedTabs } from '../../stores/tabStore'
 import { useFileListStore } from '../../stores/fileListStore'
@@ -777,7 +778,7 @@ export function App() {
           break
         case 'copyMarkdown': {
           const content = useEditorStore.getState().document.content
-          if (content) navigator.clipboard.writeText(content)
+          if (content) getApi().copyToClipboard(content)
           break
         }
         case 'addComment':

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -140,7 +140,7 @@ export function Toolbar() {
   const handleCopy = async () => {
     if (!document.content) return
     try {
-      await navigator.clipboard.writeText(document.content)
+      await getApi().copyToClipboard(document.content)
       setHasCopied(true)
       setTimeout(() => setHasCopied(false), 2000)
     } catch (err) {

--- a/src/renderer/components/ui/copy-button.tsx
+++ b/src/renderer/components/ui/copy-button.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Check, Copy } from 'lucide-react'
 import { cn } from '../../lib/utils'
+import { getApi } from '../../lib/browserApi'
 import { Button } from './button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip'
 
@@ -14,7 +15,7 @@ export function CopyButton({ value, className, ...props }: CopyButtonProps) {
 
   const handleCopy = React.useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(value)
+      await getApi().copyToClipboard(value)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch (error) {

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -455,6 +455,9 @@ export const browserApi: ElectronAPI = {
   refreshRecentMenu: async (): Promise<void> => {},
   clearRecentFiles: async (): Promise<void> => {},
 
+  // Clipboard - use browser API in web mode
+  copyToClipboard: async (text: string): Promise<void> => { await navigator.clipboard.writeText(text) },
+
   // Sentry error tracking - no-op in browser mode
   sentrySetEnabled: async (): Promise<void> => {},
 

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -430,6 +430,8 @@ export interface ElectronAPI {
   // Recent files
   getRecentFiles: () => Promise<string[]>
   clearRecentFiles: () => Promise<void>
+  // Clipboard
+  copyToClipboard: (text: string) => Promise<void>
   // Sentry error tracking
   sentrySetEnabled: (enabled: boolean) => Promise<void>
   // prose:// URL scheme — open content as a new document


### PR DESCRIPTION
navigator.clipboard.writeText() silently fails in Electron's sandboxed renderer due to missing user activation (especially when triggered via menu accelerator IPC). Route all clipboard writes through an IPC handler in the main process, which has unrestricted clipboard access.