### PR TITLE
fix(updater): restart actually quits + relaunches (#501)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,12 +38,7 @@ import { getMcpHttpServer, getMcpBridge, getMcpSocketServer } from './mcp'
 import { initializeSpellcheck, setupContextMenu } from './spellcheck'
 import { initAutoUpdater } from './updater'
 import { IS_MAS_BUILD } from './env'
-
-// Track quit intent so macOS hide-on-close can be bypassed during actual quit
-let isQuitting = false
-app.on('before-quit', () => {
-  isQuitting = true
-})
+import { isQuitting } from './quitState'
 
 console.log('[Main] Environment loaded. OCR URL:', process.env.REMARKABLE_OCR_URL ? 'set' : 'not set')
 console.log('[Main] Google configured:', process.env.GOOGLE_CLIENT_ID ? 'ID set' : 'ID missing', process.env.GOOGLE_CLIENT_SECRET ? 'Secret set' : 'Secret missing')
@@ -282,7 +277,7 @@ function createWindow(): BrowserWindow {
   // and allows the window to be re-shown via dock click or Window menu.
   if (process.platform === 'darwin') {
     mainWindow.on('close', (e) => {
-      if (!isQuitting) {
+      if (!isQuitting()) {
         e.preventDefault()
         mainWindow.hide()
       }

--- a/src/main/quitState.ts
+++ b/src/main/quitState.ts
@@ -1,0 +1,24 @@
+import { app } from 'electron'
+
+// Tracks whether the app is in the middle of a real quit (vs. macOS Cmd+W,
+// which we intercept and turn into a window hide). The main window's close
+// handler checks `isQuitting()` to decide whether to honor or swallow the
+// close. Kept in its own module to avoid circular imports between `index.ts`
+// and modules like `updater.ts` that need to flip the flag.
+
+let quitting = false
+
+app.on('before-quit', () => {
+  quitting = true
+})
+
+export function isQuitting(): boolean {
+  return quitting
+}
+
+// For paths that bypass `app.quit()` and therefore won't fire `before-quit`
+// in time — notably electron-updater's `quitAndInstall`, which closes all
+// windows first and only then calls `app.quit()`.
+export function markQuitting(): void {
+  quitting = true
+}

--- a/src/main/quitState.ts
+++ b/src/main/quitState.ts
@@ -5,6 +5,9 @@ import { app } from 'electron'
 // handler checks `isQuitting()` to decide whether to honor or swallow the
 // close. Kept in its own module to avoid circular imports between `index.ts`
 // and modules like `updater.ts` that need to flip the flag.
+//
+// Main-process only — the module-level `app.on('before-quit', ...)` below
+// runs on import. Importing from a renderer/test context would fail.
 
 let quitting = false
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, ipcMain } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { IS_MAS_BUILD } from './env'
+import { markQuitting } from './quitState'
 
 export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> {
   if (IS_MAS_BUILD) {
@@ -28,6 +29,7 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
     autoUpdater.allowPrerelease = false
 
     let updateDownloaded = false
+    let installInvoked = false
 
     autoUpdater.on('update-available', (info) => {
       console.log('[Updater] Update available:', info.version)
@@ -72,6 +74,18 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
 
     ipcMain.handle('updater:install', () => {
       if (!updateDownloaded) return
+      // Re-entrancy guard: a second QuitAndInstall call double-registers an
+      // observer in Electron's native auto-updater and trips a NOTREACHED
+      // (electron_api_auto_updater.cc:118), which bails out before the actual
+      // quit/relaunch — see Sentry PROSE-H.
+      if (installInvoked) return
+      installInvoked = true
+      // electron-updater calls Electron's native autoUpdater.quitAndInstall(),
+      // which closes all windows BEFORE firing `before-quit`. Our macOS
+      // hide-on-close handler would otherwise swallow the close and leave the
+      // app running in the background, with the user seeing the window vanish
+      // but no relaunch.
+      markQuitting()
       autoUpdater.quitAndInstall()
     })
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -78,7 +78,10 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
       // observer in Electron's native auto-updater and trips a NOTREACHED
       // (electron_api_auto_updater.cc:118), which bails out before the actual
       // quit/relaunch — see Sentry PROSE-H.
-      if (installInvoked) return
+      if (installInvoked) {
+        console.warn('[Updater] install ignored — already invoked')
+        return
+      }
       installInvoked = true
       // electron-updater calls Electron's native autoUpdater.quitAndInstall(),
       // which closes all windows BEFORE firing `before-quit`. Our macOS


### PR DESCRIPTION
Closes #501.

## Summary

- Native `autoUpdater.quitAndInstall()` closes all windows before firing `before-quit`. Our macOS hide-on-close handler at `src/main/index.ts:284` was swallowing that close (`isQuitting === false`), so the window vanished but the app never quit and never relaunched.
- A re-entrant `updater:install` call double-registers a WindowList observer in Electron's native auto-updater and trips a `NOTREACHED` at `electron_api_auto_updater.cc:118` (Sentry [PROSE-H](https://soloist.sentry.io/issues/7485958282/)).

## Changes

- New `src/main/quitState.ts` owns the `isQuitting` flag — extracted from `index.ts` so `updater.ts` can flip it without a circular import.
- `updater:install` calls `markQuitting()` before `autoUpdater.quitAndInstall()` so the close handler honors the close.
- `updater:install` no-ops on subsequent invocations, preventing the double-AddObserver NOTREACHED.

## Test plan

This needs a real signed release to exercise — there's no good way to test the native auto-updater locally.

- [ ] Merge, cut a v1.2.1 release.
- [ ] On a machine running v1.2.0, accept the update prompt and download.
- [ ] Click **Restart** — confirm window closes and v1.2.1 relaunches.
- [ ] In DevTools, invoke `window.api.updaterInstall()` twice in quick succession — confirm second call is a no-op (no NOTREACHED in Sentry on the new release).
- [ ] Check Sentry 24h after rollout — no new PROSE-H events on v1.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)