### PR TITLE
feat(#467): Chat Mode passes read-only tools instead of nothing

### DIFF
--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { useChatStore, createMessageId } from '../stores/chatStore'
+import { useChatStore, createMessageId, type ToolMode } from '../stores/chatStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useEditorStore } from '../stores/editorStore'
 import { useEditorInstanceStore } from '../stores/editorInstanceStore'
@@ -12,6 +12,32 @@ import { executeTool, resolveToolPosition } from '../lib/tools'
 import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import { resolveModelName } from '../../shared/llm/models'
 import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
+
+// Chat Mode (legacy internal key 'suggestions') gets a read-only tool subset
+// rather than zero tools, so the agent can ground itself in the document
+// without proposing edits. We can't filter by `category === 'document'` alone
+// — that category includes the mutating add_comment and resolve_comment tools.
+// Mutating comment tools move behind Editor Mode via `requiresMode` in Chunk 4
+// of #467; until then this explicit allowlist is the gate.
+//
+// Audit checkpoint: when #450 (list_tabs / select_tab) merges, decide whether
+// those new tools belong in Chat Mode and extend this set, or defer them to
+// Chunk 3.
+const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'read_document',
+  'read_selection',
+  'get_metadata',
+  'search_document',
+  'get_outline',
+  'list_comments'
+])
+
+function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
+  if (toolMode === 'suggestions') {
+    return getToolsForClaudeAPI('full').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
+  }
+  return getToolsForClaudeAPI(toolMode)
+}
 
 // Module-level flag to ensure stream listeners are only registered once globally
 let streamListenersInitialized = false
