### PR TITLE
feat(files): refresh File Explorer on filesystem events (#418)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@tiptap/starter-kit": "^2.11.2",
         "@types/js-yaml": "^4.0.9",
         "ai": "^6.0.3",
+        "chokidar": "^3.6.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -6722,6 +6723,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@tiptap/starter-kit": "^2.11.2",
     "@types/js-yaml": "^4.0.9",
     "ai": "^6.0.3",
+    "chokidar": "^3.6.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/main/fileWatcher.ts
+++ b/src/main/fileWatcher.ts
@@ -6,10 +6,11 @@
  * disposed and a new one is started. File-system events are forwarded to the
  * renderer via IPC push events:
  *
- *   file:watch:event  — { type: 'created' | 'deleted' | 'renamed', path: string }
+ *   file:watch:event  — { type: 'created' | 'deleted', path: string }
  *
- * A single event type keeps the renderer side simple: it can reload the
- * directory listing on any event regardless of type.
+ * Renames are reported as an unlink + add pair by chokidar (no native rename
+ * event), so we don't model them separately. The renderer just reloads on
+ * any event regardless of type.
  */
 
 import { ipcMain, BrowserWindow } from 'electron'
@@ -166,9 +167,10 @@ export function setupFileWatcherHandlers(): void {
 }
 
 /**
- * Tear down the watcher and IPC handlers on app quit.
- * Called from the app 'will-quit' event in src/main/index.ts. Routes through
- * the same queue so it can't race with an in-flight start/stop.
+ * Stop the active watcher on app quit. Called from the app 'will-quit' event
+ * in src/main/index.ts. Routes through the same queue so it can't race with
+ * an in-flight start/stop. IPC handler registrations are left in place — they
+ * get reclaimed by the process exit a moment later.
  */
 export async function teardownFileWatcher(): Promise<void> {
   await enqueueWatcherOp(() => stopWatcher())

--- a/src/main/fileWatcher.ts
+++ b/src/main/fileWatcher.ts
@@ -1,0 +1,147 @@
+/**
+ * fileWatcher.ts
+ *
+ * Manages a single chokidar watcher for the directory currently displayed in
+ * the File Explorer. When the watched directory changes, the old watcher is
+ * disposed and a new one is started. File-system events are forwarded to the
+ * renderer via IPC push events:
+ *
+ *   file:watch:event  — { type: 'created' | 'deleted' | 'renamed', path: string }
+ *
+ * A single event type keeps the renderer side simple: it can reload the
+ * directory listing on any event regardless of type.
+ */
+
+import { ipcMain, BrowserWindow } from 'electron'
+import chokidar from 'chokidar'
+import { normalize } from 'path'
+
+export interface FileWatchEvent {
+  type: 'created' | 'deleted' | 'renamed'
+  path: string
+}
+
+// The single active watcher (null when no directory is being watched)
+let activeWatcher: ReturnType<typeof chokidar.watch> | null = null
+let watchedDirectory: string | null = null
+
+/**
+ * Send a file-watch event to every open BrowserWindow renderer.
+ */
+function sendEvent(event: FileWatchEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('file:watch:event', event)
+    }
+  }
+}
+
+/**
+ * Stop and dispose the current watcher, if any.
+ */
+async function stopWatcher(): Promise<void> {
+  if (activeWatcher) {
+    try {
+      await activeWatcher.close()
+    } catch {
+      // Ignore close errors
+    }
+    activeWatcher = null
+    watchedDirectory = null
+    console.log('[FileWatcher] Watcher stopped')
+  }
+}
+
+/**
+ * Start watching a new directory. Disposes any existing watcher first.
+ * The directory must already be validated (path traversal check) by the caller.
+ */
+async function startWatcher(dirPath: string): Promise<void> {
+  const normalized = normalize(dirPath)
+
+  // No-op if we're already watching this exact directory
+  if (watchedDirectory === normalized) return
+
+  await stopWatcher()
+
+  console.log('[FileWatcher] Starting watcher for:', normalized)
+
+  const watcher = chokidar.watch(normalized, {
+    // Watch only the immediate children of the directory, not subdirectories.
+    // The File Explorer uses lazy loading for subdirectories, so we only need
+    // to detect top-level changes to trigger a reload. Watching recursively
+    // would fire excessive events for large trees and is not needed.
+    depth: 0,
+    // Ignore dotfiles — the File Explorer skips them too
+    ignored: /(^|[/\\])\../,
+    // Don't report the initial scan as added events
+    ignoreInitial: true,
+    // Stabilize burst events (e.g., editor temp files) before firing
+    awaitWriteFinish: false,
+    // Use native OS events where available (FSEvents on macOS)
+    usePolling: false,
+    // Persist the watcher even when the watched directory is temporarily
+    // inaccessible (e.g., network drive goes offline)
+    persistent: true,
+  })
+
+  watcher.on('add', (filePath) => {
+    sendEvent({ type: 'created', path: filePath })
+  })
+
+  watcher.on('addDir', (dirPath) => {
+    sendEvent({ type: 'created', path: dirPath })
+  })
+
+  watcher.on('unlink', (filePath) => {
+    sendEvent({ type: 'deleted', path: filePath })
+  })
+
+  watcher.on('unlinkDir', (dirPath) => {
+    sendEvent({ type: 'deleted', path: dirPath })
+  })
+
+  // chokidar fires 'unlink' + 'add' for renames; we map that via the 'add'
+  // event above. No native 'rename' event needed — the renderer just reloads.
+
+  watcher.on('error', (error) => {
+    console.error('[FileWatcher] Watcher error:', error)
+  })
+
+  activeWatcher = watcher
+  watchedDirectory = normalized
+}
+
+/**
+ * Register IPC handlers for watcher lifecycle control.
+ * Called once from src/main/index.ts after the window is created.
+ *
+ * Channels:
+ *   file:watch:start  (invokable) — start watching a directory
+ *   file:watch:stop   (invokable) — stop the current watcher
+ */
+export function setupFileWatcherHandlers(): void {
+  ipcMain.handle('file:watch:start', async (_event, dirPath: string) => {
+    if (!dirPath || typeof dirPath !== 'string') return
+    // Caller (renderer via store) must only pass already-validated paths.
+    // We normalize here as a belt-and-suspenders measure.
+    const normalized = normalize(dirPath)
+    if (normalized.includes('..')) {
+      console.warn('[FileWatcher] Rejected path traversal attempt:', dirPath)
+      return
+    }
+    await startWatcher(normalized)
+  })
+
+  ipcMain.handle('file:watch:stop', async () => {
+    await stopWatcher()
+  })
+}
+
+/**
+ * Tear down the watcher and IPC handlers on app quit.
+ * Called from the app 'will-quit' event in src/main/index.ts.
+ */
+export async function teardownFileWatcher(): Promise<void> {
+  await stopWatcher()
+}

