### PR TITLE
fix(statusbar): suppress browser focus ring on dropdown triggers

### DIFF
--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -95,7 +95,7 @@ export function StatusBar() {
       <div className="flex items-center gap-1">
         <button
           onClick={toggleSourceMode}
-          className="hover:text-foreground transition-colors cursor-pointer"
+          className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer"
         >
           {sourceMode ? 'source' : 'wysiwyg'}
         </button>
@@ -120,7 +120,7 @@ export function StatusBar() {
               <TooltipTrigger asChild>
                 <button
                   onClick={() => useReviewStore.getState().setReviewMode('quick')}
-                  className="text-violet-600 dark:text-violet-400 hover:text-violet-500 transition-colors cursor-pointer"
+                  className="text-violet-600 dark:text-violet-400 hover:text-violet-500 focus-visible:text-violet-500 focus-visible:outline-none transition-colors cursor-pointer"
                 >
                   {suggestionCount} suggestion{suggestionCount !== 1 ? 's' : ''}
                 </button>
@@ -138,7 +138,7 @@ export function StatusBar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <button className="hover:text-foreground transition-colors cursor-pointer max-w-[120px] truncate">
+                <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer max-w-[120px] truncate">
                   {modelDisplayName}
                 </button>
               </DropdownMenuTrigger>
@@ -179,7 +179,7 @@ export function StatusBar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <button className="hover:text-foreground transition-colors cursor-pointer">
+                <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer">
                   {currentMode.label}
                 </button>
               </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary

Caught during #467 manual QA. After clicking a StatusBar dropdown item, Radix returns focus to the trigger button (correct a11y behavior — keyboard users want focus back), but the trigger then displays Chromium's default focus-visible ring (orange outline). Looks ugly: see [screenshot](https://github.com/solo-ist/prose/pull/524#issuecomment-).

Affected buttons: source-mode toggle, suggestion count, model picker, mode picker — all four had `hover:text-foreground transition-colors cursor-pointer` with no `focus-visible:` rule, so the OS default leaked through.

## Fix

For each affected button:
- `focus-visible:outline-none` — suppresses the default ring
- `focus-visible:text-foreground` (or `text-violet-500` for the suggestion-count violet button) — gives keyboard users a subtle hint matching the existing hover state

No visual change for mouse users; keyboard users still get a focus indicator (same color hover already uses).

## Scope

Pre-existing pattern issue, **not a #467 regression** — but caught in QA so landing it on the release branch keeps things clean before merging to main.

## Verification

`npm run dev`, open Prose, click the mode picker, select another mode → no orange ring after menu closes. Same for the model picker, source/wysiwyg toggle, and suggestion-count button. Tab through the StatusBar with keyboard → buttons highlight in foreground color (subtle, matches hover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)