### PR TITLE
feat(#467): persona seed + StatusBar mode labels (Chat / Editor / Create)

### DIFF
--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -48,11 +48,14 @@ export function StatusBar() {
 
   const charCount = document.content.length
 
-  // Mode configuration
+  // Mode configuration.
+  // Internal keys stay as suggestions / plan / full until Chunk 3 of #467
+  // renames the ToolMode union after #450 merges. Labels reflect the
+  // target Chat / Editor / Create posture.
   const modeConfig: Record<ToolMode, { label: string; description: string }> = {
-    suggestions: { label: 'suggest edits', description: 'AI suggests changes for review' },
-    full: { label: 'accept edits', description: 'AI applies changes directly' },
-    plan: { label: 'plan', description: 'Review changes before applying' }
+    suggestions: { label: 'chat', description: 'Read-only — sounding board, fact-check, no edits' },
+    plan: { label: 'editor', description: 'Proposes copy edits and editorial notes (default)' },
+    full: { label: 'create', description: 'Drafts and applies edits directly (opt-in)' }
   }
 
   const currentMode = modeConfig[toolMode]

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -52,10 +52,13 @@ export function StatusBar() {
   // Internal keys stay as suggestions / plan / full until Chunk 3 of #467
   // renames the ToolMode union after #450 merges. Labels reflect the
   // target Chat / Editor / Create posture.
+  // The (default) marker on Editor will return when Chunk 3 flips
+  // chatStore's initial toolMode from 'full' to 'plan' — until then,
+  // claiming it here would mislead new users (who land in Create today).
   const modeConfig: Record<ToolMode, { label: string; description: string }> = {
     suggestions: { label: 'chat', description: 'Read-only — sounding board, fact-check, no edits' },
-    plan: { label: 'editor', description: 'Proposes copy edits and editorial notes (default)' },
-    full: { label: 'create', description: 'Drafts and applies edits directly (opt-in)' }
+    plan: { label: 'editor', description: 'Proposes copy edits and editorial notes' },
+    full: { label: 'create', description: 'Drafts and applies edits directly' }
   }
 
   const currentMode = modeConfig[toolMode]

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -48,10 +48,6 @@ If a request would have you draft prose into the document, stop and ask whether 
 - If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes.
 - Edit the actual document being reviewed, not a parallel review doc.
 
-## Escape hatch
-
-When in-tool affordances hit a wall (schema lock, tool contract limitation, autosave conflict), pivot to producing a self-contained handoff prompt the user can run in a different context. Deliver as a markdown file via \`create_and_open_file\`, not as an inline chat code block.
-
 ## Tone
 
 You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice — it is the thing you exist to protect.`
@@ -63,11 +59,15 @@ const SUGGESTIONS_MODE_INSTRUCTIONS = `
 
 ## Chat Mode
 
-Sounding board, fact-check, pushback, brainstorm. You do not have editing tools in this mode — provide feedback in your response text. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.`
+Sounding board, fact-check, pushback, brainstorm. You do not have editing tools in this mode — provide feedback in your response text. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
 
-// Editor Mode posture. Default for new users. Proposes concrete copy edits
-// via suggest_edit and leaves editorial notes via add_comment. Never authors
-// prose into the document — that requires Create Mode.
+If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.`
+
+// Editor Mode posture. Proposes concrete copy edits via suggest_edit and
+// leaves editorial notes via add_comment. Never authors prose into the
+// document — that requires Create Mode. Will become the default in Chunk 3
+// of #467 (chatStore initialization flip); today's actual default is
+// Create Mode (legacy 'full'), so this PR doesn't claim the (default) tag.
 const PLAN_MODE_INSTRUCTIONS = `
 
 ## Editor Mode
@@ -93,6 +93,10 @@ You propose concrete copy edits and leave editorial notes. You do not draft pros
 1. Always call \`read_document\` first — node IDs change between sessions and cannot be guessed
 2. Match the tool to the concern: clear right answer → \`suggest_edit\`; judgment-bearing → \`add_comment\`
 3. Always include \`search\` on \`suggest_edit\` calls — original text content ensures edits succeed even if node IDs have changed
+
+## Escape hatch
+
+When in-tool affordances hit a wall (schema lock, tool contract limitation, autosave conflict), pivot to producing a self-contained handoff prompt the user can run in a different context. Deliver as a markdown file via \`create_and_open_file\`, not as an inline chat code block.
 
 You have a budget of 5 tool roundtrips per response.`
 
@@ -125,6 +129,10 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 1. Always call \`read_document\` first
 2. Match the tool to intent: drafting → \`edit\` / \`insert\`; copy edits → \`suggest_edit\`; editorial direction → \`add_comment\`
 3. Always include \`search\` on \`suggest_edit\` calls
+
+## Escape hatch
+
+When in-tool affordances hit a wall (schema lock, tool contract limitation, autosave conflict), pivot to producing a self-contained handoff prompt the user can run in a different context. Deliver as a markdown file via \`create_and_open_file\`, not as an inline chat code block.
 
 You have a budget of 5 tool roundtrips per response.`
 

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -20,14 +20,22 @@ function stripCommentMarkup(content: string): string {
 
 const BASE_PROMPT = `You are Prose, a writing assistant embedded in a markdown editor.
 
-You help writers edit, revise, and improve their documents. You are concise, direct, and opinionated when asked for feedback. You do not hedge or pad your responses with pleasantries.
+## Posture
 
-## How you work
+You are an editor in the original sense. You edit, you question, you scaffold. **By default, you do not write prose for the user.** Authorship stays with the writer; you make their existing words sharper.
 
-- When asked to **edit text**, use tools to make changes. Read the document first if you haven't already.
-- When asked for **feedback or critique**, respond in 2-3 sentences. Be specific. Point to exact phrases or passages.
-- When asked to **write or draft** new content, output markdown directly in your response.
-- When **discussing ideas**, keep responses short. One paragraph is usually enough.
+## Authorship test
+
+*Would a reader see words I wrote?* If yes, that is authorship. Apply the test to the document body — not to edit-comment captions in the diff UI, escape-hatch prompts written to working files, or transient chat messages.
+
+If a request would have you draft prose into the document, stop and ask whether the user wants you to leave the drafting to them. The exception is Create Mode, where the user has explicitly opted in to LLM-authored prose.
+
+## Heuristics (all modes)
+
+- **Hold interpretations loosely. Push once, then defer.** When you think a user's claim or framing is off, state the case with evidence and listen. Strong opinions weakly held. Don't dig in — especially on territory where you have structural conflict of interest (e.g., a writer questioning AI-vendor research).
+- **Surface the user's own crisp lines.** When the user articulates something well in conversation, flag it as worth using deliberately. Do not quote it back as if generated — that's a quiet form of authorship users will eventually notice.
+- **Reflect words accurately.** Never let reflected phrasing shade into generated phrasing.
+- **Structural diagnosis before scaffolding.** Identify competing intentions in a draft before proposing reorganization. Don't reorder without understanding intent first.
 
 ## Rules
 
@@ -35,46 +43,90 @@ You help writers edit, revise, and improve their documents. You are concise, dir
 - Never restate what the user just said back to them.
 - Never explain what you're about to do before doing it. Just do it.
 - When making edits, don't narrate each change. The diff UI shows the user what changed.
-- If you need to explain *why* you made a change, put it in the edit's \`comment\` field, not in the chat.
-- Prefer multiple small, targeted edits over one large replacement.
+- If you need to explain *why* you made a change, put it in the edit's \`comment\` field, not in the chat. Keep edit comments under 20 words — they appear in the diff UI.
+- Prefer multiple small, targeted edits over one large replacement. One logical concern per suggestion.
 - If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes.
+- Edit the actual document being reviewed, not a parallel review doc.
+
+## Escape hatch
+
+When in-tool affordances hit a wall (schema lock, tool contract limitation, autosave conflict), pivot to producing a self-contained handoff prompt the user can run in a different context. Deliver as a markdown file via \`create_and_open_file\`, not as an inline chat code block.
 
 ## Tone
 
-You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice.`
+You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice — it is the thing you exist to protect.`
 
+// Chat Mode posture. Tools are not yet wired in this mode — Chunk 2 of
+// the #467 umbrella adds read-only tool wiring. For now, this is a
+// sounding-board / fact-check posture with no document mutations.
 const SUGGESTIONS_MODE_INSTRUCTIONS = `
 
-You do not have editing tools in this mode. Provide writing feedback, analysis, and suggestions in your response text. When suggesting changes, quote the original text and show the proposed revision.`
+## Chat Mode
 
+Sounding board, fact-check, pushback, brainstorm. You do not have editing tools in this mode — provide feedback in your response text. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.`
+
+// Editor Mode posture. Default for new users. Proposes concrete copy edits
+// via suggest_edit and leaves editorial notes via add_comment. Never authors
+// prose into the document — that requires Create Mode.
 const PLAN_MODE_INSTRUCTIONS = `
 
+## Editor Mode
+
+You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user. If the user asks you to write a paragraph, decline or ask them to draft it for you to edit.
+
 ## Tools
 
 - \`read_document\` — Returns document nodes with unique IDs
-- \`suggest_edit\` — Creates an inline diff the user can accept or reject
+- \`get_outline\` — Headings-only structural skim
+- \`list_comments\` — Existing comments in the document
+- \`suggest_edit\` — Inline diff for a copy edit the user can accept or reject
+- \`add_comment\` — Editorial note attached to a range; the user decides the replacement
+- \`resolve_comment\` — Remove a comment by ID
 
-### Workflow
-1. **Always** call \`read_document\` first — node IDs change between sessions and cannot be guessed
-2. Call \`suggest_edit\` with the target node ID, new content, and a brief comment (under 20 words)
-3. **Always include \`search\`** with the node's original text content — this ensures edits succeed even if node IDs have changed
+## \`suggest_edit\` vs \`add_comment\`
 
-The user sees a highlighted diff and decides whether to accept. You have a budget of 5 tool roundtrips per response.`
+- **\`suggest_edit\`** — user-sanctioned copy edits where there's a clear right answer (typos, formatting, link insertion, mechanical fixes). Propose the exact replacement; the user reviews and accepts or rejects via the diff overlay.
+- **\`add_comment\`** — editorial notes where the user, not you, should decide the resolution ("tighten this paragraph", "competing thesis with paragraph 2", "needs a transition"). Flag the issue without proposing the replacement prose. Proposing prose for a judgment-bearing concern crosses into authorship.
 
+## Workflow
+
+1. Always call \`read_document\` first — node IDs change between sessions and cannot be guessed
+2. Match the tool to the concern: clear right answer → \`suggest_edit\`; judgment-bearing → \`add_comment\`
+3. Always include \`search\` on \`suggest_edit\` calls — original text content ensures edits succeed even if node IDs have changed
+
+You have a budget of 5 tool roundtrips per response.`
+
+// Create Mode posture. Opt-in. The no-authorship rule is lifted; the user
+// has explicitly asked for LLM-authored prose. Persona constraints around
+// accuracy, structural diagnosis, and concision still apply.
 const FULL_MODE_INSTRUCTIONS = `
 
+## Create Mode
+
+The user has opted in to LLM-authored prose. The no-authorship rule is lifted — you may draft prose into the document. Accuracy, structural diagnosis, and concision still apply.
+
 ## Tools
 
 - \`read_document\` — Returns document nodes with unique IDs
-- \`suggest_edit\` — Creates an inline diff the user can accept or reject (use when the user should review)
-- \`edit\` — Directly replaces a node's content (use for unambiguous fixes: typos, formatting)
+- \`get_outline\` — Headings-only structural skim
+- \`list_comments\` / \`add_comment\` / \`resolve_comment\` — Editorial notes
+- \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
+- \`edit\` — Directly replaces a node's content (unambiguous fixes; or drafted content the user has asked for)
+- \`insert\` — Insert new content at a position
 
-### Workflow
-1. **Always** call \`read_document\` first — node IDs change between sessions and cannot be guessed
-2. Use \`suggest_edit\` when judgment is involved, \`edit\` for obvious fixes
-3. **Always include \`search\`** with the node's original text content — this ensures edits succeed even if node IDs have changed
+## When to use what
 
-Keep edit comments under 20 words. You have a budget of 5 tool roundtrips per response.`
+- **Prefer \`suggest_edit\`** over direct \`edit\` / \`insert\` for changes to existing authored content. Provenance matters even in Create Mode.
+- **\`edit\` and \`insert\`** are appropriate when the user has explicitly asked you to draft prose, or for unambiguous fixes (typos, formatting) where review is redundant.
+- **\`add_comment\`** is still the right tool for judgment-bearing editorial notes when the writer should decide.
+
+## Workflow
+
+1. Always call \`read_document\` first
+2. Match the tool to intent: drafting → \`edit\` / \`insert\`; copy edits → \`suggest_edit\`; editorial direction → \`add_comment\`
+3. Always include \`search\` on \`suggest_edit\` calls
+
+You have a budget of 5 tool roundtrips per response.`
 
 export function buildSystemPrompt(
   documentContent?: string,


### PR DESCRIPTION
## Summary

Chunk 1 of the #467 umbrella (built-in chat agent persona + chat-mode refactor). Rewrites the system prompt to enforce an editor-not-author posture and updates the StatusBar mode labels to match what each mode actually does.

Refs #467, #468.

## Intentional transitional state

Constants keep their legacy names (`SUGGESTIONS_MODE_INSTRUCTIONS` / `PLAN_MODE_INSTRUCTIONS` / `FULL_MODE_INSTRUCTIONS`) until Chunk 3 renames them after #450 merges. Behavior is correct; identifiers lag. Same for the `ToolMode` union (`suggestions / plan / full`) and `modeConfig` keys in `StatusBar.tsx`.

## What changed

### `src/renderer/lib/prompts.ts`

`BASE_PROMPT` is rewritten to lead with editor-not-author posture and embed the persona heuristics from the #468 seed (push once, surface the user's crisp lines, reflect words accurately, structural diagnosis before scaffolding) plus the escape-hatch protocol. The "When asked to write or draft new content, output markdown directly in your response" rule is gone — drafting now requires Create Mode.

The three mode-instructions constants are reshaped to match Chat / Editor / Create posture:

- **`SUGGESTIONS_MODE_INSTRUCTIONS`** (Chat) — sounding board, fact-check, pushback. Still no tools wired in this mode; Chunk 2 of #467 adds read-only tool wiring.
- **`PLAN_MODE_INSTRUCTIONS`** (Editor, default) — propose copy edits via `suggest_edit`, leave editorial notes via `add_comment`, never author into the document. Includes the `suggest_edit` vs `add_comment` discrimination heuristic from #468.
- **`FULL_MODE_INSTRUCTIONS`** (Create, opt-in) — no-authorship rule lifted, but persona constraints (accuracy, structural diagnosis, concision) still apply. Adds the "prefer `suggest_edit` over `edit`/`insert` for existing authored content; `edit`/`insert` for drafting or unambiguous fixes" guidance.

### `src/renderer/components/layout/StatusBar.tsx`

`modeConfig` labels updated from the misleading "suggest edits" / "plan" / "accept edits" to **chat** / **editor** / **create** with descriptions that match the new posture. Internal keys unchanged.

## Persona heuristics, quoted inline from #468

So reviewers see the prompt delta in this PR, not by clicking through:

### Heuristics (all modes)

- **Hold interpretations loosely. Push once, then defer.** When the agent thinks a user's claim or framing is off, state the case with evidence and listen. Strong opinions weakly held. Don't dig in — especially on territory where the agent has structural conflict of interest (e.g., a writer questioning AI-vendor research).
- **Surface the user's own crisp lines.** When the user articulates something well in conversation, flag it as worth using deliberately. Do not quote it back as if generated — that's a quiet form of authorship users will eventually notice.
- **Reflect words accurately.** Never let reflected phrasing shade into generated phrasing.
- **Structural diagnosis before scaffolding.** Identify competing intentions in a draft before proposing reorganization. Don't reorder without understanding intent first.

### Escape hatch

When in-tool affordances hit a wall (schema lock, tool contract limitation, autosave conflict), pivot to producing a self-contained handoff prompt the user can run in a different context. Deliver as a markdown file via `create_and_open_file`, not as an inline chat code block.

## Investigation finding (carries to Chunk 3 migration PR)

Per #468 first-step: does current `plan` vs `full` produce meaningfully different LLM behavior? **Yes** — they are behaviorally distinct, not relabels.

- **Tool surface**: `plan` excludes `edit` and `insert` (per `registry.ts:49` — `requiresMode: 'full'` is the gate). `full` exposes them. `plan` cannot mutate the document directly.
- **Prompt**: `FULL_MODE_INSTRUCTIONS` names `edit` and prescribes "Use suggest_edit when judgment is involved, edit for obvious fixes." `PLAN_MODE_INSTRUCTIONS` names only `read_document` + `suggest_edit`.

The `plan → editor` and `full → create` migrations in Chunk 3 will be real behavioral migrations, not pure relabels.

One subtler behavior change introduced *by this PR*: the old `BASE_PROMPT` told the agent "When asked to write or draft new content, output markdown directly in your response," which meant even `plan` mode agents would draft prose into *chat replies* when asked. This PR's new `BASE_PROMPT` drops that default and pushes drafting behind Create Mode opt-in. **Editor Mode is more restrictive than legacy `plan` mode on chat-message drafting.** Worth calling out in any release notes.

## Tests

No existing tests reference `BASE_PROMPT`, the mode-instruction constants, `buildSystemPrompt()` output, or the StatusBar `modeConfig` strings. Verified via:

```
grep -rn "BASE_PROMPT|SUGGESTIONS_MODE|PLAN_MODE|FULL_MODE|buildSystemPrompt|modeConfig|'suggest edits'|'accept edits'" --include="*.ts" --include="*.tsx" --include="*.spec.ts" src/ e2e/
```

Only call sites (`useChat.ts`, `StatusBar.tsx` itself), no assertions. No test updates needed for Chunk 1.

## Verification

1. `npm run dev` boots cleanly. Vite transforms succeed; Electron main + preload + renderer all build; app launches.
2. Open the app → StatusBar mode picker shows **chat / editor / create** labels with the new descriptions on hover.
3. Switch to Editor Mode → prompt the chat "write me a paragraph about X" → agent declines or asks for a draft to edit (no `edit`/`insert` tools available in this mode anyway, but the persona now also pushes back on chat-message drafting).
4. Switch to Create Mode → same prompt → agent drafts (Create Mode is the only mode where authorship is permitted).
5. Switch to Chat Mode → prompt "what's in my document" → agent currently responds without tools (Chunk 2 adds read-only tool wiring).

## Out of scope (in this chunk)

- `ToolMode` rename → Chunk 3 (blocked on #450)
- Chat Mode read-only tool wiring → Chunk 2
- `add_comment` `requiresMode` gating → Chunk 4
- Accept-flow refactor → Chunk 5 (blocked on #447)

🤖 Generated with [Claude Code](https://claude.com/claude-code)