### PR TITLE
feat(editor): persistent visual selection across editor↔chat focus

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -24,6 +24,7 @@ import { SearchHighlight } from '../../extensions/search-highlight'
 import { LinkHover } from '../../extensions/link-hover'
 import { PlainTextMode } from '../../extensions/plain-text-mode'
 import { ImageWithUpload } from '../../extensions/image'
+import { PersistentSelection } from '../../extensions/persistent-selection'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
@@ -194,6 +195,7 @@ export function Editor() {
           class: 'editor-image'
         }
       }),
+      PersistentSelection,
     ],
     content: initialContent,
     editorProps: {

--- a/src/renderer/extensions/persistent-selection/index.ts
+++ b/src/renderer/extensions/persistent-selection/index.ts
@@ -1,0 +1,102 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+/**
+ * Persistent visual selection across focus changes.
+ *
+ * Native browser `::selection` highlighting is suppressed the moment the
+ * editor loses focus (e.g., user clicks into the chat input). That makes
+ * tools like `read_selection` opaque — you can't see what's about to be
+ * read. This extension paints an inline ProseMirror decoration over the
+ * selection range while the editor is blurred, so the highlight persists
+ * visually. When the editor regains focus, the decoration clears and
+ * native `::selection` takes over.
+ *
+ * The decoration class `.persistent-selection` is styled in
+ * `src/renderer/index.css` to match the global `::selection` background.
+ */
+
+interface PersistentSelectionState {
+  isBlurred: boolean
+  from: number | null
+  to: number | null
+}
+
+const persistentSelectionKey = new PluginKey<PersistentSelectionState>('persistentSelection')
+
+export const PersistentSelection = Extension.create({
+  name: 'persistentSelection',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<PersistentSelectionState>({
+        key: persistentSelectionKey,
+        state: {
+          init(): PersistentSelectionState {
+            return { isBlurred: false, from: null, to: null }
+          },
+          apply(tr, prev): PersistentSelectionState {
+            const meta = tr.getMeta(persistentSelectionKey) as PersistentSelectionState | undefined
+            if (meta) {
+              return meta
+            }
+            // Map stored range across doc edits so the decoration stays
+            // attached to the right span even if the doc is mutated while
+            // the editor is blurred (e.g., agent applies an edit).
+            if (prev.from !== null && prev.to !== null && tr.docChanged) {
+              return {
+                isBlurred: prev.isBlurred,
+                from: tr.mapping.map(prev.from),
+                to: tr.mapping.map(prev.to)
+              }
+            }
+            return prev
+          }
+        },
+        props: {
+          decorations(state) {
+            const pluginState = persistentSelectionKey.getState(state)
+            if (
+              !pluginState ||
+              !pluginState.isBlurred ||
+              pluginState.from === null ||
+              pluginState.to === null ||
+              pluginState.from === pluginState.to
+            ) {
+              return DecorationSet.empty
+            }
+            return DecorationSet.create(state.doc, [
+              Decoration.inline(pluginState.from, pluginState.to, {
+                class: 'persistent-selection'
+              })
+            ])
+          },
+          handleDOMEvents: {
+            blur(view) {
+              const { from, to } = view.state.selection
+              view.dispatch(
+                view.state.tr.setMeta(persistentSelectionKey, {
+                  isBlurred: true,
+                  from: from === to ? null : from,
+                  to: from === to ? null : to
+                } satisfies PersistentSelectionState)
+              )
+              return false
+            },
+            focus(view) {
+              view.dispatch(
+                view.state.tr.setMeta(persistentSelectionKey, {
+                  isBlurred: false,
+                  from: null,
+                  to: null
+                } satisfies PersistentSelectionState)
+              )
+              return false
+            }
+          }
+        }
+      })
+    ]
+  }
+})

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -415,6 +415,24 @@
   background: hsl(var(--primary) / 0.2);
 }
 
+/* Persistent visual selection while the editor is blurred.
+ * Painted by src/renderer/extensions/persistent-selection/ so users can
+ * still see what e.g. read_selection will operate against after focus
+ * moves to the chat input.
+ *
+ * Two-layer visual: a primary-tinted background for the common case,
+ * plus an inset outline that survives even when the inner content has
+ * its own background-image (e.g., .ai-annotation-replacement's
+ * linear-gradient). The outline paints on top of inner backgrounds, so
+ * users always see a selection boundary regardless of what mark or
+ * decoration wraps the range. */
+.prose-editor .persistent-selection {
+  background: hsl(var(--primary) / 0.2);
+  outline: 1.5px solid hsl(var(--primary) / 0.7);
+  outline-offset: -1.5px;
+  border-radius: 2px;
+}
+
 /* Diff Suggestions */
 .prose-editor .diff-suggestion {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Caught during the #467 manual QA pass: when the user has text selected in the editor and clicks into the chat input, the browser suppresses native \`::selection\` highlighting because focus moved away. The agent's \`read_selection\` tool still reads the right text (the data path falls back to \`editorStore.SelectionCache\` populated by the existing \`selectionUpdate\` listener), but the user has no visual confirmation of what \`read_selection\` will operate against.

## Fix

New TipTap extension at \`src/renderer/extensions/persistent-selection/\`. It registers a ProseMirror plugin with:

- **State field** \`{ isBlurred, from, to }\` mapped across doc edits so the decoration stays attached if the doc mutates while blurred.
- **\`handleDOMEvents.blur\`** captures \`view.state.selection.from/.to\`; skips empty selections.
- **\`handleDOMEvents.focus\`** clears the state.
- **\`decorations()\`** returns a \`DecorationSet\` with an inline \`Decoration.inline\` over the cached range using class \`persistent-selection\`.

CSS in \`src/renderer/index.css\`:

\`\`\`css
.prose-editor .persistent-selection {
  background: hsl(var(--primary) / 0.2);   /* common case: shows over plain text */
  outline: 1.5px solid hsl(var(--primary) / 0.7);
  outline-offset: -1.5px;                  /* drawn inside the box, on top */
  border-radius: 2px;
}
\`\`\`

The two-layer treatment matters: \`.ai-annotation-replacement\` paints a \`linear-gradient\` background-image that would otherwise fully cover a flat background-color from an outer decoration. Adding an inset outline ensures the selection boundary is visible regardless of what mark wraps the range — initial single-layer attempt failed exactly that case in QA.

## Files

- New: \`src/renderer/extensions/persistent-selection/index.ts\` (~85 lines, one Tiptap extension wrapping one ProseMirror plugin)
- \`src/renderer/index.css\` — new \`.persistent-selection\` rule
- \`src/renderer/components/editor/Editor.tsx\` — add the extension to the \`useTipTapEditor\` extensions array

## Verification

1. Open a doc, select text. Native selection visible.
2. Click into the chat input. Selection remains visibly highlighted (primary tint + outline).
3. Click back into the editor. Native selection takes over cleanly.
4. Place a bare cursor in editor → click chat → no decoration paints (empty selections skipped).
5. Select text that overlaps an existing AI annotation (e.g., an accepted suggestion). The outline shows over the annotation's gradient.
6. \`read_selection\` returns content matching the visibly highlighted range.

## Scope

UX polish surfaced during #467 QA. Lands on the release branch so QA can resume against a state that includes the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)