@@ -303,7 +329,7 @@ export function useChat() {
         // Call LLM again with tool results
         const settingsState = useSettingsStore.getState()
         const editorState = useEditorStore.getState()
-        const tools = state.toolMode !== 'suggestions' ? getToolsForClaudeAPI(state.toolMode) : undefined
+        const tools = getToolsForToolMode(state.toolMode)
 
         try {
           await api.llmChatStream({
@@ -479,9 +505,9 @@ export function useChat() {
 
       // Initialize tool loop context if tools are enabled
       console.log('[useChat] toolMode:', toolMode)
-      let tools
+      let tools: ReturnType<typeof getToolsForToolMode> | undefined
       try {
-        tools = toolMode !== 'suggestions' ? getToolsForClaudeAPI(toolMode) : undefined
+        tools = getToolsForToolMode(toolMode)
         console.log('[useChat] tools:', tools?.length || 0)
         if (tools && tools.length > 0) {
           console.log('[useChat] First tool schema:', JSON.stringify(tools[0], null, 2))
@@ -490,7 +516,7 @@ export function useChat() {
         console.error('[useChat] Error getting tools:', toolErr)
         tools = undefined
       }
-      if (tools) {
+      if (tools && tools.length > 0) {
         toolLoopContextRef.current = {
           apiMessages,
           assistantMsgId,

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -52,16 +52,27 @@ If a request would have you draft prose into the document, stop and ask whether 
 
 You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice — it is the thing you exist to protect.`
 
-// Chat Mode posture. Tools are not yet wired in this mode — Chunk 2 of
-// the #467 umbrella adds read-only tool wiring. For now, this is a
-// sounding-board / fact-check posture with no document mutations.
+// Chat Mode posture. Read-only tool surface — the agent can read the
+// document to ground its responses but cannot propose edits, comment, or
+// mutate anything.
 const SUGGESTIONS_MODE_INSTRUCTIONS = `
 
 ## Chat Mode
 
-Sounding board, fact-check, pushback, brainstorm. You do not have editing tools in this mode — provide feedback in your response text. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
+Sounding board, fact-check, pushback, brainstorm. You have read-only tools to ground yourself in the document, but you cannot propose edits or leave comments. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
 
-If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.`
+## Tools
+
+- \`read_document\` — Returns document nodes with unique IDs
+- \`read_selection\` — Returns the currently selected text and position
+- \`get_outline\` — Headings-only structural skim
+- \`search_document\` — Locate text or regex matches
+- \`get_metadata\` — Document path, word count, frontmatter, dirty state
+- \`list_comments\` — Existing comments in the document
+
+If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.
+
+You have a budget of 5 tool roundtrips per response.`
 
 // Editor Mode posture. Proposes concrete copy edits via suggest_edit and
 // leaves editorial notes via add_comment. Never authors prose into the
@@ -163,7 +174,8 @@ export function buildSystemPrompt(
     prompt += `\n\nThe user is currently working on the following document:\n\n---\n${cleanContent}\n---`
 
     if (!toolMode || toolMode === 'suggestions') {
-      // Line references only when no tools available
+      // Chat Mode: agent references doc content in plain chat replies; line
+      // refs render as clickable jump-to-line links in the UI.
       prompt += `\n\n## Referencing Line Numbers\nFormat: [Line N](line:N) — these render as clickable links that navigate to that line.`
     } else {
       prompt += `\n\nCall \`read_document\` for node IDs needed by editing tools.`


### PR DESCRIPTION
## Summary

Chunk 2 of the #467 umbrella. Chat Mode (internal `ToolMode` key `'suggestions'`) currently passes zero tools to the LLM — `useChat.ts:306,484` had a `state.toolMode !== 'suggestions' ? getToolsForClaudeAPI(...) : undefined` ternary. This means the in-app chat agent couldn't even read the document to ground its responses. Chunk 2 wires a read-only tool subset so Chat Mode becomes a real sounding-board mode that can ground itself in the doc.

**Stacked on #513** — base branch is `issue-467-persona-seed-prompts`. Merge #513 first.

Refs #467, #468.

## What changed

### `src/renderer/hooks/useChat.ts`

- New module-level allowlist: `CHAT_MODE_TOOL_NAMES` — `read_document`, `read_selection`, `get_outline`, `search_document`, `get_metadata`, `list_comments`.
- New helper: `getToolsForToolMode(toolMode)` — returns the Chat Mode subset for `'suggestions'`, otherwise delegates to `getToolsForClaudeAPI(toolMode)`.
- Both call sites (`:306`, `:484`) collapse from the old ternary into a single `getToolsForToolMode(...)` call.
- Tool-loop init guard (line ~493) tightened from `if (tools)` to `if (tools && tools.length > 0)` to preserve the original "don't init when there are no tools" semantics now that `tools` is always an array.

### `src/renderer/lib/prompts.ts`

- `SUGGESTIONS_MODE_INSTRUCTIONS` rewritten to describe the new read-only tool surface, with a redirect note: "If the user asks for an edit or annotation, tell them to switch to Editor Mode (StatusBar → editor) and re-ask." The previous version said the agent has no tools and should put proposed revisions in chat text.
- Touched the `// Line references only when no tools available` comment in `buildSystemPrompt()` — now reads "Chat Mode: agent references doc content in plain chat replies; line refs render as clickable jump-to-line links in the UI" since Chat Mode has tools now. The line-refs block itself is kept as-is (clickable jump-to-line is useful regardless of tool surface).

## Deviation from the approved chunking plan — read this

The plan's Chunk 2 bullet said: *"filter by `category === 'document'` when in `suggestions` mode."* That filter is **too loose** in this codebase as it stands — `category: 'document'` includes the **mutating** `add_comment` and `resolve_comment` tools (see `src/shared/tools/schemas/document.ts:142,160`). A pure category filter would silently put `add_comment` in Chat Mode, breaking the "Chat Mode is read-only" invariant the chunking plan explicitly relies on.

This PR substitutes an explicit name allowlist instead. Rationale:

- **It's read-only by construction.** The set lists the six tools that actually read; you can't accidentally let a mutating tool through by typo or by a downstream category change.
- **It survives #450.** When `list_tabs` / `select_tab` land, they'll have a different category anyway (likely `'ui'` or a new tab category). The plan's `category === 'document'` filter would have excluded them automatically; the allowlist explicitly excludes them too, and we revisit when #450 merges to decide whether tab discovery belongs in Chat Mode.
- **The plan's reasoning still holds.** Category-vs-`requiresMode` was the user's preference because `category` is intent-based. An explicit allowlist is also intent-based — just at a finer grain.

If you'd prefer the pure category filter and accept the temporary `add_comment` leak until Chunk 4 sets `requiresMode: 'editor'` on it, say so and I'll swap it. Default stance: stay surgical.

## #450 / #447 contention status

- `gh pr list --repo solo-ist/prose --state open --search '450 list_tabs select_tab'` → no open PR. #450 not yet in flight.
- `src/shared/tools/registry.ts` not touched in this PR (the filter lives at the call site in `useChat.ts`), so this PR does not race with #450.
- `src/renderer/extensions/ai-suggestions/**` not touched, so no race with #447.

## Tests

No existing tests reference `useChat`'s tool wiring, `getToolsForClaudeAPI`, `CHAT_MODE_TOOL_NAMES`, or `SUGGESTIONS_MODE_INSTRUCTIONS` output. Verified via the same grep as Chunk 1 (#513). No test updates needed.

If we want unit coverage for the Chat Mode filter (recommended once we add a vitest setup), the test would assert `getToolsForToolMode('suggestions').map(t => t.name)` matches the allowlist exactly and excludes `add_comment` / `resolve_comment`. Leaving as a follow-up unless you want it inline.

## Verification

1. `npm run dev` — main process + preload + vite all build clean.
2. Open the app on the Chunk 2 branch. Switch to **chat** mode in the StatusBar.
3. Prompt the chat: *"what's in my document?"* — agent calls `read_document`, summarizes the content. Previously: agent had no tools and either guessed or refused.
4. Prompt: *"add a comment on paragraph 2"* — agent declines and tells the user to switch to Editor Mode. (Mutating comment tools are not in the Chat Mode allowlist.)
5. Switch to **editor** mode. Same comment-add request now works.
6. Switch to **create** mode. All tools still available, no regression.

## Out of scope (in this chunk)

- `ToolMode` rename to `chat / editor / create` → Chunk 3 (blocked on #450).
- `add_comment` gated by `requiresMode: 'editor'` → Chunk 4 (after Chunk 3 + #455 verification).
- Accept-flow refactor → Chunk 5 (blocked on #447).

🤖 Generated with [Claude Code](https://claude.com/claude-code)