### PR TITLE
fix: post-merge bug batch (#489, #490, #491, #492)

### DIFF
--- a/src/renderer/components/CommentPopover.tsx
+++ b/src/renderer/components/CommentPopover.tsx
@@ -40,17 +40,21 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
         event.stopPropagation()
 
         const id = mark.getAttribute('data-comment-id')
-        const text = mark.getAttribute('data-comment') || ''
-
-        if (id) {
-          const rect = mark.getBoundingClientRect()
-          setPopover({
-            isOpen: true,
-            commentId: id,
-            commentText: text,
-            position: { x: rect.left + rect.width / 2, y: rect.bottom + 8 },
-          })
+        if (!id) {
+          // Malformed mark — the Comment extension's renderHTML drops the
+          // attribute when attrs.id is falsy. Warn loudly so the source of
+          // the bad mark is debuggable, but don't silently swallow the click.
+          console.warn('[CommentPopover] comment-mark clicked with no data-comment-id', mark)
+          return
         }
+        const text = mark.getAttribute('data-comment') || ''
+        const rect = mark.getBoundingClientRect()
+        setPopover({
+          isOpen: true,
+          commentId: id,
+          commentText: text,
+          position: { x: rect.left + rect.width / 2, y: rect.bottom + 8 },
+        })
         return
       }
 

--- a/src/renderer/extensions/node-ids/index.ts
+++ b/src/renderer/extensions/node-ids/index.ts
@@ -213,7 +213,13 @@ function collectNodes(
 export function getNodesWithIds(
   doc: import('@tiptap/pm/model').Node
 ): NodeWithId[] {
-  return collectNodes(doc, 0, doc)
+  // pos = -1 so the first top-level child's childPos = -1 + 0 + 1 = 0, matching
+  // ProseMirror's content-position semantics for the doc root (which, unlike
+  // inner container nodes, has no opening token to skip). Without this,
+  // doc.resolve(childPos) lands one position too deep inside top-level paragraphs
+  // and the listItem-skip filter below never fires — re-introducing the
+  // duplication this walker was rewritten to eliminate. See #458, #489.
+  return collectNodes(doc, -1, doc)
 }
 
 /**

--- a/src/renderer/lib/tools/executors/document.ts
+++ b/src/renderer/lib/tools/executors/document.ts
@@ -12,6 +12,7 @@ import { getNodesWithIds, findNodeById } from '../../../extensions/node-ids'
 import type { NodeWithId } from '../../../extensions/node-ids'
 import { getComments } from '../../../extensions/comments'
 import { getAISuggestions } from '../../../extensions/ai-suggestions'
+import { isEditorReadOnly } from './editor'
 import { getApi } from '../../browserApi'
 import { generateId } from '../../persistence'
 
@@ -379,6 +380,10 @@ export function executeAddComment(args: {
     return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
   }
 
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
+  }
+
   const { nodeId, comment } = args
   let from = args.from
   let to = args.to
@@ -440,6 +445,10 @@ export function executeResolveComment(args: {
 
   if (!editor) {
     return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
+  }
+
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
   const { id } = args

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -27,9 +27,10 @@ function getEditor(): Editor | null {
 
 /**
  * Check if the editor is in a read-only mode (reMarkable OCR or preview tab).
- * AI tools should not mutate the document in these modes.
+ * AI tools should not mutate the document in these modes. Exported so that
+ * document-tool executors (add_comment, resolve_comment) can apply the same gate.
  */
-function isEditorReadOnly(): boolean {
+export function isEditorReadOnly(): boolean {
   const state = useEditorStore.getState()
   return state.isRemarkableReadOnly || state.isPreviewTab
 }

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -320,9 +320,15 @@ export function executeSuggestEdit(
   if (content.trimStart().startsWith('---')) {
     const { content: body, frontmatter } = parseMarkdown(content)
     if (Object.keys(frontmatter).length > 0) {
+      // Real frontmatter — apply it to the store and use the stripped body
+      // as the suggestion content.
       useEditorStore.getState().setFrontmatter(frontmatter)
+      content = body
     }
-    content = body
+    // If parseMarkdown matched the regex but yielded no keys (e.g., bare
+    // string YAML, malformed YAML, or a deliberate thematic break followed
+    // by prose), leave content untouched. Otherwise we'd silently drop the
+    // ---...--- block from the suggestion. See #490.
   }
 
   // Find the node by ID, fall back to content matching if stale


### PR DESCRIPTION
## Summary

Four bugs surfaced via post-merge claude-bot reviews on PRs #479 and #480 (yesterday's Do First sweep). All four are small, scoped, and bundled here so 1.1.1 can ship clean.

| Bug | Severity | Fix |
|---|---|---|
| #489 | **Critical** — defeats #458 | `collectNodes(doc, -1, doc)` so root-level positions don't shift +1. Without this, the paragraph-in-listItem skip never fires and every listItem ends up with a duplicate inner paragraph in `read_document` output. |
| #490 | Data loss | Move `content = body` inside the keys-non-empty guard in `executeSuggestEdit` so malformed YAML doesn't silently strip a real body. |
| #491 | Privilege bypass | Export `isEditorReadOnly` from `editor.ts` and gate `executeAddComment` / `executeResolveComment` with it — they were the only mutation tools bypassing the read-only check. |
| #492 | Defensive | Surface `console.warn` instead of silent no-op when a comment-mark is clicked without a `data-comment-id`. |

## Files

- `src/renderer/extensions/node-ids/index.ts` — #489
- `src/renderer/lib/tools/executors/editor.ts` — #490 + export `isEditorReadOnly`
- `src/renderer/lib/tools/executors/document.ts` — #491
- `src/renderer/components/CommentPopover.tsx` — #492

4 commits, one per bug. Net ~40 lines.

## Verification (manual — please run before merge)

### #489 — read_document nesting

1. Open a doc with a bullet list (e.g., `- one\n- two\n- three`).
2. From Claude Desktop: *"Call the prose read_document tool."*
3. **Expected**: each listItem has `children: []` (or `children` absent for empty), NOT `children: [{ type: "paragraph", content: "<same text as listItem>" }]`. Verify by inspecting the JSON response in Claude Desktop's tool-call output.

### #490 — frontmatter body drop

1. From Claude Desktop: *"Use suggest_edit with content `---\nplain text\n---\nreal body` targeting the first paragraph."*
2. **Expected**: the suggestion popup shows the FULL replacement text including the `---\nplain text\n---` block. No frontmatter is applied to the doc.
3. Regression check — happy path: *"Use suggest_edit with content `---\ntitle: Test\n---\nbody`"* — should still apply frontmatter and show only `body` in the diff.

### #491 — comment tools on read-only

1. Open a reMarkable-synced notebook (read-only OCR view) OR a preview tab (single-click any file from the explorer — don't double-click).
2. From Claude Desktop: *"Use add_comment with this nodeId [any id from read_document] and comment 'test'."*
3. **Expected**: error `EDITOR_READ_ONLY` — *"Document is read-only in this mode"*.
4. Same for `resolve_comment`.

### #492 — null comment-id guard

1. Regression check — add a comment normally, click it. Popover opens.
2. In DevTools console:
   ```js
   const el = document.createElement('span')
   el.className = 'comment-mark'
   document.body.appendChild(el)
   el.click()
   ```
3. **Expected**: console warning `[CommentPopover] comment-mark clicked with no data-comment-id`, no popover opens. Clean up: `el.remove()`.

## Workflow constraint

**Do NOT auto-merge.** This batch ships before 1.1.1 — needs eyes-on confirmation that #489 actually undoes the listItem duplication and that #491's gate works on a real reMarkable doc. Hand off to user for manual verification.

Closes #489
Closes #490
Closes #491
Closes #492