### PR TITLE
ci(web-e2e): generate build info before web build

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -81,6 +81,12 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
+      # Explicit so fork PRs / older branches without #484 still build.
+      # main's build:web now chains build:buildinfo internally too — this step is
+      # redundant for branches that contain that fix, but harmless.
+      - name: Generate build info
+        run: npm run build:buildinfo
+
       - name: Build web app
         run: npm run build:web
 


### PR DESCRIPTION
Adds an explicit `npm run build:buildinfo` step before `Build web app` in web-e2e.yml.

#484 fixed `build:web` in package.json to chain `build:buildinfo` internally, but CI checks out the PR's branch — so any branch that predates #484 (including fork PRs that haven't rebased) still runs the old `build:web` that doesn't generate `buildInfo.generated.ts`. The web build then fails to resolve the import in `AboutDialog.tsx`. Surfaced again on `/test` for #482 just now.

This makes web-e2e independent of the branch's package.json. Redundant for branches that contain #484's fix; harmless either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)