### PR TITLE
fix(mcp): node-id walker bugs in list items and container wrappers (#496, #497)

### DIFF
--- a/src/renderer/extensions/node-ids/index.ts
+++ b/src/renderer/extensions/node-ids/index.ts
@@ -19,6 +19,9 @@ const NODE_TYPES_WITH_IDS = [
   'heading',
   'codeBlock',
   'blockquote',
+  'bulletList',
+  'orderedList',
+  'taskList',
   'listItem',
   'taskItem',
 ]
@@ -65,8 +68,16 @@ export const NodeIds = Extension.create({
             // Only process nodes that should have IDs
             if (!NODE_TYPES_WITH_IDS.includes(node.type.name)) return
 
-            // Skip if node already has an ID
-            if (node.attrs.nodeId) return
+            // Check the transaction's current mapped document for an existing ID.
+            // We intentionally do NOT use `node.attrs.nodeId` here: when tiptap-markdown
+            // parses a list, sibling listItems may share the same attrs object reference.
+            // After `setNodeMarkup` assigns an id to the first sibling, that shared attrs
+            // object reflects the new id — so `node.attrs.nodeId` on subsequent siblings
+            // would appear truthy even though no id was written for them, causing all
+            // siblings to report the same id. Reading from `tr.doc` gives us the actual
+            // committed state for each node individually.
+            const currentNode = tr.doc.nodeAt(pos)
+            if (currentNode?.attrs.nodeId) return
 
             // Assign a new ID
             tr.setNodeMarkup(pos, undefined, {


### PR DESCRIPTION
## Summary

- **#496**: Sibling `listItem` nodes shared the same `nodeId` because `tiptap-markdown` can produce list nodes with a reference-shared `attrs` object. After `setNodeMarkup` wrote an id to the first sibling, the shared attrs object reflected that id — so the `if (node.attrs.nodeId)` guard short-circuited all subsequent siblings, leaving them all with the same id. Fixed by reading from `tr.doc.nodeAt(pos)` (the transaction's own document state) instead of `node.attrs`, so each sibling is checked independently.
- **#497**: `bulletList`, `orderedList`, `taskList` were in `CONTAINER_TYPES` (emitted by the walker) but absent from `NODE_TYPES_WITH_IDS` (so the extension never assigned them ids). Every list wrapper arrived at MCP consumers with `id: ""`. Fixed by adding the three types to `NODE_TYPES_WITH_IDS` (Option A from the issue).

## Test plan

- [ ] `npm run build` passes (verified: clean build)
- [ ] Open a doc with a bullet list; call `read_document` — each `listItem` should have a unique non-empty `id`
- [ ] Verify `bulletList` / `orderedList` / `taskList` wrappers also have non-empty `id` values
- [ ] Verify `suggest_edit` targeting any list item lands on the correct item (not always the first)

Closes #496
Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)