### PR TITLE
feat(#467): Chat Mode passes read-only tools instead of nothing

### DIFF
--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { useChatStore, createMessageId } from '../stores/chatStore'
+import { useChatStore, createMessageId, type ToolMode } from '../stores/chatStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useEditorStore } from '../stores/editorStore'
 import { useEditorInstanceStore } from '../stores/editorInstanceStore'
@@ -12,6 +12,32 @@ import { executeTool, resolveToolPosition } from '../lib/tools'
 import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import { resolveModelName } from '../../shared/llm/models'
 import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
+
+// Chat Mode (legacy internal key 'suggestions') gets a read-only tool subset
+// rather than zero tools, so the agent can ground itself in the document
+// without proposing edits. We can't filter by `category === 'document'` alone
+// — that category includes the mutating add_comment and resolve_comment tools.
+// Mutating comment tools move behind Editor Mode via `requiresMode` in Chunk 4
+// of #467; until then this explicit allowlist is the gate.
+//
+// Audit checkpoint: when #450 (list_tabs / select_tab) merges, decide whether
+// those new tools belong in Chat Mode and extend this set, or defer them to
+// Chunk 3.
+const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'read_document',
+  'read_selection',
+  'get_metadata',
+  'search_document',
+  'get_outline',
+  'list_comments'
+])
+
+function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
+  if (toolMode === 'suggestions') {
+    return getToolsForClaudeAPI('full').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
+  }
+  return getToolsForClaudeAPI(toolMode)
+}
 
 // Module-level flag to ensure stream listeners are only registered once globally
 let streamListenersInitialized = false
@@ -303,7 +329,7 @@ export function useChat() {
         // Call LLM again with tool results
         const settingsState = useSettingsStore.getState()
         const editorState = useEditorStore.getState()
-        const tools = state.toolMode !== 'suggestions' ? getToolsForClaudeAPI(state.toolMode) : undefined
+        const tools = getToolsForToolMode(state.toolMode)
 
         try {
           await api.llmChatStream({
@@ -479,9 +505,9 @@ export function useChat() {
 
       // Initialize tool loop context if tools are enabled
       console.log('[useChat] toolMode:', toolMode)
-      let tools
+      let tools: ReturnType<typeof getToolsForToolMode> | undefined
       try {
-        tools = toolMode !== 'suggestions' ? getToolsForClaudeAPI(toolMode) : undefined
+        tools = getToolsForToolMode(toolMode)
         console.log('[useChat] tools:', tools?.length || 0)
         if (tools && tools.length > 0) {
           console.log('[useChat] First tool schema:', JSON.stringify(tools[0], null, 2))
@@ -490,7 +516,7 @@ export function useChat() {
         console.error('[useChat] Error getting tools:', toolErr)
         tools = undefined
       }
-      if (tools) {
+      if (tools && tools.length > 0) {
         toolLoopContextRef.current = {
           apiMessages,
           assistantMsgId,

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -52,16 +52,27 @@ If a request would have you draft prose into the document, stop and ask whether 
 
 You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice — it is the thing you exist to protect.`
 
-// Chat Mode posture. Tools are not yet wired in this mode — Chunk 2 of
-// the #467 umbrella adds read-only tool wiring. For now, this is a
-// sounding-board / fact-check posture with no document mutations.
+// Chat Mode posture. Read-only tool surface — the agent can read the
+// document to ground its responses but cannot propose edits, comment, or
+// mutate anything.
 const SUGGESTIONS_MODE_INSTRUCTIONS = `
 
 ## Chat Mode
 
-Sounding board, fact-check, pushback, brainstorm. You do not have editing tools in this mode — provide feedback in your response text. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
+Sounding board, fact-check, pushback, brainstorm. You have read-only tools to ground yourself in the document, but you cannot propose edits or leave comments. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
 
-If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.`
+## Tools
+
+- \`read_document\` — Returns document nodes with unique IDs
+- \`read_selection\` — Returns the currently selected text and position
+- \`get_outline\` — Headings-only structural skim
+- \`search_document\` — Locate text or regex matches
+- \`get_metadata\` — Document path, word count, frontmatter, dirty state
+- \`list_comments\` — Existing comments in the document
+
+If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.
+
+You have a budget of 5 tool roundtrips per response.`
 
 // Editor Mode posture. Proposes concrete copy edits via suggest_edit and
 // leaves editorial notes via add_comment. Never authors prose into the
@@ -163,7 +174,8 @@ export function buildSystemPrompt(
     prompt += `\n\nThe user is currently working on the following document:\n\n---\n${cleanContent}\n---`
 
     if (!toolMode || toolMode === 'suggestions') {
-      // Line references only when no tools available
+      // Chat Mode: agent references doc content in plain chat replies; line
+      // refs render as clickable jump-to-line links in the UI.
       prompt += `\n\n## Referencing Line Numbers\nFormat: [Line N](line:N) — these render as clickable links that navigate to that line.`
     } else {
       prompt += `\n\nCall \`read_document\` for node IDs needed by editing tools.`


### PR DESCRIPTION
## Summary

Chunk 2 of the #467 umbrella. Chat Mode (internal `ToolMode` key `'suggestions'`) currently passes zero tools to the LLM. This wires a read-only tool subset so Chat Mode becomes a real sounding-board mode that can ground itself in the doc.

**Replaces #514**, which was auto-closed when its previous base branch (`issue-467-persona-seed-prompts`) was deleted after #513 squash-merged. Same diff, rebased onto `release/v1.2-agent-persona`.

Refs #467, #468.

## What changed

### `src/renderer/hooks/useChat.ts`

- New module-level allowlist: `CHAT_MODE_TOOL_NAMES` — `read_document`, `read_selection`, `get_outline`, `search_document`, `get_metadata`, `list_comments`.
- New helper: `getToolsForToolMode(toolMode)` — returns the Chat Mode subset for `'suggestions'`, otherwise delegates to `getToolsForClaudeAPI(toolMode)`.
- Both call sites (`:306`, `:484`) collapse from the old ternary into a single `getToolsForToolMode(...)` call.
- Tool-loop init guard tightened from `if (tools)` to `if (tools && tools.length > 0)`.

### `src/renderer/lib/prompts.ts`

- `SUGGESTIONS_MODE_INSTRUCTIONS` rewritten to describe the new read-only tool surface with a redirect note: "If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask."
- Touched the `// Line references` comment in `buildSystemPrompt()` — line-refs block kept (clickable jump-to-line is useful regardless of tool surface).

## Deviation from the approved chunking plan

The plan said: *"filter by `category === 'document'` when in `suggestions` mode."* That filter is too loose — `category: 'document'` includes the mutating `add_comment` and `resolve_comment`. This PR substitutes an explicit name allowlist instead. Rationale: read-only by construction; survives #450; finer-grained intent-based filter. See the original #514 thread for the full discussion.

## Tests

No existing tests reference `useChat`'s tool wiring or `SUGGESTIONS_MODE_INSTRUCTIONS` output. No test updates needed.

## Verification

1. `npm run dev` — main + preload + vite all build clean.
2. Switch to **chat** mode in the StatusBar.
3. Prompt: *"what's in my document?"* → agent calls `read_document` and summarizes.
4. Prompt: *"add a comment on paragraph 2"* → agent declines and tells the user to switch to Editor Mode.
5. Switch to **editor** mode. Same comment-add request works.
6. Switch to **create** mode. All tools still available, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)