### PR TITLE
feat(#467): gate every mutating tool to Editor Mode (add_comment, resolve_comment, suggest_edit, accept_diff, reject_diff)

### DIFF
--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -6,7 +6,7 @@ import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useChatStore, createMessageId } from '../../stores/chatStore'
 import { useCommandHistoryStore } from '../../stores/commandHistoryStore'
-import { executeTool, getAvailableTools } from '../../lib/tools'
+import { executeTool, getAvailableTools, isToolAvailableInMode } from '../../lib/tools'
 import { cn } from '../../lib/utils'
 import { useReviewStore } from '../../stores/reviewStore'
 
@@ -133,14 +133,16 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   // Disable input while app is initializing (loading draft/conversations) or while loading
   const isDisabled = isLoading || isInitializing
 
-  // All available commands (including built-in shortcuts)
-  // Normalize aliases: get_outline → outline for consistent display
+  // All available commands (including built-in shortcuts) filtered by the
+  // current ToolMode — don't suggest /suggest_edit in Chat Mode if it would
+  // fail at checkToolAccess. Normalize aliases: get_outline → outline.
   const allCommands = useMemo(() => [
     ...getAvailableTools()
       .filter(t => t !== 'create_and_open_file')
+      .filter(t => isToolAvailableInMode(t, toolMode))
       .map(t => t === 'get_outline' ? 'outline' : t),
     'help', 'clear', 'new', 'quick-review', 'review-diff'
-  ], [])
+  ], [toolMode])
 
   // Parse the current command from input (e.g., "/list_files " -> "list_files")
   const activeCommand = useMemo(() => {
@@ -217,7 +219,6 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
     // Handle /help specially
     if (command.toolName === 'help') {
       const { addMessage } = useChatStore.getState()
-      const availableTools = getAvailableTools()
       addMessage({
         id: createMessageId(),
         role: 'user',

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -38,7 +38,13 @@ const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
 
 function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
   if (toolMode === 'chat') {
-    return getToolsForClaudeAPI('create').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
+    // Pass 'chat' to the registry filter first so layer 1 actually fires for
+    // Chat Mode — only tools with `requiresMode <= chat` survive. Then narrow
+    // further to the explicit allowlist. Both layers run in series, so a
+    // regression in either (a missing `requiresMode: 'editor'` on a future
+    // mutating tool, or a missing entry in the allowlist) is caught by the
+    // other.
+    return getToolsForClaudeAPI('chat').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
   }
   return getToolsForClaudeAPI(toolMode)
 }

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -15,13 +15,18 @@ import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
 
 // Chat Mode gets a read-only tool subset rather than the full read+write
 // surface, so the agent can ground itself in the document without proposing
-// edits. We can't filter by `category === 'document'` alone — that category
-// includes the mutating add_comment and resolve_comment tools. Mutating
-// comment tools move behind Editor Mode via `requiresMode` in Chunk 4 of
-// #467; until then this explicit allowlist is the gate.
+// edits. Defense-in-depth alongside the registry-level mode gating:
+// `requiresMode` on each ToolConfig excludes mutating tools from Chat Mode at
+// the registry, AND this explicit allowlist ensures Chat Mode only ever
+// receives tools we have specifically vetted as read-only.
 //
-// Audit checkpoint: when new MCP/agent tools land (e.g., list_tabs, select_tab
-// from #450), decide whether they belong in Chat Mode and extend this set.
+// Why both layers: registry gating relies on every new tool author setting
+// `requiresMode` correctly; a tool added with `requiresMode: null` (the
+// default for read-only tools) would silently appear in Chat Mode. The
+// allowlist keeps the failure mode "tool missing" rather than "tool leaks."
+//
+// Audit checkpoint: when new tools land, decide whether they belong in
+// Chat Mode and extend this set.
 const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'read_document',
   'read_selection',

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -163,6 +163,7 @@ export function getAvailableTools(): string[] {
  * Re-export types and utilities.
  */
 export { checkToolAccess, getDefaultMode } from './modes'
+export { isToolAvailableInMode } from '../../../shared/tools/registry'
 export { resolveToolPosition }
 export type { ToolResult, ToolMode } from '../../../shared/tools/types'
 export { toolSuccess, toolError } from '../../../shared/tools/types'

--- a/src/renderer/lib/tools/modes.ts
+++ b/src/renderer/lib/tools/modes.ts
@@ -24,7 +24,13 @@ export function checkToolAccess(toolName: string, mode: ToolMode): string | null
   }
 
   if (!isToolAvailableInMode(toolName, mode)) {
-    return `Tool "${toolName}" is not available in ${MODE_LABEL[mode]} Mode. Switch to Create Mode to use this tool.`
+    // Point the user/agent at the *minimum* mode that exposes this tool — not
+    // always Create. A suggest_edit attempted from Chat Mode should say "Switch
+    // to Editor", not "Switch to Create". `tool.requiresMode` is guaranteed
+    // non-null here (the `requiresMode === null` branch in isToolAvailableInMode
+    // would have returned true already), but we default for type-safety.
+    const required = tool.requiresMode ? MODE_LABEL[tool.requiresMode] : 'Create'
+    return `Tool "${toolName}" is not available in ${MODE_LABEL[mode]} Mode. Switch to ${required} Mode to use this tool.`
   }
 
   return null

--- a/src/shared/tools/schemas/document.ts
+++ b/src/shared/tools/schemas/document.ts
@@ -145,7 +145,10 @@ export const addCommentConfig: ToolConfig<typeof addCommentSchema> = {
     'Add a comment to a node or range in the document. Provide nodeId (preferred, from read_document) or from/to positions. Returns { id } of the new comment.',
   schema: addCommentSchema,
   category: 'document',
-  requiresMode: null,
+  // Comments mutate document state; Chat Mode stays read-only. Editor Mode
+  // needs add_comment to deliver the non-authorship affordance: the agent
+  // can flag editorial issues without proposing replacement prose.
+  requiresMode: 'editor',
   dangerous: false
 }
 
@@ -163,7 +166,9 @@ export const resolveCommentConfig: ToolConfig<typeof resolveCommentSchema> = {
     'Resolve (remove) a comment by its ID. Use list_comments to see all comment IDs.',
   schema: resolveCommentSchema,
   category: 'document',
-  requiresMode: null,
+  // Sibling of add_comment — removing a comment is also a mutation, so it
+  // belongs in Editor Mode and up. list_comments stays read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -85,7 +85,9 @@ export const suggestEditConfig: ToolConfig<typeof suggestEditSchema> = {
     'Create an inline diff suggestion on a node. The user sees a highlighted comparison and can accept or reject it. Use read_document first to get node IDs. Always include the search parameter with the original text for reliability.',
   schema: suggestEditSchema,
   category: 'editor',
-  requiresMode: null, // Available in all modes
+  // Suggestions are still mutations of pending document state (the diff
+  // overlay). Editor Mode's defining capability; Chat Mode stays read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 
@@ -105,7 +107,8 @@ export const acceptDiffConfig: ToolConfig<typeof acceptDiffSchema> = {
   description: 'Accept a pending suggestion. If no ID provided, accepts all pending suggestions.',
   schema: acceptDiffSchema,
   category: 'editor',
-  requiresMode: null, // Available in all modes
+  // Accepting a diff commits a content mutation. Chat Mode stays read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 
@@ -125,7 +128,9 @@ export const rejectDiffConfig: ToolConfig<typeof rejectDiffSchema> = {
   description: 'Reject a pending suggestion. If no ID provided, rejects all pending suggestions.',
   schema: rejectDiffSchema,
   category: 'editor',
-  requiresMode: null, // Available in all modes
+  // Rejecting a diff dismisses pending state. Symmetric with accept_diff;
+  // belongs in Editor Mode so Chat stays purely read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 


### PR DESCRIPTION
## Summary

Chunk 4 of the #467 umbrella. Delivers the **non-authorship affordance** that #467 hinges on: in Editor Mode, the agent can flag judgment-bearing editorial concerns via `add_comment` without proposing the replacement prose. **Also tightens the dual-layer invariant codebase-wide** — every tool that mutates document or pending state now carries `requiresMode >= 'editor'`, so Chat Mode is read-only at the registry level, not just at the useChat call-site allowlist.

**Stacked on #522** — base branch is `issue-467-mode-rename`. Merge #522 first.

Refs #467, #468, #455 (which shipped the comment tools but didn't gate them for the built-in agent).

## What changed

### `src/shared/tools/schemas/document.ts`

| Tool | Before | After | Why |
|---|---|---|---|
| `add_comment` | `requiresMode: null` | `requiresMode: 'editor'` | Mutates document state. Chat Mode is read-only; Editor needs it for the non-authorship affordance. |
| `resolve_comment` | `requiresMode: null` | `requiresMode: 'editor'` | Sibling of `add_comment` — removing a comment is also a mutation. |
| `list_comments` | `requiresMode: null` | **(unchanged)** | Read-only; stays available everywhere. |

### `src/shared/tools/schemas/editor.ts`

| Tool | Before | After | Why |
|---|---|---|---|
| `suggest_edit` | `requiresMode: null` | `requiresMode: 'editor'` | Creates a pending suggestion (document state mutation, even if not yet applied). Editor's defining capability. |
| `accept_diff` | `requiresMode: null` | `requiresMode: 'editor'` | Commits a pending suggestion into content. |
| `reject_diff` | `requiresMode: null` | `requiresMode: 'editor'` | Dismisses pending suggestion state. Symmetric with accept_diff. |

After this PR, every tool that mutates state has `requiresMode >= 'editor'`. The dual-layer invariant (registry gating + useChat allowlist) is true codebase-wide.

Combined with the `MODE_LEVEL` ladder from Chunk 3 (#522: `chat ⊂ editor ⊂ create`):

- **Chat Mode** → only read-only tools (`list_comments`, `read_document`, `get_outline`, etc.). Mutating comment tools and edit/suggest/accept/reject tools all excluded.
- **Editor Mode** → all the above plus `add_comment`, `resolve_comment`, `suggest_edit`, `accept_diff`, `reject_diff`.
- **Create Mode** → all the above plus `edit` and `insert` (direct writes).

### `src/renderer/hooks/useChat.ts`

Updated the comment on `CHAT_MODE_TOOL_NAMES` to reflect that the allowlist is now defense-in-depth alongside the registry-level mode gating. Both layers run; either one would catch a mutating tool leaking into Chat Mode, but having both means the failure mode is "tool missing" rather than "tool leaks" if anyone adds a future mutating tool with `requiresMode: null` by accident.

No behavioral change to the filter itself.

## Why both layers

Registry gating relies on every new tool author setting `requiresMode` correctly. The default for read-only tools is `null` — meaning "available in every mode" — so a brand-new mutating tool that forgets to set `requiresMode: 'editor'` would silently appear in Chat Mode. The explicit allowlist in `useChat.ts` keeps Chat Mode tight regardless: if someone adds `delete_paragraph` with `requiresMode: null`, it doesn't reach Chat Mode unless they also add it to `CHAT_MODE_TOOL_NAMES` deliberately.

## Prompt copy

The `suggest_edit` vs `add_comment` discrimination heuristic was added to `EDITOR_MODE_INSTRUCTIONS` back in Chunk 1 (#513). No prompt changes needed here.

## Verification

1. `npm run dev` — 142 modules transformed, main + preload + renderer build clean, app launches.
2. Switch to **chat** mode → ask the agent to list comments → works (`list_comments` still available). Ask the agent to add a comment → declines and redirects to Editor Mode.
3. Switch to **editor** mode → ask "the second paragraph has a competing thesis with the first" → agent uses `add_comment`, not `suggest_edit` (per the prompt discrimination heuristic from Chunk 1).
4. Switch to **create** mode → all comment tools still available, plus `edit` / `insert` for direct writes.

## Tests

No existing tests cover mode gating for these tools. A small unit-test suite is the natural insurance once vitest lands — assertions of the shape `isToolAvailableInMode('add_comment', 'chat') === false`. Worth a follow-up.

## Out of scope (in this chunk)

- Chunk 5 — accept-flow audit against #447's caption infrastructure (already completed in [#467 comment](https://github.com/solo-ist/prose/issues/467#issuecomment-4471340693); no PR required).
- `setAgentMode` dead-code removal — landed on #522 in commit [476ebdc](https://github.com/solo-ist/prose/pull/522/commits/476ebdc) in response to the same review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)