### PR TITLE
refactor(ci): use machine-readable sentinel for security gate detection (#395)

### DIFF
--- a/.claude/skills/pipeline-eng/SKILL.md
+++ b/.claude/skills/pipeline-eng/SKILL.md
@@ -30,14 +30,16 @@ The full workflow chain, trigger to output:
 | `claude.yml` (auto-review) | `/review` comment on PR | — | `<!-- review-verdict: clean -->` or `<!-- review-verdict: issues-found -->` | — |
 | `review-feedback.yml` (clean-gate) | `issue_comment` with `<!-- review-verdict: clean -->` | `<!-- review-verdict: clean -->`, absence of `<!-- review-feedback-analysis -->` | `<!-- review-feedback-analysis -->` | — |
 | `review-feedback.yml` (analyze) | `issue_comment` with `## Code Review` (no verdict trailer) | absence of `<!-- review-feedback-analysis -->`, `<!-- review-verdict: clean -->`, `<!-- review-verdict: issues-found -->` | `<!-- review-feedback-analysis -->`, `<!-- pipeline-bypass-warning -->` | — |
-| `pipeline-triage.yml` (security-gate) | `issue_comment` with `<!-- review-verdict: issues-found -->` | `[SECURITY GATE]` in review body | `<!-- orchestrator-verdict: hitl-full -->` (short-circuit) | — |
+| `pipeline-triage.yml` (security-gate) | `issue_comment` with `<!-- review-verdict: issues-found -->` | `<!-- security-gate: true -->` in review body | `<!-- orchestrator-verdict: hitl-full -->` (short-circuit) | — |
 | `pipeline-triage.yml` (scorer + PE) | `issue_comment` with `<!-- review-verdict: issues-found -->` (security gate NOT detected) | `<!-- review-verdict: issues-found -->`, absence of `<!-- scorer-output:` / `<!-- pe-output:` | `<!-- scorer-output: {...} -->`, `<!-- pe-output: {...} -->` | — |
 | `pipeline-triage.yml` (orchestrate) | `needs: [run-scorer, run-pe-analysis]` | `<!-- scorer-output: {...} -->`, `<!-- pe-output: {...} -->` | `<!-- orchestrator-verdict: auto-fix\|auto-fix-verify\|hitl-light\|hitl-full -->` | — |
 | `pipeline-fix.yml` | `issue_comment` with `<!-- orchestrator-verdict: auto-fix -->` or `auto-fix-verify` | `<!-- orchestrator-verdict: ... -->`, absence of `<!-- agent-fix-attempt:` AND `<!-- e2e-fix-attempt:` | `<!-- agent-fix-attempt: 1 -->`, `<!-- agent-fix-escalation -->` | — |
 | `dispatch.yml` | `/triage`, `/fix`, `/pipeline` comment | — | — | `pipeline-triage.yml`, `pipeline-fix.yml`, or posts `/review` |
 | `notify.yml` | PR labeled `needs-review` or `complex` | — | — | Slack webhook |
 
-**Sync hazard:** `run-pe-analysis.mjs` and `claude.yml` auto-review both hardcode the same privilege-boundary path list (`src/main/**`, `src/preload/**`, `electron-builder.*`, `electron.vite.config.*`). If you update one, update the other. `validate-pipeline.sh` invariant #19 enforces this.
+**Sync hazard:** `run-pe-analysis.mjs` and `claude.yml` auto-review both hardcode the same privilege-boundary path list (`src/main/**`, `src/preload/**`, `electron-builder.*`, `electron.vite.config.*`). If you update one, update the other. `validate-pipeline.sh` invariant #20 enforces this.
+
+**Sync hazard:** `claude.yml` emits and `pipeline-triage.yml` greps the `<!-- security-gate: true -->` sentinel. If either side drifts, the short-circuit silently breaks and privilege-boundary PRs waste API calls on scorer+PE. `validate-pipeline.sh` invariant #19 enforces this.
 
 **Dual `/test` trigger:** Posting `/test` on a PR fires BOTH `e2e.yml` (Electron Playwright) and `web-e2e.yml` (browser Playwright) in parallel. This is intentional — it runs the full test matrix. For `pull_request` events, only `e2e.yml` runs automatically; `web-e2e.yml` only runs on `accelerated`-labeled PRs.
 

--- a/.claude/skills/pipeline-orchestrate/SKILL.md
+++ b/.claude/skills/pipeline-orchestrate/SKILL.md
@@ -43,7 +43,7 @@ PRs touching privilege-boundary paths auto-route to `hitl-full` regardless of sc
 - `src/preload/**` — context bridge / attack surface
 - `electron-builder.*`, `electron.vite.config.*` — build/packaging config
 
-With the security-gate short-circuit (383-2), these PRs skip scorer+PE entirely — the `pipeline-triage.yml` `security-gate-check` job detects `[SECURITY GATE]` in the review and posts `hitl-full` directly.
+With the security-gate short-circuit (383-2), these PRs skip scorer+PE entirely — the `pipeline-triage.yml` `security-gate-check` job detects the `<!-- security-gate: true -->` sentinel in the review and posts `hitl-full` directly.
 
 ## Workflow
 

--- a/.github/scripts/validate-pipeline.sh
+++ b/.github/scripts/validate-pipeline.sh
@@ -236,7 +236,25 @@ if $SENTINEL_OK; then
 fi
 echo ""
 
-# 19. Privilege-boundary path sync (383-7)
+# 19. Security-gate sentinel sync (#395)
+# claude.yml emits `<!-- security-gate: true -->` and pipeline-triage.yml
+# greps for the same sentinel. If either side drifts, the short-circuit
+# silently breaks and privilege-boundary PRs waste API calls on scorer+PE.
+echo "--- Check: Security-gate sentinel sync ---"
+SENTINEL_SYNC_OK=true
+for f in .github/workflows/claude.yml .github/workflows/pipeline-triage.yml; do
+  if ! grep -q "security-gate: true" "$f"; then
+    echo "FAIL: $f does not reference the 'security-gate: true' sentinel"
+    SENTINEL_SYNC_OK=false
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+if $SENTINEL_SYNC_OK; then
+  echo "PASS"
+fi
+echo ""
+
+# 20. Privilege-boundary path sync (383-7)
 # The path list must be identical in claude.yml and run-pe-analysis.mjs
 echo "--- Check: Privilege-boundary path sync ---"
 PATHS_CLAUDE=$(grep -oE 'src/main/\*\*|src/preload/\*\*|electron-builder\.\*|electron\.vite\.config\.\*' .github/workflows/claude.yml | sort -u)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -102,10 +102,12 @@ jobs:
             - [ ] Dependencies checked for known CVEs (if new deps added)
             - [ ] Content Security Policy not weakened
 
-            If the PR touches privilege-boundary files (`src/main/**`, `src/preload/**`, `electron-builder.*`, `electron.vite.config.*`), prepend your review with:
+            If the PR touches privilege-boundary files (`src/main/**`, `src/preload/**`, `electron-builder.*`, `electron.vite.config.*`), prepend your review with the following hidden HTML comment **exactly** (do not paraphrase, translate, or alter — it is a machine-readable sentinel parsed by `pipeline-triage.yml`):
             (NOTE: This list is duplicated in run-pe-analysis.mjs — keep both in sync)
 
-            > **[SECURITY GATE]** This PR modifies Electron privilege-boundary code. Requires human review regardless of other findings.
+            `<!-- security-gate: true -->`
+
+            After the sentinel, also include a short human-readable note explaining that this PR modifies Electron privilege-boundary code and requires full human review regardless of other findings.
 
             Be concise. Only comment on significant issues - if the code looks good, say so briefly.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -103,11 +103,12 @@ jobs:
             - [ ] Content Security Policy not weakened
 
             If the PR touches privilege-boundary files (`src/main/**`, `src/preload/**`, `electron-builder.*`, `electron.vite.config.*`), prepend your review with the following hidden HTML comment **exactly** (do not paraphrase, translate, or alter — it is a machine-readable sentinel parsed by `pipeline-triage.yml`):
-            (NOTE: This list is duplicated in run-pe-analysis.mjs — keep both in sync)
 
             `<!-- security-gate: true -->`
 
             After the sentinel, also include a short human-readable note explaining that this PR modifies Electron privilege-boundary code and requires full human review regardless of other findings.
+
+            (Maintainer note: the privilege-boundary path list above is duplicated in `run-pe-analysis.mjs` — keep both in sync.)
 
             Be concise. Only comment on significant issues - if the code looks good, say so briefly.
 

--- a/.github/workflows/pipeline-triage.yml
+++ b/.github/workflows/pipeline-triage.yml
@@ -11,9 +11,12 @@ on:
         type: number
 
 jobs:
-  # 383-2: Short-circuit when review contains [SECURITY GATE] — skip scorer+PE,
-  # go straight to hitl-full. PRs touching privilege-boundary files always route
-  # hitl-full regardless of score, so running scorer+PE is pure API waste.
+  # 383-2: Short-circuit when review contains the `<!-- security-gate: true -->`
+  # sentinel — skip scorer+PE, go straight to hitl-full. PRs touching
+  # privilege-boundary files always route hitl-full regardless of score, so
+  # running scorer+PE is pure API waste. The sentinel is emitted by the review
+  # prompt in claude.yml; both files must reference `security-gate: true`
+  # (enforced by .github/scripts/validate-pipeline.sh).
   security-gate-check:
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -55,7 +58,7 @@ jobs:
             REVIEW="$COMMENT_BODY"
           fi
 
-          if echo "$REVIEW" | grep -q '\[SECURITY GATE\]'; then
+          if echo "$REVIEW" | grep -q '<!-- security-gate: true -->'; then
             echo "::notice::Security gate detected — short-circuiting to hitl-full (skipping scorer+PE)"
             echo "shortcircuit=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

The `pipeline-triage.yml` security-gate short-circuit was detecting privilege-boundary PRs by grepping for the literal string `[SECURITY GATE]` in the review comment body — a silent coupling between the prompt wording in `claude.yml` and the triage workflow. If the LLM paraphrased or the prompt drifted, the short-circuit would silently break and privilege-boundary PRs would waste API calls on scorer+PE before still ending up at `hitl-full`.

This PR swaps the human-readable text for a hidden HTML comment sentinel that the LLM is instructed to emit verbatim.

## Changes

**`refactor(ci):` commit:**
- `claude.yml` — review prompt instructs the LLM to emit `<!-- security-gate: true -->` exactly (with a separate human-readable note for reviewers)
- `pipeline-triage.yml` — `grep -q '<!-- security-gate: true -->'` replaces the text match; comment block explains the contract
- `validate-pipeline.sh` — new invariant **#19** asserts both files reference `security-gate: true`; the existing privilege-boundary path-sync renumbered to **#20**

**`docs(pipeline):` follow-up commit:**
- `pipeline-eng` and `pipeline-orchestrate` skill docs updated to reference the sentinel and the renumbered invariant

## Verification

Local: `bash .github/scripts/validate-pipeline.sh` → all 20 checks pass, including the new sentinel-sync invariant.

## Provenance

Cloud `@claude` agent drafted this on #395 but the GitHub App lacked `workflows: write` scope and couldn't push. Applied locally from the agent's posted patch (verbatim + skill-docs follow-on as suggested).

Closes #395
Refs #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)