### PR TITLE
ci(ci-gate): look up PR by head SHA for fork contributors

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -21,12 +21,23 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Same-repo PRs populate workflow_run.pull_requests directly.
+            // Fork PRs do NOT — GitHub omits them from that array. Fall back
+            // to a SHA search so auto-review still triggers for fork contributors.
             const prs = context.payload.workflow_run.pull_requests;
-            if (!prs || prs.length === 0) {
-              core.info('No PR associated with this workflow run');
+            if (prs && prs.length > 0) {
+              core.setOutput('number', prs[0].number);
               return;
             }
-            core.setOutput('number', prs[0].number);
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr sha:${headSha}`,
+            });
+            if (data.items.length === 0) {
+              core.info(`No PR found for head SHA ${headSha}`);
+              return;
+            }
+            core.setOutput('number', data.items[0].number);
 
       - name: Check for duplicate or recent review
         if: steps.pr.outputs.number


### PR DESCRIPTION
## Summary

`workflow_run.pull_requests` is empty for fork PRs — [GitHub explicitly omits them](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run). When a fork PR's E2E run passed, ci-gate's `Get PR number` step exited early, and the auto-review trigger was silently skipped. The ci-gate run reported `success` because the no-PR path is a no-op, not a failure — masking the bug entirely.

This is the third pipeline bug surfaced by #482 (Robby's first contribution from `robbylucia/prose`), after [#483](https://github.com/solo-ist/prose/pull/483) (fork checkout) and [#484](https://github.com/solo-ist/prose/pull/484)/[#485](https://github.com/solo-ist/prose/pull/485) (web build self-containment). Each prior fix moved the failure one step further down the pipeline.

## Behavior

| PR source | Before | After |
|-----------|--------|-------|
| Same repo | ✅ auto-review fires after E2E passes | ✅ unchanged (`pull_requests` populated, fast path) |
| Fork | ❌ auto-review never fires (silent skip) | ✅ fallback SHA search finds the PR |

Fast path for same-repo PRs is preserved — the SHA search only runs when `workflow_run.pull_requests` is empty.

## Test plan

- [ ] Merge, then push another empty commit to #482 to retrigger `pull_request` → E2E → ci-gate → expect auto-review comment to appear on #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)