### PR TITLE
fix(chat): filter /quick-review and /review-diff from Chat Mode autocomplete

### DIFF
--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -136,13 +136,16 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   // All available commands (including built-in shortcuts) filtered by the
   // current ToolMode — don't suggest /suggest_edit in Chat Mode if it would
   // fail at checkToolAccess. Normalize aliases: get_outline → outline.
-  const allCommands = useMemo(() => [
-    ...getAvailableTools()
+  // The review-UI shortcuts (/quick-review, /review-diff) operate on pending
+  // suggestions, which Chat Mode can't produce — exclude them there too.
+  const allCommands = useMemo(() => {
+    const tools = getAvailableTools()
       .filter(t => t !== 'create_and_open_file')
       .filter(t => isToolAvailableInMode(t, toolMode))
-      .map(t => t === 'get_outline' ? 'outline' : t),
-    'help', 'clear', 'new', 'quick-review', 'review-diff'
-  ], [toolMode])
+      .map(t => t === 'get_outline' ? 'outline' : t)
+    const reviewShortcuts = toolMode === 'chat' ? [] : ['quick-review', 'review-diff']
+    return [...tools, 'help', 'clear', 'new', ...reviewShortcuts]
+  }, [toolMode])
 
   // Parse the current command from input (e.g., "/list_files " -> "list_files")
   const activeCommand = useMemo(() => {


### PR DESCRIPTION
## Summary

Caught during #467 manual QA Step 1.5. The built-in slash-command shortcuts \`/quick-review\` and \`/review-diff\` were hardcoded after the tool list in \`ChatInput.tsx\`'s \`allCommands\` memo, bypassing the \`isToolAvailableInMode\` filter that Chunk 4 added for the registered tools. Result: Chat Mode users saw these two entries in the autocomplete dropdown even though Chat Mode can't produce pending suggestions to review against.

## Fix

Treat the review shortcuts as Editor/Create-only:

\`\`\`ts
const reviewShortcuts = toolMode === 'chat' ? [] : ['quick-review', 'review-diff']
return [...tools, 'help', 'clear', 'new', ...reviewShortcuts]
\`\`\`

Other built-ins (\`help\`, \`clear\`, \`new\`) stay unrestricted — they're meaningful in every mode.

## Verification

1. Switch to Chat Mode, type \`/\` in the chat input → autocomplete does **not** include \`/quick-review\` or \`/review-diff\`.
2. Switch to Editor Mode, type \`/\` → both appear in autocomplete.
3. Switch to Create Mode, type \`/\` → both appear.

## Scope

Pre-existing miss in #524's autocomplete filtering, caught during QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)