--- a/src/main/fileWatcher.ts
+++ b/src/main/fileWatcher.ts
@@ -24,9 +24,26 @@ export interface FileWatchEvent {
   path: string
 }
 
-// The single active watcher (null when no directory is being watched)
+// The single active watcher (null when no directory is being watched).
+// Single-window assumption: state is global; if Prose ever opens multiple
+// windows with different File Explorer roots, both will share one watcher
+// and broadcast each other's events. Revisit when adding multi-window.
 let activeWatcher: ReturnType<typeof chokidar.watch> | null = null
 let watchedDirectory: string | null = null
+
+/**
+ * Serialize lifecycle operations on the watcher. Without this, fire-and-forget
+ * IPC calls from the renderer can interleave at the main process — e.g., a
+ * `null → B` transition where `start(B)` resolves before `stop(null)` would
+ * leave the watcher torn down. The queue makes lifecycle ordering deterministic.
+ */
+let watcherOpQueue: Promise<void> = Promise.resolve()
+
+function enqueueWatcherOp(op: () => Promise<void>): Promise<void> {
+  // Chain on settled (not just resolved) so a failed op doesn't poison the queue.
+  watcherOpQueue = watcherOpQueue.then(op, op)
+  return watcherOpQueue
+}
 
 /**
  * Send a file-watch event to every open BrowserWindow renderer.
@@ -135,18 +152,19 @@ export function setupFileWatcherHandlers(): void {
       console.warn('[FileWatcher] Rejected path:', dirPath, '—', message)
       return
     }
-    await startWatcher(normalized)
+    await enqueueWatcherOp(() => startWatcher(normalized))
   })
 
   ipcMain.handle('file:watch:stop', async () => {
-    await stopWatcher()
+    await enqueueWatcherOp(() => stopWatcher())
   })
 }
 
 /**
  * Tear down the watcher and IPC handlers on app quit.
- * Called from the app 'will-quit' event in src/main/index.ts.
+ * Called from the app 'will-quit' event in src/main/index.ts. Routes through
+ * the same queue so it can't race with an in-flight start/stop.
  */
 export async function teardownFileWatcher(): Promise<void> {
-  await stopWatcher()
+  await enqueueWatcherOp(() => stopWatcher())
 }

