### PR TITLE
feat(mcp): add list_tabs and select_tab tools for multi-tab navigation (#450)

### DIFF
--- a/resources/prose-skill/prose/SKILL.md
+++ b/resources/prose-skill/prose/SKILL.md
@@ -82,8 +82,10 @@ If MCP isn't usable, surface why and offer an alternative.
 | `suggest_edit` | `{ nodeId (req), content (req), comment?, search? }` → `{ suggested: true, suggestionId }`. User accepts/rejects in Prose. Always pass `search` (the original node text) so the server can match if `nodeId` is stale. |
 | `open_file` | Opens a file by absolute path. |
 | `create_and_open_file` | Writes a file (default save dir, auto-suffixes on collision) and opens it. `filename` is just a name, not a path. |
+| `list_tabs` | Returns all open tabs: `{ tabs: [{ tabId, title, path, isActive, isDirty, isPreview, documentId }] }`. Read-only; doesn't affect UI. Call this first when the user references a document by name ("go back to my novel", "switch to the draft"). |
+| `select_tab` | Switch to a tab by `tabId` (exact, from `list_tabs`) or `match` (case-insensitive substring of title or path filename). Returns `{ selected, tabId, title, path }`. On ambiguous match, returns `{ error: "ambiguous", candidates: [...] }` — ask the user to pick. |
 
-`get_outline` and `read_document` are read-only. `create_and_open_file` and `open_file` switch the active document and dismiss any pending `suggest_edit` overlay — render diffs LAST in multi-tool flows. The MCP exposes only these 5 tools; there's no "get current file path".
+`get_outline`, `read_document`, and `list_tabs` are read-only. `create_and_open_file`, `open_file`, and `select_tab` switch the active document and dismiss any pending `suggest_edit` overlay — render diffs LAST in multi-tool flows. When the user references a document that isn't currently active ("go back to X", "switch to my novel"), call `list_tabs` first to find it, then `select_tab` — don't guess a path or call `open_file` blindly.
 
 ## Outline + diff widgets (for MCP work)
 

--- a/src/renderer/lib/tools/executors/index.ts
+++ b/src/renderer/lib/tools/executors/index.ts
@@ -5,3 +5,4 @@
 export * from './document'
 export * from './editor'
 export * from './file'
+export * from './tabs'

--- a/src/renderer/lib/tools/executors/tabs.ts
+++ b/src/renderer/lib/tools/executors/tabs.ts
@@ -1,0 +1,175 @@
+/**
+ * Tab tool executors - tools for multi-tab navigation.
+ */
+
+import type { ToolResult } from '../../../../shared/tools/types'
+import { toolSuccess, toolError } from '../../../../shared/tools/types'
+import { useTabStore } from '../../../stores/tabStore'
+import { useEditorStore } from '../../../stores/editorStore'
+import { useChatStore, setCurrentDocumentId } from '../../../stores/chatStore'
+import { useAnnotationStore } from '../../../extensions/ai-annotations'
+import { useSuggestionStore } from '../../../extensions/ai-suggestions/store'
+import { useFileListStore } from '../../../stores/fileListStore'
+
+// Tab summary shape returned to Claude
+interface TabSummary {
+  tabId: string
+  title: string
+  path: string | null
+  isActive: boolean
+  isDirty: boolean
+  isPreview: boolean
+  documentId: string
+}
+
+/**
+ * list_tabs - Read-only snapshot of all open tabs.
+ * Returns all tabs including preview tabs (marked with isPreview: true).
+ */
+export function executeListTabs(): ToolResult<{ tabs: TabSummary[] }> {
+  const tabState = useTabStore.getState()
+
+  const tabs: TabSummary[] = tabState.tabs.map((tab) => ({
+    tabId: tab.id,
+    title: tab.title,
+    path: tab.path,
+    isActive: tab.id === tabState.activeTabId,
+    isDirty: tab.isDirty,
+    isPreview: tab.isPreview ?? false,
+    documentId: tab.documentId
+  }))
+
+  return toolSuccess({ tabs })
+}
+
+/**
+ * select_tab - Switch the active tab.
+ * Accepts tabId (exact) or match (case-insensitive substring of title or path basename).
+ * Mirrors the switchToTab logic from useTabs.ts, using store APIs directly.
+ */
+export async function executeSelectTab(args: {
+  tabId?: string
+  match?: string
+}): Promise<ToolResult<{ selected: boolean; tabId: string; title: string; path: string | null }>> {
+  const { tabId, match } = args
+
+  if (!tabId && !match) {
+    return toolError('Provide either tabId or match', 'INVALID_INPUT')
+  }
+
+  const tabState = useTabStore.getState()
+
+  let targetTab = null
+
+  if (tabId) {
+    // Exact ID lookup
+    targetTab = tabState.tabs.find((t) => t.id === tabId) ?? null
+    if (!targetTab) {
+      return toolError(`Tab not found: ${tabId}`, 'TAB_NOT_FOUND')
+    }
+  } else if (match) {
+    // Case-insensitive substring match on title and path basename
+    const lower = match.toLowerCase()
+    const candidates = tabState.tabs.filter((t) => {
+      const titleMatch = t.title.toLowerCase().includes(lower)
+      const pathMatch = t.path
+        ? (t.path.split('/').pop() ?? '').toLowerCase().includes(lower)
+        : false
+      return titleMatch || pathMatch
+    })
+
+    if (candidates.length === 0) {
+      return toolError('tab not found', 'TAB_NOT_FOUND')
+    }
+
+    if (candidates.length > 1) {
+      return toolError(
+        JSON.stringify({
+          error: 'ambiguous',
+          candidates: candidates.map((t) => ({
+            tabId: t.id,
+            title: t.title,
+            path: t.path
+          }))
+        }),
+        'AMBIGUOUS_MATCH'
+      )
+    }
+
+    targetTab = candidates[0]
+  }
+
+  if (!targetTab) {
+    return toolError('tab not found', 'TAB_NOT_FOUND')
+  }
+
+  // Already the active tab — no-op
+  if (targetTab.id === tabState.activeTabId) {
+    return toolSuccess({
+      selected: true,
+      tabId: targetTab.id,
+      title: targetTab.title,
+      path: targetTab.path
+    })
+  }
+
+  try {
+    // Save current tab conversation state
+    const { document } = useEditorStore.getState()
+    await useChatStore.getState().saveCurrentConversation(document.documentId)
+
+    // Pause annotation position updates during document loading
+    useAnnotationStore.getState().setLoadingDocument(true)
+
+    // Activate the new tab
+    useTabStore.getState().setActiveTab(targetTab.id)
+
+    // Load target tab's document into editorStore
+    const newDocumentId = targetTab.documentId
+    useEditorStore.getState().setDocument({
+      documentId: newDocumentId,
+      path: targetTab.path,
+      content: targetTab.content ?? '',
+      frontmatter: targetTab.frontmatter ?? {},
+      isDirty: targetTab.isDirty
+    })
+
+    if (targetTab.cursorPosition) {
+      useEditorStore.getState().setCursorPosition(
+        targetTab.cursorPosition.line,
+        targetTab.cursorPosition.column
+      )
+    }
+
+    // Load conversations, annotations, and suggestions for the new document
+    setCurrentDocumentId(newDocumentId)
+    await useChatStore.getState().loadForDocument(newDocumentId)
+    await useAnnotationStore.getState().loadAnnotations(newDocumentId)
+    await useSuggestionStore.getState().loadSuggestions(newDocumentId)
+
+    // Clear reMarkable read-only state
+    useEditorStore.getState().setRemarkableReadOnly(false, null)
+
+    // Mark as editing
+    useEditorStore.getState().setEditing(true)
+
+    // Update file list selection if file has path
+    if (targetTab.path) {
+      useFileListStore.getState().revealAndSelectPath(targetTab.path)
+    }
+
+    // Resume annotation position updates
+    setTimeout(() => {
+      useAnnotationStore.getState().setLoadingDocument(false)
+    }, 100)
+
+    return toolSuccess({
+      selected: true,
+      tabId: targetTab.id,
+      title: targetTab.title,
+      path: targetTab.path
+    })
+  } catch (e) {
+    return toolError(`Failed to switch tab: ${e}`, 'SWITCH_FAILED')
+  }
+}

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -41,6 +41,12 @@ import {
   executeCreateAndOpenFile
 } from './executors/file'
 
+// Tab executors
+import {
+  executeListTabs,
+  executeSelectTab
+} from './executors/tabs'
+
 /** Provenance context for AI-generated content tracking */
 export interface ToolProvenance {
   model: string
@@ -131,6 +137,12 @@ export async function executeTool(
         return await executeReadFile(validatedArgs)
       case 'create_and_open_file':
         return await executeCreateAndOpenFile(validatedArgs)
+
+      // Tab tools
+      case 'list_tabs':
+        return executeListTabs()
+      case 'select_tab':
+        return await executeSelectTab(validatedArgs)
 
       default:
         return toolError(`Tool "${toolName}" not implemented`, 'NOT_IMPLEMENTED')

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -6,12 +6,13 @@ import type { ToolConfig, ToolMode, ToolCategory } from './types'
 import { documentTools } from './schemas/document'
 import { editorTools } from './schemas/editor'
 import { fileTools } from './schemas/file'
+import { tabTools } from './schemas/tabs'
 import { zodToJsonSchema } from './utils'
 
 /**
  * All registered tools.
  */
-export const allTools = [...documentTools, ...editorTools, ...fileTools] as const
+export const allTools = [...documentTools, ...editorTools, ...fileTools, ...tabTools] as const
 
 /**
  * Tool name type (union of all tool names).
@@ -92,7 +93,9 @@ const mcpToolNames = [
   'create_and_open_file',
   'list_comments',
   'add_comment',
-  'resolve_comment'
+  'resolve_comment',
+  'list_tabs',
+  'select_tab'
 ] as const
 
 /**

--- a/src/shared/tools/schemas/index.ts
+++ b/src/shared/tools/schemas/index.ts
@@ -5,3 +5,4 @@
 export * from './document'
 export * from './editor'
 export * from './file'
+export * from './tabs'

--- a/src/shared/tools/schemas/tabs.ts
+++ b/src/shared/tools/schemas/tabs.ts
@@ -1,0 +1,57 @@
+/**
+ * Tab tool schemas - tools for multi-tab navigation.
+ */
+
+import { z } from 'zod'
+import type { ToolConfig } from '../types'
+
+// ============================================================================
+// list_tabs
+// ============================================================================
+
+export const listTabsSchema = z.object({}).describe('No parameters required')
+
+export const listTabsConfig: ToolConfig<typeof listTabsSchema> = {
+  name: 'list_tabs',
+  description:
+    'List all open tabs in the Prose editor. Returns tabId, title, path, isActive, isDirty, isPreview, and documentId for each tab. Call this first when the user references a document by name ("go back to my novel", "switch to the draft") to discover which tab to select.',
+  schema: listTabsSchema,
+  category: 'document',
+  requiresMode: null, // Available in all modes
+  dangerous: false
+}
+
+// ============================================================================
+// select_tab
+// ============================================================================
+
+export const selectTabSchema = z.object({
+  tabId: z
+    .string()
+    .optional()
+    .describe(
+      'The exact tab ID from list_tabs. Preferred over match — use this when you have the ID.'
+    ),
+  match: z
+    .string()
+    .optional()
+    .describe(
+      'Case-insensitive substring to match against tab title and path basename. Use when you only have a partial name. If multiple tabs match, returns an error with candidates. If none match, returns "tab not found".'
+    )
+})
+
+export const selectTabConfig: ToolConfig<typeof selectTabSchema> = {
+  name: 'select_tab',
+  description:
+    'Switch the active tab in the Prose editor. Accepts either tabId (exact, from list_tabs) or match (case-insensitive substring of title or filename). On ambiguous match, returns candidates so the user can pick. Dismisses any pending suggest_edit diff overlay — same side effect as open_file.',
+  schema: selectTabSchema,
+  category: 'document',
+  requiresMode: null,
+  dangerous: false
+}
+
+// ============================================================================
+// Export all tab tools
+// ============================================================================
+
+export const tabTools = [listTabsConfig, selectTabConfig] as const


### PR DESCRIPTION
## Summary

- Adds `list_tabs` MCP tool: read-only snapshot of all open tabs (`tabId`, `title`, `path`, `isActive`, `isDirty`, `isPreview`, `documentId`). No args; safe to call any time without affecting UI.
- Adds `select_tab` MCP tool: switches active document by `tabId` (exact, from `list_tabs`) or `match` (case-insensitive substring of title or path basename). Returns candidates on ambiguous match. Dismisses pending `suggest_edit` diff overlay — same side effect as `open_file`.
- Both tools registered in `mcpToolNames` allowlist (`registry.ts`).
- `SKILL.md` updated: new rows in the tools table, `select_tab` side-effect note, removed the "no get-current-path, ask the user" caveat, and workflow guidance to call `list_tabs` first when the user references a doc by name.

## Manual verification (user action)

- [ ] With Prose open and multiple documents loaded in tabs, connect Claude Desktop (or claude.ai) via MCP.
- [ ] Call `list_tabs` and confirm each open tab appears with correct `title`, `path`, `isActive`, and `isPreview` values.
- [ ] Call `select_tab` with a partial `match` (e.g. the first few letters of a tab title) and confirm the active document switches in Prose.
- [ ] Call `select_tab` with a `match` that matches multiple tabs and confirm the response returns `{ error: "ambiguous", candidates: [...] }` with the matching tabs listed.
- [ ] Call `select_tab` with a `match` that matches nothing and confirm the response returns `"tab not found"`.
- [ ] Say "go back to my novel" — confirm Claude calls `list_tabs` first, then `select_tab`, and the document switches without requiring the user to provide a path.

Closes #450