### PR TITLE
refactor(#467): rename ToolMode → chat/editor/create + flip default to Editor

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -60,7 +60,7 @@ export function Editor() {
   const sourceMode = useEditorStore((state) => state.sourceMode)
   const setSourceMode = useEditorStore((state) => state.setSourceMode)
   const { settings, setDialogOpen, setShortcutsDialogOpen, setModelPickerOpen } = useSettings()
-  const { setContext, agentMode, setAgentMode } = useChat()
+  const { setContext, cycleToolMode } = useChat()
   const { isChatOpen, isFileListOpen, toggleChat, toggleFileList, setChatOpen, setFileListOpen } = usePanelLayoutContext()
   const setEditorInstance = useEditorInstanceStore((state) => state.setEditor)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -643,9 +643,11 @@ export function Editor() {
       e.preventDefault()
       setShortcutsDialogOpen(true)
     } else if (e.shiftKey && e.key === 'Tab' && !isMod) {
-      // Shift+Tab: Toggle agent mode
+      // Shift+Tab: Cycle through tool modes (chat → editor → create → chat).
+      // Editor must be reachable via keyboard — it's the new safe-by-default
+      // mode, and the previous binary agentMode toggle skipped it.
       e.preventDefault()
-      setAgentMode(!agentMode)
+      cycleToolMode()
     } else if (isMod && e.key === 'k' && !e.shiftKey) {
       // Cmd+K: Insert/edit link
       e.preventDefault()
@@ -734,7 +736,7 @@ export function Editor() {
         }
       }
     }
-  }, [openFile, saveFile, setDialogOpen, setShortcutsDialogOpen, setModelPickerOpen, editor, setContext, setChatOpen, setFileListOpen, toggleChat, toggleFileList, isChatOpen, isFileListOpen, isFindOpen, openAddCommentDialog, openLinkPopover, agentMode, setAgentMode, toggleAnnotationsVisible])
+  }, [openFile, saveFile, setDialogOpen, setShortcutsDialogOpen, setModelPickerOpen, editor, setContext, setChatOpen, setFileListOpen, toggleChat, toggleFileList, isChatOpen, isFileListOpen, isFindOpen, openAddCommentDialog, openLinkPopover, cycleToolMode, toggleAnnotationsVisible])
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown)

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -899,7 +899,7 @@ export function App() {
     const unsubscribe = window.api.onMcpToolInvoke(async (requestId, toolName, args) => {
       try {
         const documentId = useEditorStore.getState().document.documentId
-        const result = await executeTool(toolName, args, 'full', {
+        const result = await executeTool(toolName, args, 'create', {
           model: 'Claude (MCP)',
           conversationId: requestId,
           messageId: requestId,

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -49,16 +49,12 @@ export function StatusBar() {
   const charCount = document.content.length
 
   // Mode configuration.
-  // Internal keys stay as suggestions / plan / full until Chunk 3 of #467
-  // renames the ToolMode union after #450 merges. Labels reflect the
-  // target Chat / Editor / Create posture.
-  // The (default) marker on Editor will return when Chunk 3 flips
-  // chatStore's initial toolMode from 'full' to 'plan' — until then,
-  // claiming it here would mislead new users (who land in Create today).
+  // ToolMode union renamed to chat / editor / create in #467 Chunk 3.
+  // Editor is the actual default — chatStore initializes new users into it.
   const modeConfig: Record<ToolMode, { label: string; description: string }> = {
-    suggestions: { label: 'chat', description: 'Read-only — sounding board, fact-check, no edits' },
-    plan: { label: 'editor', description: 'Proposes copy edits and editorial notes' },
-    full: { label: 'create', description: 'Drafts and applies edits directly' }
+    chat: { label: 'chat', description: 'Read-only — sounding board, fact-check, no edits' },
+    editor: { label: 'editor', description: 'Proposes copy edits and editorial notes (default)' },
+    create: { label: 'create', description: 'Drafts and applies edits directly (opt-in)' }
   }
 
   const currentMode = modeConfig[toolMode]

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -110,7 +110,6 @@ export function useChat() {
     togglePanel,
     setPanelOpen,
     setContext,
-    setAgentMode,
     setToolMode,
     cycleToolMode,
     startStreaming,
@@ -694,7 +693,6 @@ export function useChat() {
     togglePanel,
     setPanelOpen,
     setContext,
-    setAgentMode,
     setToolMode,
     cycleToolMode
   }

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -112,6 +112,7 @@ export function useChat() {
     setContext,
     setAgentMode,
     setToolMode,
+    cycleToolMode,
     startStreaming,
     appendStreamChunk,
     completeStreaming
@@ -694,6 +695,7 @@ export function useChat() {
     setPanelOpen,
     setContext,
     setAgentMode,
-    setToolMode
+    setToolMode,
+    cycleToolMode
   }
 }

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -13,16 +13,15 @@ import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import { resolveModelName } from '../../shared/llm/models'
 import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
 
-// Chat Mode (legacy internal key 'suggestions') gets a read-only tool subset
-// rather than zero tools, so the agent can ground itself in the document
-// without proposing edits. We can't filter by `category === 'document'` alone
-// — that category includes the mutating add_comment and resolve_comment tools.
-// Mutating comment tools move behind Editor Mode via `requiresMode` in Chunk 4
-// of #467; until then this explicit allowlist is the gate.
+// Chat Mode gets a read-only tool subset rather than the full read+write
+// surface, so the agent can ground itself in the document without proposing
+// edits. We can't filter by `category === 'document'` alone — that category
+// includes the mutating add_comment and resolve_comment tools. Mutating
+// comment tools move behind Editor Mode via `requiresMode` in Chunk 4 of
+// #467; until then this explicit allowlist is the gate.
 //
-// Audit checkpoint: when #450 (list_tabs / select_tab) merges, decide whether
-// those new tools belong in Chat Mode and extend this set, or defer them to
-// Chunk 3.
+// Audit checkpoint: when new MCP/agent tools land (e.g., list_tabs, select_tab
+// from #450), decide whether they belong in Chat Mode and extend this set.
 const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'read_document',
   'read_selection',
@@ -33,8 +32,8 @@ const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
 ])
 
 function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
-  if (toolMode === 'suggestions') {
-    return getToolsForClaudeAPI('full').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
+  if (toolMode === 'chat') {
+    return getToolsForClaudeAPI('create').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
   }
   return getToolsForClaudeAPI(toolMode)
 }
@@ -347,7 +346,7 @@ export function useChat() {
             streamId: newStreamId,
             tools,
             maxToolRoundtrips: 5,
-            maxTokens: state.toolMode === 'suggestions' ? 3072 : 4096
+            maxTokens: state.toolMode === 'chat' ? 3072 : 4096
           })
         } catch (error) {
           console.error('[Chat] Tool loop error:', error)
@@ -547,7 +546,7 @@ export function useChat() {
           streamId,
           tools,
           maxToolRoundtrips: 5,
-          maxTokens: toolMode === 'suggestions' ? 3072 : 4096
+          maxTokens: toolMode === 'chat' ? 3072 : 4096
         })
       } catch (error) {
         console.error('[Chat] Error:', error)

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -55,7 +55,7 @@ You write the way a good editor marks up a manuscript: precise, economical, occa
 // Chat Mode posture. Read-only tool surface — the agent can read the
 // document to ground its responses but cannot propose edits, comment, or
 // mutate anything.
-const SUGGESTIONS_MODE_INSTRUCTIONS = `
+const CHAT_MODE_INSTRUCTIONS = `
 
 ## Chat Mode
 
@@ -74,12 +74,10 @@ If a request would require an edit, an annotation, or a file write, tell the use
 
 You have a budget of 5 tool roundtrips per response.`
 
-// Editor Mode posture. Proposes concrete copy edits via suggest_edit and
-// leaves editorial notes via add_comment. Never authors prose into the
-// document — that requires Create Mode. Will become the default in Chunk 3
-// of #467 (chatStore initialization flip); today's actual default is
-// Create Mode (legacy 'full'), so this PR doesn't claim the (default) tag.
-const PLAN_MODE_INSTRUCTIONS = `
+// Editor Mode posture. Default for new users. Proposes concrete copy edits
+// via suggest_edit and leaves editorial notes via add_comment. Never
+// authors prose into the document — that requires Create Mode.
+const EDITOR_MODE_INSTRUCTIONS = `
 
 ## Editor Mode
 
@@ -114,7 +112,7 @@ You have a budget of 5 tool roundtrips per response.`
 // Create Mode posture. Opt-in. The no-authorship rule is lifted; the user
 // has explicitly asked for LLM-authored prose. Persona constraints around
 // accuracy, structural diagnosis, and concision still apply.
-const FULL_MODE_INSTRUCTIONS = `
+const CREATE_MODE_INSTRUCTIONS = `
 
 ## Create Mode
 
@@ -159,13 +157,15 @@ export function buildSystemPrompt(
     prompt = `You are ${modelName}.\n\n` + prompt
   }
 
-  // Mode-specific tool instructions
-  if (!toolMode || toolMode === 'suggestions') {
-    prompt += SUGGESTIONS_MODE_INSTRUCTIONS
-  } else if (toolMode === 'plan') {
-    prompt += PLAN_MODE_INSTRUCTIONS
-  } else if (toolMode === 'full') {
-    prompt += FULL_MODE_INSTRUCTIONS
+  // Mode-specific tool instructions. Defaults to Editor when no mode supplied
+  // (matches the chatStore initial value).
+  const resolvedMode: ToolMode = toolMode ?? 'editor'
+  if (resolvedMode === 'chat') {
+    prompt += CHAT_MODE_INSTRUCTIONS
+  } else if (resolvedMode === 'editor') {
+    prompt += EDITOR_MODE_INSTRUCTIONS
+  } else if (resolvedMode === 'create') {
+    prompt += CREATE_MODE_INSTRUCTIONS
   }
 
   // Document context — always include full document regardless of tool mode
@@ -173,7 +173,7 @@ export function buildSystemPrompt(
     const cleanContent = stripCommentMarkup(documentContent)
     prompt += `\n\nThe user is currently working on the following document:\n\n---\n${cleanContent}\n---`
 
-    if (!toolMode || toolMode === 'suggestions') {
+    if (resolvedMode === 'chat') {
       // Chat Mode: agent references doc content in plain chat replies; line
       // refs render as clickable jump-to-line links in the UI.
       prompt += `\n\n## Referencing Line Numbers\nFormat: [Line N](line:N) — these render as clickable links that navigate to that line.`

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -62,7 +62,7 @@ export interface ToolProvenance {
 export async function executeTool(
   toolName: string,
   args: unknown,
-  mode: ToolMode = 'full',
+  mode: ToolMode = 'create',
   provenance?: ToolProvenance
 ): Promise<ToolResult> {
   // Check if tool exists

--- a/src/renderer/lib/tools/modes.ts
+++ b/src/renderer/lib/tools/modes.ts
@@ -6,6 +6,12 @@
 import type { ToolMode } from '../../../shared/tools/types'
 import { getTool, isToolAvailableInMode } from '../../../shared/tools/registry'
 
+const MODE_LABEL: Record<ToolMode, string> = {
+  chat: 'Chat',
+  editor: 'Editor',
+  create: 'Create'
+}
+
 /**
  * Check if a tool can be executed in the current mode.
  * Returns an error message if not allowed, or null if allowed.
@@ -18,14 +24,7 @@ export function checkToolAccess(toolName: string, mode: ToolMode): string | null
   }
 
   if (!isToolAvailableInMode(toolName, mode)) {
-    const modeLabel =
-      mode === 'suggestions'
-        ? 'Suggestions'
-        : mode === 'plan'
-          ? 'Plan'
-          : 'Full Autonomy'
-
-    return `Tool "${toolName}" is not available in ${modeLabel} mode. Switch to Full Autonomy mode to use this tool.`
+    return `Tool "${toolName}" is not available in ${MODE_LABEL[mode]} Mode. Switch to Create Mode to use this tool.`
   }
 
   return null
@@ -35,5 +34,5 @@ export function checkToolAccess(toolName: string, mode: ToolMode): string | null
  * Get the default mode for the chat.
  */
 export function getDefaultMode(): ToolMode {
-  return 'suggestions'
+  return 'editor'
 }

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -50,7 +50,6 @@ interface ChatState {
   togglePanel: () => void
   setPanelOpen: (open: boolean) => void
   setContext: (context: string | null) => void
-  setAgentMode: (enabled: boolean) => void
   setToolMode: (mode: ToolMode) => void
   cycleToolMode: () => void
 
@@ -81,10 +80,12 @@ export const useChatStore = create<ChatState>()(
     context: null,
     // Editor is the default — safe-by-default posture: agent proposes copy
     // edits and editorial notes but never authors prose into the document.
-    // Users opt into Create Mode via the StatusBar dropdown (or Shift+Tab,
-    // which still toggles chat ↔ create for legacy keyboard-shortcut users).
-    // agentMode is a legacy boolean kept in sync with toolMode for the
-    // small number of call sites that still read it (Editor.tsx Shift+Tab).
+    // Users opt into Create Mode via the StatusBar dropdown or Shift+Tab
+    // (cycleToolMode walks chat → editor → create → chat). agentMode is a
+    // legacy boolean kept in sync with toolMode === 'create' for the few
+    // remaining readers — currently ChatMessage.tsx's legacy <edit>-block
+    // auto-apply path (`agentMode=true` auto-applies; `agentMode=false`
+    // renders edit blocks as reviewable diffs).
     agentMode: false,
     toolMode: 'editor',
     isInitializing: true, // Start as true, will be set to false after app init
@@ -218,14 +219,6 @@ export const useChatStore = create<ChatState>()(
     setPanelOpen: (open) => set({ isPanelOpen: open }),
 
     setContext: (context) => set({ context }),
-
-    setAgentMode: (enabled) => set({
-      agentMode: enabled,
-      // Legacy compatibility for any remaining callers: maps a boolean to
-      // the two extremes of the mode ladder. Keyboard cycling goes through
-      // cycleToolMode instead so Editor is reachable.
-      toolMode: enabled ? 'create' : 'chat'
-    }),
 
     setToolMode: (mode) => set({
       toolMode: mode,

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -8,14 +8,9 @@ import {
   generateConversationTitle
 } from '../lib/persistence'
 import type { ChatConversation } from '../lib/persistence'
+import type { ToolMode } from '../../shared/tools/types'
 
-/**
- * Tool modes control which tools are available to the AI.
- * - suggestions: Read-only + suggest_edit (safe default)
- * - full: All tools available (direct edits)
- * - plan: Proposes changes, user must approve
- */
-export type ToolMode = 'suggestions' | 'full' | 'plan'
+export type { ToolMode }
 
 interface ChatState {
   // Conversation management
@@ -83,8 +78,14 @@ export const useChatStore = create<ChatState>()(
     isLoading: false,
     isPanelOpen: false,
     context: null,
-    agentMode: true, // Legacy - maps to toolMode
-    toolMode: 'full', // Default to full for backwards compatibility with agentMode: true
+    // Editor is the default — safe-by-default posture: agent proposes copy
+    // edits and editorial notes but never authors prose into the document.
+    // Users opt into Create Mode via the StatusBar dropdown (or Shift+Tab,
+    // which still toggles chat ↔ create for legacy keyboard-shortcut users).
+    // agentMode is a legacy boolean kept in sync with toolMode for the
+    // small number of call sites that still read it (Editor.tsx Shift+Tab).
+    agentMode: false,
+    toolMode: 'editor',
     isInitializing: true, // Start as true, will be set to false after app init
     isStreaming: false,
     currentStreamId: null,
@@ -219,14 +220,17 @@ export const useChatStore = create<ChatState>()(
 
     setAgentMode: (enabled) => set({
       agentMode: enabled,
-      // Sync toolMode with agentMode for backwards compatibility
-      toolMode: enabled ? 'full' : 'suggestions'
+      // Legacy compatibility: Shift+Tab toggles between chat and create
+      // (the "agent off" vs "agent fully on" extremes). Users who want
+      // Editor Mode must pick it from the StatusBar dropdown.
+      toolMode: enabled ? 'create' : 'chat'
     }),
 
     setToolMode: (mode) => set({
       toolMode: mode,
-      // Sync agentMode with toolMode for backwards compatibility
-      agentMode: mode === 'full'
+      // Legacy agentMode is "true" only in Create Mode — the only mode
+      // where the agent can author prose directly.
+      agentMode: mode === 'create'
     }),
 
     // Streaming actions

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -52,6 +52,7 @@ interface ChatState {
   setContext: (context: string | null) => void
   setAgentMode: (enabled: boolean) => void
   setToolMode: (mode: ToolMode) => void
+  cycleToolMode: () => void
 
   // Streaming actions
   startStreaming: (messageId: string, streamId: string) => void
@@ -220,9 +221,9 @@ export const useChatStore = create<ChatState>()(
 
     setAgentMode: (enabled) => set({
       agentMode: enabled,
-      // Legacy compatibility: Shift+Tab toggles between chat and create
-      // (the "agent off" vs "agent fully on" extremes). Users who want
-      // Editor Mode must pick it from the StatusBar dropdown.
+      // Legacy compatibility for any remaining callers: maps a boolean to
+      // the two extremes of the mode ladder. Keyboard cycling goes through
+      // cycleToolMode instead so Editor is reachable.
       toolMode: enabled ? 'create' : 'chat'
     }),
 
@@ -232,6 +233,17 @@ export const useChatStore = create<ChatState>()(
       // where the agent can author prose directly.
       agentMode: mode === 'create'
     }),
+
+    // Cycle through all three modes: chat → editor → create → chat.
+    // Used by the Shift+Tab keyboard shortcut so Editor Mode (the new
+    // safe-by-default mode) is reachable via keyboard, not just the
+    // StatusBar dropdown. Delegates to setToolMode so agentMode stays
+    // in sync.
+    cycleToolMode: () => {
+      const current = get().toolMode
+      const next: ToolMode = current === 'chat' ? 'editor' : current === 'editor' ? 'create' : 'chat'
+      get().setToolMode(next)
+    },
 
     // Streaming actions
     startStreaming: (messageId, streamId) =>

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -41,15 +41,31 @@ export function getToolsByCategory(category: ToolCategory): ToolConfig[] {
 }
 
 /**
+ * Mode capability ladder: each mode includes everything below it.
+ *
+ *   chat   ⊂ editor ⊂ create
+ *
+ * A tool with `requiresMode: 'editor'` is available in editor and create, not chat.
+ * `requiresMode: 'create'` is create-only. `requiresMode: null` is available everywhere.
+ *
+ * Note: `chat` is at the bottom of the ladder for gating purposes — at runtime,
+ * Chat Mode's actual tool surface is narrowed further at the useChat call site
+ * to a read-only subset (see CHAT_MODE_TOOL_NAMES in src/renderer/hooks/useChat.ts).
+ */
+const MODE_LEVEL: Record<ToolMode, number> = {
+  chat: 0,
+  editor: 1,
+  create: 2
+}
+
+/**
  * Get all tools available in a given mode.
  */
 export function getToolsForMode(mode: ToolMode): ToolConfig[] {
+  const modeLevel = MODE_LEVEL[mode]
   return allTools.filter((tool) => {
     if (tool.requiresMode === null) return true
-    if (mode === 'full') return true // Full mode has access to all tools
-    if (mode === 'plan') return tool.requiresMode !== 'full' // Plan excludes full-only
-    // Suggestions mode: only tools that don't require full or plan
-    return tool.requiresMode === 'suggestions' || tool.requiresMode === null
+    return MODE_LEVEL[tool.requiresMode] <= modeLevel
   })
 }
 
@@ -60,16 +76,14 @@ export function isToolAvailableInMode(name: string, mode: ToolMode): boolean {
   const tool = getTool(name)
   if (!tool) return false
   if (tool.requiresMode === null) return true
-  if (mode === 'full') return true
-  if (mode === 'plan') return tool.requiresMode !== 'full'
-  return tool.requiresMode === null
+  return MODE_LEVEL[tool.requiresMode] <= MODE_LEVEL[mode]
 }
 
 /**
  * Get tools formatted for Claude API tool_use.
  * Returns array of tool definitions with JSON schema.
  */
-export function getToolsForClaudeAPI(mode: ToolMode = 'full'): Array<{
+export function getToolsForClaudeAPI(mode: ToolMode = 'create'): Array<{
   name: string
   description: string
   input_schema: Record<string, unknown>

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -30,7 +30,7 @@ export const editConfig: ToolConfig<typeof editSchema> = {
     "Replace the content of a specific node by ID. Use read_document first to see all nodes with their IDs, then target the node you want to edit. Always include the search parameter with the original text for reliability. Special nodeId: pass 'frontmatter' with the COMPLETE new YAML (with or without --- fences) to direct-write the frontmatter block (no overlay, no search needed).",
   schema: editSchema,
   category: 'editor',
-  requiresMode: 'full', // Only available in Full Autonomy mode
+  requiresMode: 'create', // Direct writes — only available in Create Mode
   dangerous: false
 }
 
@@ -52,7 +52,7 @@ export const insertConfig: ToolConfig<typeof insertSchema> = {
   description: 'Insert text at the specified position in the document',
   schema: insertSchema,
   category: 'editor',
-  requiresMode: 'full',
+  requiresMode: 'create',
   dangerous: false
 }
 

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -12,8 +12,10 @@ import type { z } from 'zod'
  * - `editor` — propose copy edits via suggest_edit, leave editorial notes via add_comment. Default. No direct writes.
  * - `create` — opt-in. Drafting allowed (`edit` / `insert` available). User has explicitly lifted the no-authorship rule.
  *
- * Renamed from `suggestions` / `plan` / `full` in #467 Chunk 3. Persisted state
- * is migrated forward in `chatStore`; old values do not reach this type.
+ * Renamed from `suggestions` / `plan` / `full` in #467 Chunk 3. `toolMode`
+ * is in-memory only — `chatStore` does not use Zustand's `persist` middleware
+ * and `ChatConversation` does not carry `toolMode`. Each session re-initializes
+ * to the chatStore default, so no migration is needed.
  */
 export type ToolMode = 'chat' | 'editor' | 'create'
 

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -7,8 +7,15 @@ import type { z } from 'zod'
 
 /**
  * Tool execution modes that control which tools are available.
+ *
+ * - `chat`   — read-only. Sounding board / fact-check; agent cannot mutate the doc.
+ * - `editor` — propose copy edits via suggest_edit, leave editorial notes via add_comment. Default. No direct writes.
+ * - `create` — opt-in. Drafting allowed (`edit` / `insert` available). User has explicitly lifted the no-authorship rule.
+ *
+ * Renamed from `suggestions` / `plan` / `full` in #467 Chunk 3. Persisted state
+ * is migrated forward in `chatStore`; old values do not reach this type.
  */
-export type ToolMode = 'suggestions' | 'full' | 'plan'
+export type ToolMode = 'chat' | 'editor' | 'create'
 
 /**
  * Tool categories for organization and filtering.


### PR DESCRIPTION
## Summary

Chunk 3 of the #467 umbrella. Internal `ToolMode` keys finally catch up to the user-facing labels established in Chunks 1+2 (#513, #521). Editor Mode becomes the **actual** default — fresh users no longer land in Create Mode (legacy `full`).

Refs #467, #468.

## Surface-by-surface

| File | Change |
|---|---|
| `src/shared/tools/types.ts` | `ToolMode` union: `'suggestions' \| 'full' \| 'plan'` → `'chat' \| 'editor' \| 'create'`. |
| `src/shared/tools/registry.ts` | Rewrite `getToolsForMode` / `isToolAvailableInMode` as a clean capability ladder via `MODE_LEVEL` (`chat ⊂ editor ⊂ create`). Drops the special-case branches. `getToolsForClaudeAPI` default param `'full'` → `'create'`. |
| `src/shared/tools/schemas/editor.ts` | `edit` and `insert` `requiresMode: 'full'` → `'create'`. |
| `src/renderer/stores/chatStore.ts` | Drop duplicate `ToolMode` declaration; re-export from `shared/tools/types`. **Flip initial `toolMode` `'full'` → `'editor'`** (the safety-by-default promise of #467). `agentMode` legacy boolean now defaults `false` and is kept in sync with `toolMode === 'create'`. New `cycleToolMode` action cycles chat → editor → create → chat for the Shift+Tab keyboard shortcut. |
| `src/renderer/hooks/useChat.ts` | `CHAT_MODE_TOOL_NAMES` filter check + `maxTokens` ternary updated. Exposes `cycleToolMode`. |
| `src/renderer/lib/tools/modes.ts` | `getDefaultMode()` returns `'editor'`. `checkToolAccess` labels use the new `MODE_LABEL` map. |
| `src/renderer/lib/tools/index.ts` | `executeTool` default `mode: 'full'` → `'create'`. |
| `src/renderer/components/layout/StatusBar.tsx` | `modeConfig` keys updated to new union. **`(default)` marker restored on Editor** (the marker was dropped in #513's fix because the default hadn't actually flipped; now it has). |
| `src/renderer/components/layout/App.tsx` | MCP-mode `executeTool` call: `'full'` → `'create'`. |
| `src/renderer/components/editor/Editor.tsx` | Shift+Tab handler: `setAgentMode(!agentMode)` → `cycleToolMode()`. Editor mode is now reachable via keyboard (was permanently unreachable from a fresh launch under the old binary toggle). |
| `src/renderer/lib/prompts.ts` | `SUGGESTIONS/PLAN/FULL_MODE_INSTRUCTIONS` renamed to `CHAT/EDITOR/CREATE_MODE_INSTRUCTIONS`. `buildSystemPrompt` switch arms use new keys. Default-mode comment restored on Editor. |

## Behavioral consequence: legacy `<edit>` block auto-apply

`chatStore.agentMode` initial value flips `true` → `false` (since it's now derived from `toolMode === 'create'`, and Editor is the default). That boolean still drives the auto-apply path in `src/renderer/components/chat/ChatMessage.tsx:420-436` — when the agent emits legacy `<edit>` blocks in its plain-text response, `agentMode=true` auto-applies them and `agentMode=false` renders them as reviewable diffs.

**Net effect:** fresh users in the new default Editor mode now see legacy edit blocks as reviewable diffs needing approval, rather than auto-applied changes. This is consistent with the safety-by-default goal of #467 — Editor Mode's whole posture is "propose, don't write" — but it's a real user-visible change from the previous default behavior. Calling it out explicitly so it doesn't surprise anyone post-merge.

Per-mode behavior of the auto-apply path:
- **Chat** (`agentMode=false`): edit blocks → reviewable diffs. (Defensive — Chat Mode shouldn't really see edit blocks since the model has no tools to emit them, but if it manually writes the legacy XML-style block, it stays reviewable.)
- **Editor** (`agentMode=false`): edit blocks → reviewable diffs. Matches Editor posture: agent proposes, user reviews.
- **Create** (`agentMode=true`): edit blocks → auto-applied. Matches Create posture: drafting allowed.

## Carry-forward from Chunk 1's investigation

Chunk 1 confirmed `plan` vs `full` were behaviorally distinct (not just relabels) — `plan` excluded `edit`/`insert`; `full` exposed them. The new key migration preserves that distinction one-for-one:

- legacy `'suggestions'` → `'chat'` (still read-only)
- legacy `'plan'` → `'editor'` (still no `edit`/`insert`)
- legacy `'full'` → `'create'` (still has `edit`/`insert`)

Existing users with explicit toggles from Chunks 1/2 sessions will see the same tool surface they had before, under the new name.

## Persistence migration story — there isn't one

The chunking plan called for an idempotent migration of persisted `toolMode` state. **Reality check during implementation: `toolMode` is purely in-memory in `chatStore`.** Verified by grepping `toolMode|agentMode` across `persistence.ts`, `ipc.ts`, `types/index.ts`, settings code — no persistence layer touches it. Each session starts with the chatStore initial value.

Implication:
- Fresh launch on this branch → `toolMode === 'editor'`.
- An existing user with an open session won't be affected mid-session (the type narrowing doesn't break in-flight state because the in-memory value is still one of the old strings until they restart — and after they restart, it just initializes fresh to `'editor'`).
- No idempotency concerns; no schema-bump in IndexedDB.

## Block-check #2 from the plan: orphan grep

Ran `rg \"'suggestions'|'plan'|'full'|\\\"suggestions\\\"|\\\"plan\\\"|\\\"full\\\"\" --type ts src/`. Final state:

- All real ToolMode-string-literal references migrated.
- Two false positives left, both unrelated:
  - `src/renderer/lib/persistence.ts:72  SUGGESTIONS: 'suggestions'` — IndexedDB object store name for the AI suggestions extension. Not ToolMode.
  - `src/renderer/extensions/ai-suggestions/extension.ts` — log message containing the literal word "suggestions".

## Verification

1. `npm run dev` — 142 modules transformed, main + preload + renderer all built clean, app launched. No compile errors.
2. Fresh launch → StatusBar mode picker shows **editor (default)**.
3. Editor mode: `suggest_edit` + `add_comment` available; no `edit`/`insert`.
4. Switch to Create → `edit`/`insert` available; agent allowed to draft directly.
5. Switch to Chat → tool list narrows to the read-only allowlist from Chunk 2.
6. Shift+Tab cycles **chat → editor → create → chat**; Editor reachable from any starting position.

## Tests

No existing unit tests for `chatStore` initial state, `getToolsForMode`, `getDefaultMode`, the `buildSystemPrompt` mode-arm selection, or `cycleToolMode`. A small assertion suite would be cheap insurance once vitest lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)