--- a/src/main/fileWatcher.ts
+++ b/src/main/fileWatcher.ts
@@ -14,6 +14,7 @@
 
 import { ipcMain, BrowserWindow } from 'electron'
 import chokidar from 'chokidar'
+import { basename } from 'path'
 import { validatePath } from './ipc'
 
 export interface FileWatchEvent {
@@ -91,8 +92,12 @@ async function startWatcher(normalized: string): Promise<void> {
     // to detect top-level changes to trigger a reload. Watching recursively
     // would fire excessive events for large trees and is not needed.
     depth: 0,
-    // Ignore dotfiles — the File Explorer skips them too
-    ignored: /(^|[/\\])\../,
+    // Ignore dotfiles — match only the LEAF segment, never an ancestor.
+    // A naive `/(^|[/\\])\../` regex would suppress every event when the
+    // watched root sits beneath a hidden parent (e.g., `/Users/me/.config/notes`).
+    // The `!== normalized` guard preserves events on the watched root itself.
+    ignored: (filePath: string) =>
+      filePath !== normalized && basename(filePath).startsWith('.'),
     // Don't report the initial scan as added events
     ignoreInitial: true,
     // Don't wait for write-finish; the renderer-side debounce coalesces bursts.

--- a/src/main/fileWatcher.ts
+++ b/src/main/fileWatcher.ts
@@ -14,10 +14,13 @@
 
 import { ipcMain, BrowserWindow } from 'electron'
 import chokidar from 'chokidar'
-import { normalize } from 'path'
+import { validatePath } from './ipc'
 
 export interface FileWatchEvent {
-  type: 'created' | 'deleted' | 'renamed'
+  // chokidar emits 'unlink' + 'add' for renames rather than a 'rename' event,
+  // so we don't model 'renamed' explicitly — the renderer just reloads on any
+  // event regardless of type.
+  type: 'created' | 'deleted'
   path: string
 }
 
@@ -54,11 +57,10 @@ async function stopWatcher(): Promise<void> {
 
 /**
  * Start watching a new directory. Disposes any existing watcher first.
- * The directory must already be validated (path traversal check) by the caller.
+ * Caller is responsible for path validation; this function takes an already-
+ * normalized absolute path (the IPC handler runs validatePath upstream).
  */
-async function startWatcher(dirPath: string): Promise<void> {
-  const normalized = normalize(dirPath)
-
+async function startWatcher(normalized: string): Promise<void> {
   // No-op if we're already watching this exact directory
   if (watchedDirectory === normalized) return
 
@@ -76,7 +78,7 @@ async function startWatcher(dirPath: string): Promise<void> {
     ignored: /(^|[/\\])\../,
     // Don't report the initial scan as added events
     ignoreInitial: true,
-    // Stabilize burst events (e.g., editor temp files) before firing
+    // Don't wait for write-finish; the renderer-side debounce coalesces bursts.
     awaitWriteFinish: false,
     // Use native OS events where available (FSEvents on macOS)
     usePolling: false,
@@ -123,11 +125,14 @@ async function startWatcher(dirPath: string): Promise<void> {
 export function setupFileWatcherHandlers(): void {
   ipcMain.handle('file:watch:start', async (_event, dirPath: string) => {
     if (!dirPath || typeof dirPath !== 'string') return
-    // Caller (renderer via store) must only pass already-validated paths.
-    // We normalize here as a belt-and-suspenders measure.
-    const normalized = normalize(dirPath)
-    if (normalized.includes('..')) {
-      console.warn('[FileWatcher] Rejected path traversal attempt:', dirPath)
+    // Project security rule: every filesystem IPC handler must validatePath().
+    // Expands ~ and blocks traversal sequences in one shared helper.
+    let normalized: string
+    try {
+      normalized = validatePath(dirPath)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn('[FileWatcher] Rejected path:', dirPath, '—', message)
       return
     }
     await startWatcher(normalized)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,7 @@ import { initializeSpellcheck, setupContextMenu } from './spellcheck'
 import { initAutoUpdater } from './updater'
 import { IS_MAS_BUILD } from './env'
 import { isQuitting } from './quitState'
+import { setupFileWatcherHandlers, teardownFileWatcher } from './fileWatcher'
 
 console.log('[Main] Environment loaded. OCR URL:', process.env.REMARKABLE_OCR_URL ? 'set' : 'not set')
 console.log('[Main] Google configured:', process.env.GOOGLE_CLIENT_ID ? 'ID set' : 'ID missing', process.env.GOOGLE_CLIENT_SECRET ? 'Secret set' : 'Secret missing')
@@ -488,6 +489,7 @@ app.whenReady().then(async () => {
 
   const mainWindow = createWindow()
   setupIpcHandlers()
+  setupFileWatcherHandlers()
   createMenu(mainWindow)
   initAutoUpdater(mainWindow)
 
@@ -588,8 +590,9 @@ app.on('window-all-closed', () => {
   }
 })
 
-// Clean up socket server and auth token on quit
+// Clean up socket server, file watcher, and auth token on quit
 app.on('will-quit', async () => {
+  await teardownFileWatcher()
   const socketServer = getMcpSocketServer()
   await socketServer.stop()
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -89,8 +89,9 @@ function expandPath(path: string): string {
 /**
  * Validate and sanitize a file path to prevent path traversal attacks.
  * Expands ~ paths and normalizes, then blocks any path containing traversal sequences.
+ * Exported so other main-process modules (e.g., fileWatcher) can apply the same gate.
  */
-function validatePath(inputPath: string): string {
+export function validatePath(inputPath: string): string {
   const expanded = expandPath(inputPath)
   const normalized = normalize(expanded)
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -277,6 +277,10 @@ export interface ElectronAPI {
   downloadSkill: () => Promise<{ success: boolean; error?: string }>
   // Build info
   isMasBuild: boolean
+  // File watcher — subscribe to filesystem events for the File Explorer
+  startWatchingDirectory: (dirPath: string) => Promise<void>
+  stopWatchingDirectory: () => Promise<void>
+  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted' | 'renamed'; path: string }) => void) => () => void
 }
 
 export interface FileItem {
@@ -533,6 +537,18 @@ const api: ElectronAPI = {
   downloadSkill: () => ipcRenderer.invoke('skill:download'),
   // Build info
   isMasBuild: process.env.MAS_BUILD === '1',
+  // File watcher — subscribe to filesystem events for the File Explorer
+  startWatchingDirectory: (dirPath: string) => ipcRenderer.invoke('file:watch:start', dirPath),
+  stopWatchingDirectory: () => ipcRenderer.invoke('file:watch:stop'),
+  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted' | 'renamed'; path: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, fileEvent: { type: 'created' | 'deleted' | 'renamed'; path: string }): void => {
+      callback(fileEvent)
+    }
+    ipcRenderer.on('file:watch:event', handler)
+    return () => {
+      ipcRenderer.removeListener('file:watch:event', handler)
+    }
+  },
   // Window fullscreen state
   onFullscreenChange: (callback: (isFullscreen: boolean) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, isFullscreen: boolean): void => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -280,7 +280,7 @@ export interface ElectronAPI {
   // File watcher — subscribe to filesystem events for the File Explorer
   startWatchingDirectory: (dirPath: string) => Promise<void>
   stopWatchingDirectory: () => Promise<void>
-  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted' | 'renamed'; path: string }) => void) => () => void
+  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted'; path: string }) => void) => () => void
 }
 
 export interface FileItem {
@@ -540,8 +540,8 @@ const api: ElectronAPI = {
   // File watcher — subscribe to filesystem events for the File Explorer
   startWatchingDirectory: (dirPath: string) => ipcRenderer.invoke('file:watch:start', dirPath),
   stopWatchingDirectory: () => ipcRenderer.invoke('file:watch:stop'),
-  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted' | 'renamed'; path: string }) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, fileEvent: { type: 'created' | 'deleted' | 'renamed'; path: string }): void => {
+  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted'; path: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, fileEvent: { type: 'created' | 'deleted'; path: string }): void => {
       callback(fileEvent)
     }
     ipcRenderer.on('file:watch:event', handler)

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -90,9 +90,16 @@ export function App() {
   const editor = useEditorInstanceStore((state) => state.editor)
   const tabs = useTabStore((state) => state.tabs)
   const addTab = useTabStore((state) => state.addTab)
+  const initFileWatcher = useFileListStore((state) => state.initFileWatcher)
 
   // Initialize autosave functionality
   useAutosave()
+
+  // Subscribe to filesystem events from the main process for live File Explorer updates
+  useEffect(() => {
+    const unsubscribe = initFileWatcher()
+    return unsubscribe
+  }, [initFileWatcher])
 
   // Review mode: auto-open sidebar, resize for mode, restore on exit
   const reviewMode = useReviewMode()

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -13,6 +13,49 @@ export interface SyncProgress {
 
 type ViewMode = 'recent' | 'folder' | 'notebooks' | 'googledocs'
 
+/**
+ * Walk `newFiles` and re-attach `children` arrays from `oldFiles` for any
+ * directory whose path is in `expandedFolders`. Lets a depth-1 reload from
+ * the fs watcher preserve the user's deep expansion state — without this,
+ * every fs event would visibly collapse subtrees beneath direct children.
+ *
+ * Subtrees pulled from `oldFiles` are kept as-is (we don't re-fetch them).
+ * That can leave deep state slightly stale until the user collapses/reopens
+ * the folder, but it avoids an IPC burst per fs event.
+ */
+function mergeExpandedChildren(
+  newFiles: FileItem[],
+  oldFiles: FileItem[],
+  expandedFolders: Set<string>
+): FileItem[] {
+  if (expandedFolders.size === 0) return newFiles
+
+  // Flatten oldFiles into a path → node map so we can re-attach any depth.
+  const oldByPath = new Map<string, FileItem>()
+  const walk = (items: FileItem[]): void => {
+    for (const item of items) {
+      oldByPath.set(item.path, item)
+      if (item.children && item.children.length > 0) walk(item.children)
+    }
+  }
+  walk(oldFiles)
+
+  const merge = (items: FileItem[]): FileItem[] =>
+    items.map(item => {
+      if (item.isDirectory && expandedFolders.has(item.path)) {
+        const old = oldByPath.get(item.path)
+        if (old?.children && old.children.length > 0) {
+          // Recurse so an old subtree's own nested expansions get the same
+          // merge treatment if the depth-1 reload happens to include them.
+          return { ...item, children: merge(old.children) }
+        }
+      }
+      return item
+    })
+
+  return merge(newFiles)
+}
+
 interface FileListState {
   // Panel state
   isPanelOpen: boolean
@@ -268,14 +311,23 @@ export const useFileListStore = create<FileListState>()(
     },
 
     loadFiles: async () => {
-      const { rootPath } = get()
+      const { rootPath, expandedFolders, files: oldFiles } = get()
       if (!rootPath || !window.api) return
 
       set({ isLoading: true })
       try {
         // Use depth 1 for fast initial load - children loaded on demand
-        const files = await window.api.listDirectory(rootPath, 1)
-        set({ files, isLoading: false })
+        const fresh = await window.api.listDirectory(rootPath, 1)
+        // The fresh listing only includes direct children. If the user had
+        // any subfolders expanded (and their children fetched via
+        // loadFolderChildren), those `children` arrays would be wiped on
+        // every fs-event reload, causing deep expansions to silently
+        // collapse mid-edit. Re-attach previously-loaded children for any
+        // path still in expandedFolders so the user's tree state survives.
+        // This trades a small risk of stale deep state (until the user
+        // collapses/reopens) for not bursting IPC reads on every event.
+        const merged = mergeExpandedChildren(fresh, oldFiles, expandedFolders)
+        set({ files: merged, isLoading: false })
       } catch (error) {
         console.error('Failed to load files:', error)
         set({ files: [], isLoading: false })

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -243,8 +243,10 @@ export const useFileListStore = create<FileListState>()(
       // Try reading the parent — may fail in MAS sandbox
       const files = await window.api.listDirectory(parentPath, 1)
       if (files && files.length > 0) {
-        set({ rootPath: parentPath, files: [], expandedFolders: new Set() })
-        get().loadFiles()
+        // Route through setRootPath so the directory watcher follows the
+        // navigation. Setting rootPath inline would leave the watcher pinned
+        // to the previous directory and silently break live updates.
+        get().setRootPath(parentPath)
       } else {
         // Parent not accessible — prompt for folder access via Powerbox
         const result = await window.api.selectFolder(
@@ -261,8 +263,7 @@ export const useFileListStore = create<FileListState>()(
             }))
           }
           useSettingsStore.getState().saveSettings()
-          set({ rootPath: result.path, files: [], expandedFolders: new Set() })
-          get().loadFiles()
+          get().setRootPath(result.path)
         }
         // User cancelled — stay where we are
       }

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -211,14 +211,12 @@ export const useFileListStore = create<FileListState>()(
           // Verify the directory is actually readable (may fail in MAS sandbox)
           const files = await window.api.listDirectory(documentsPath)
           if (files && files.length > 0) {
-            set({ rootPath: documentsPath, isInitialized: true })
-            get().loadFiles()
-            // Start watching the initial directory
-            if (window.api.startWatchingDirectory) {
-              window.api.startWatchingDirectory(documentsPath).catch((err: unknown) => {
-                console.error('[FileListStore] Failed to start directory watcher:', err)
-              })
-            }
+            // Route through setRootPath so the watcher wiring stays in one
+            // place. Setting rootPath inline (the old pattern) duplicated
+            // the startWatchingDirectory call and was a foot-gun the day
+            // someone changed the watcher contract.
+            set({ isInitialized: true })
+            get().setRootPath(documentsPath)
           } else {
             // Can't read directory (sandbox) or genuinely empty — show picker prompt
             set({ isInitialized: true })

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -68,6 +68,7 @@ interface FileListState {
   setRemarkableSyncProgress: (progress: SyncProgress | null) => void
   setRemarkableSyncError: (error: string | null) => void
   setRootPath: (path: string | null) => void
+  initFileWatcher: () => (() => void)
   initializeDefaultPath: () => Promise<void>
   navigateToParent: () => void
   loadFiles: () => Promise<void>
@@ -145,6 +146,58 @@ export const useFileListStore = create<FileListState>()(
       set({ rootPath: path, files: [], expandedFolders: new Set() })
       if (path) {
         get().loadFiles()
+        // Notify the main process to start watching this directory.
+        // Fire-and-forget — the watcher replacing an old one is handled in main.
+        if (window.api?.startWatchingDirectory) {
+          window.api.startWatchingDirectory(path).catch((err: unknown) => {
+            console.error('[FileListStore] Failed to start directory watcher:', err)
+          })
+        }
+      } else {
+        // No directory — tear down the watcher
+        if (window.api?.stopWatchingDirectory) {
+          window.api.stopWatchingDirectory().catch((err: unknown) => {
+            console.error('[FileListStore] Failed to stop directory watcher:', err)
+          })
+        }
+      }
+    },
+
+    /**
+     * Subscribe to file-system events pushed by the main process.
+     * Call once on app mount (e.g., in the top-level App component).
+     * Returns an unsubscribe function to be called on unmount.
+     *
+     * On any event, we reload the root directory listing. This is a
+     * simple full reload — fine for the shallow (depth-1) listing we
+     * show. We avoid trying to surgically patch the tree because the
+     * cost of a re-read is negligible and correctness is guaranteed.
+     */
+    initFileWatcher: () => {
+      if (!window.api?.onFileWatchEvent) {
+        // Running in web mode — no watcher support
+        return () => {}
+      }
+
+      let reloadTimeout: ReturnType<typeof setTimeout> | null = null
+
+      const unsubscribe = window.api.onFileWatchEvent((_event) => {
+        const { viewMode, rootPath } = get()
+        // Only react in folder view — other views don't use the file tree
+        if (viewMode !== 'folder' || !rootPath) return
+
+        // Debounce: batch rapid file-system events (e.g., editor save = unlink + write)
+        // into a single reload 150ms after the last event.
+        if (reloadTimeout !== null) clearTimeout(reloadTimeout)
+        reloadTimeout = setTimeout(() => {
+          reloadTimeout = null
+          get().loadFiles()
+        }, 150)
+      })
+
+      return () => {
+        if (reloadTimeout !== null) clearTimeout(reloadTimeout)
+        unsubscribe()
       }
     },
 
@@ -160,6 +213,12 @@ export const useFileListStore = create<FileListState>()(
           if (files && files.length > 0) {
             set({ rootPath: documentsPath, isInitialized: true })
             get().loadFiles()
+            // Start watching the initial directory
+            if (window.api.startWatchingDirectory) {
+              window.api.startWatchingDirectory(documentsPath).catch((err: unknown) => {
+                console.error('[FileListStore] Failed to start directory watcher:', err)
+              })
+            }
           } else {
             // Can't read directory (sandbox) or genuinely empty — show picker prompt
             set({ isInitialized: true })


### PR DESCRIPTION
## Summary

- Adds a chokidar v3 directory watcher in the Electron main process that watches only the directory currently displayed in the File Explorer (depth 0, no recursive watching)
- File-system events (`add`, `addDir`, `unlink`, `unlinkDir`) are forwarded to the renderer as `file:watch:event` IPC push events
- The renderer debounces incoming events (150 ms) and calls `loadFiles()` to reload the listing — no manual refresh needed
- The watcher is started/stopped as the user navigates: swapping directories disposes the old watcher and starts a fresh one

## How it works

1. `src/main/fileWatcher.ts` — new module: single chokidar watcher, `file:watch:start` / `file:watch:stop` IPC handlers, cleanup on app quit
2. `src/preload/index.ts` — exposes `startWatchingDirectory()`, `stopWatchingDirectory()`, and `onFileWatchEvent()` via contextBridge
3. `src/renderer/stores/fileListStore.ts` — `setRootPath()` and `initializeDefaultPath()` call `startWatchingDirectory()`; new `initFileWatcher()` action subscribes to events and triggers debounced reloads
4. `src/renderer/components/layout/App.tsx` — calls `initFileWatcher()` once on mount

## Test plan

- [ ] `npm run build` succeeds with no TypeScript errors
- [ ] Open Prose with a directory in the File Explorer
- [ ] `touch <dir>/newfile.md` → file appears in the explorer within ~1 s without clicking anything
- [ ] `mv <dir>/newfile.md <dir>/renamed.md` → explorer updates (old gone, new appears)
- [ ] `rm <dir>/renamed.md` → file disappears from explorer
- [ ] Navigate to a different directory in the explorer → old watcher is disposed (check main process logs for `[FileWatcher] Watcher stopped`)
- [ ] Quit the app → no watcher leak (check main process logs for cleanup message)

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)