### PR TITLE
ci: surface friendly error for non-collaborator permission checks (#374)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,13 +31,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.payload.comment.user.login,
-            });
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(`User ${context.payload.comment.user.login} lacks write access`);
+            const username = context.payload.comment.user.login;
+            let permission;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status === 404) {
+                core.setFailed(`User ${username} lacks write access to this repository (not a collaborator)`);
+                return;
+              }
+              throw err;
+            }
+            if (!['admin', 'write'].includes(permission)) {
+              core.setFailed(`User ${username} lacks write access (permission: ${permission})`);
             }
 
       - name: Checkout repository
@@ -186,13 +197,23 @@ jobs:
             } else {
               username = context.payload.comment.user.login;
             }
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username,
-            });
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(`User ${username} lacks write access`);
+            let permission;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status === 404) {
+                core.setFailed(`User ${username} lacks write access to this repository (not a collaborator)`);
+                return;
+              }
+              throw err;
+            }
+            if (!['admin', 'write'].includes(permission)) {
+              core.setFailed(`User ${username} lacks write access (permission: ${permission})`);
             }
 
       - name: Checkout repository

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -31,13 +31,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.payload.comment.user.login,
-            });
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(`User ${context.payload.comment.user.login} lacks write access`);
+            const username = context.payload.comment.user.login;
+            let permission;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status === 404) {
+                core.setFailed(`User ${username} lacks write access to this repository (not a collaborator)`);
+                return;
+              }
+              throw err;
+            }
+            if (!['admin', 'write'].includes(permission)) {
+              core.setFailed(`User ${username} lacks write access (permission: ${permission})`);
             }
 
       - name: Determine PR number

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,13 +30,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.payload.comment.user.login,
-            });
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(`User ${context.payload.comment.user.login} lacks write access`);
+            const username = context.payload.comment.user.login;
+            let permission;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status === 404) {
+                core.setFailed(`User ${username} lacks write access to this repository (not a collaborator)`);
+                return;
+              }
+              throw err;
+            }
+            if (!['admin', 'write'].includes(permission)) {
+              core.setFailed(`User ${username} lacks write access (permission: ${permission})`);
             }
 
       - name: Resolve PR ref

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -35,13 +35,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.payload.comment.user.login,
-            });
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(`User ${context.payload.comment.user.login} lacks write access`);
+            const username = context.payload.comment.user.login;
+            let permission;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status === 404) {
+                core.setFailed(`User ${username} lacks write access to this repository (not a collaborator)`);
+                return;
+              }
+              throw err;
+            }
+            if (!['admin', 'write'].includes(permission)) {
+              core.setFailed(`User ${username} lacks write access (permission: ${permission})`);
             }
 
       - name: Resolve PR ref and SHA


### PR DESCRIPTION
## Summary

`getCollaboratorPermissionLevel` throws HTTP 404 for non-collaborators instead of returning a non-write permission level. The permission-gate steps fail correctly (secure outcome) but the error message in CI was the raw `HttpError: Not Found` — confusing for anyone debugging why their `@claude`/`/test`/`/triage` comment got rejected.

This PR wraps the call in try/catch and surfaces a readable failure:

> `User <login> lacks write access to this repository (not a collaborator)`

Non-404 errors are re-thrown so unrelated failures aren't masked.

## Files changed

All 5 permission-gate steps across 4 workflows:

- `.github/workflows/claude.yml` — both `auto-review` and `claude` jobs
- `.github/workflows/dispatch.yml`
- `.github/workflows/e2e.yml`
- `.github/workflows/web-e2e.yml`

## Provenance

Implementation was originally drafted by the cloud `@claude` agent on #374 but the agent's GitHub App lacked `workflows: write` scope and couldn't push. Applied locally from the agent's posted diff.

## Test plan

- [ ] CI green on this PR (claude review, E2E)
- [ ] After merge: confirm a non-collaborator triggering `/test` or `@claude` sees the readable failure in the Actions run

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)