### PR TITLE
feat(chat): tool-result renderer registry + list_files file-tree renderer

### DIFF
--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -8,6 +8,7 @@ import { useChatStore, createMessageId } from '../../stores/chatStore'
 import { useFileListStore } from '../../stores/fileListStore'
 import { useCommandHistoryStore } from '../../stores/commandHistoryStore'
 import { executeTool, getAvailableTools, isToolAvailableInMode } from '../../lib/tools'
+import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import { cn } from '../../lib/utils'
 import { useReviewStore } from '../../stores/reviewStore'
 
@@ -29,6 +30,11 @@ const toolDescriptions: Record<string, string> = {
   save_file: 'Save to file',
   list_files: 'List files in directory',
   read_file: 'Read file contents',
+  list_comments: 'List comments in document',
+  add_comment: 'Add a comment to selected text',
+  resolve_comment: 'Resolve (remove) a comment',
+  list_tabs: 'List open tabs',
+  select_tab: 'Switch to a different tab',
   help: 'Show available commands',
   clear: 'Start a new chat',
   new: 'New blank tab',
@@ -134,19 +140,31 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   // Disable input while app is initializing (loading draft/conversations) or while loading
   const isDisabled = isLoading || isInitializing
 
+  // Track pending AI suggestion count so the review shortcuts can be
+  // contextual on whether there's anything to review. Same pattern as
+  // StatusBar.tsx — keys on editor + doc reference so edits invalidate
+  // the memo.
+  const suggestionCount = useMemo(() => {
+    if (!editor) return 0
+    return getAISuggestions(editor).length
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, editor?.state.doc])
+
   // All available commands (including built-in shortcuts) filtered by the
   // current ToolMode — don't suggest /suggest_edit in Chat Mode if it would
   // fail at checkToolAccess. Normalize aliases: get_outline → outline.
-  // The review-UI shortcuts (/quick-review, /review-diff) operate on pending
-  // suggestions, which Chat Mode can't produce — exclude them there too.
+  // The review-UI shortcuts (/quick-review, /review-diff) only show when
+  // there are pending suggestions to review — and never in Chat Mode,
+  // which can't produce suggestions in the first place.
   const allCommands = useMemo(() => {
     const tools = getAvailableTools()
       .filter(t => t !== 'create_and_open_file')
       .filter(t => isToolAvailableInMode(t, toolMode))
       .map(t => t === 'get_outline' ? 'outline' : t)
-    const reviewShortcuts = toolMode === 'chat' ? [] : ['quick-review', 'review-diff']
+    const showReviewShortcuts = toolMode !== 'chat' && suggestionCount > 0
+    const reviewShortcuts = showReviewShortcuts ? ['quick-review', 'review-diff'] : []
     return [...tools, 'help', 'clear', 'new', ...reviewShortcuts]
-  }, [toolMode])
+  }, [toolMode, suggestionCount])
 
   // Parse the current command from input (e.g., "/list_files " -> "list_files")
   const activeCommand = useMemo(() => {

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -5,6 +5,7 @@ import { useChat } from '../../hooks/useChat'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useChatStore, createMessageId } from '../../stores/chatStore'
+import { useFileListStore } from '../../stores/fileListStore'
 import { useCommandHistoryStore } from '../../stores/commandHistoryStore'
 import { executeTool, getAvailableTools, isToolAvailableInMode } from '../../lib/tools'
 import { cn } from '../../lib/utils'
@@ -275,20 +276,22 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
       return
     }
 
-    // Handle /list_files - get current file's directory first
+    // Handle /list_files - default to the file explorer's current root so
+    // chat-side results mirror what the user sees in the side panel.
+    // Fall back to the active file's directory, then home, if no explorer
+    // root is set (e.g., user closed the panel without ever opening it).
     if (command.toolName === 'list_files') {
+      const { rootPath } = useFileListStore.getState()
       const { document } = useEditorStore.getState()
-      const path = document.path
-      if (path) {
-        // Extract directory from file path
-        const dir = path.substring(0, path.lastIndexOf('/')) || '~'
-        // First get metadata, then list files
-        const enhancedCommand = { ...command, args: { path: dir }, rawArg: dir }
-        await handleSlashCommand(enhancedCommand, `/list_files ${dir}`)
-      } else {
-        // No current file, list home directory
-        await handleSlashCommand({ ...command, args: { path: '~' }, rawArg: '~' }, '/list_files ~')
+      let dir = rootPath
+      if (!dir && document.path) {
+        dir = document.path.substring(0, document.path.lastIndexOf('/')) || '~'
       }
+      if (!dir) {
+        dir = '~'
+      }
+      const enhancedCommand = { ...command, args: { path: dir }, rawArg: dir }
+      await handleSlashCommand(enhancedCommand, `/list_files ${dir}`)
       return
     }
 

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -11,6 +11,7 @@ import { useSettingsStore } from '../../stores/settingsStore'
 import { CopyButton } from '../ui/copy-button'
 import { jumpToLine } from '../../lib/lineNavigation'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
+import { renderToolResult } from './toolResultRenderers'
 import avatarDark from '../../assets/avatar-dark.png'
 import avatarLight from '../../assets/avatar-light.png'
 
@@ -549,6 +550,12 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                           // Not JSON, ignore
                         }
                       }
+                      // Per-tool custom renderer if one is registered; falls
+                      // back to markdown (JSON in <pre>) for unknown tools.
+                      const customBody =
+                        part.name && part.content && part.success
+                          ? renderToolResult(part.name, part.content)
+                          : null
                       return (
                         <ToolCallIndicator
                           key={idx}
@@ -556,7 +563,7 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                           status={part.success ? 'success' : 'error'}
                           onClick={onClickHandler}
                         >
-                          {part.content && renderMarkdown(part.content, editor)}
+                          {customBody ?? (part.content && renderMarkdown(part.content, editor))}
                         </ToolCallIndicator>
                       )
                     }

--- a/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { FileTree } from '../../files/FileTree'
+import { useTabs } from '../../../hooks/useTabs'
+import { useFileListStore } from '../../../stores/fileListStore'
+import type { FileItem } from '../../../../shared/tools/types'
+
+interface ListFilesResultProps {
+  content: string
+}
+
+interface ListFilesPayload {
+  files: FileItem[]
+  truncated?: boolean
+  totalFound?: number
+}
+
+interface ListFilesEnvelope extends Partial<ListFilesPayload> {
+  success?: boolean
+  data?: ListFilesPayload
+  error?: string
+}
+
+/**
+ * The tool-result string in the chat may arrive either as the raw
+ * payload `{ files: [...] }` or wrapped in a `{ success, data }`
+ * envelope, depending on whether the renderer is invoked from a live
+ * tool call (envelope) or a parsed-from-markdown rehydration (raw).
+ * Accept both shapes.
+ */
+function extractPayload(env: ListFilesEnvelope): ListFilesPayload {
+  if (env.data?.files) return env.data
+  if (env.files) return { files: env.files, truncated: env.truncated, totalFound: env.totalFound }
+  return { files: [] }
+}
+
+/**
+ * Custom renderer for the `list_files` tool result.
+ * Replaces the default JSON-in-a-pre-block render with the same FileTree
+ * component the file explorer side panel uses — single-click opens the
+ * file in a preview tab, folders toggle expand/collapse via local state.
+ *
+ * The tool result content arrives as a JSON string (possibly wrapped in
+ * markdown code fences). We parse defensively and fall back to a textual
+ * apology + raw content dump if the shape changes unexpectedly.
+ */
+export function ListFilesResult({ content }: ListFilesResultProps) {
+  // Seed the chat-side tree with the same folders the file explorer panel
+  // currently has open, so the user sees a matching shape on first render.
+  // After this snapshot the chat tree's expansion is independent — clicking
+  // folders here doesn't propagate back to the side panel.
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
+    () => new Set(useFileListStore.getState().expandedFolders)
+  )
+  const { openFileInPreviewTab } = useTabs()
+
+  let parsed: ListFilesEnvelope | null = null
+  try {
+    const cleaned = content.replace(/```json\n?|\n?```/g, '').trim()
+    parsed = JSON.parse(cleaned) as ListFilesEnvelope
+  } catch {
+    return (
+      <div className="text-xs text-muted-foreground">
+        <div className="mb-1">Unable to parse file list result.</div>
+        <pre className="text-[10px] overflow-x-auto whitespace-pre-wrap">{content}</pre>
+      </div>
+    )
+  }
+
+  if (parsed?.error || parsed?.success === false) {
+    return (
+      <div className="text-xs text-destructive">
+        {parsed.error ?? 'list_files failed.'}
+      </div>
+    )
+  }
+
+  const payload = parsed ? extractPayload(parsed) : { files: [] }
+  const files = payload.files
+  if (files.length === 0) {
+    return <div className="text-xs text-muted-foreground">No files.</div>
+  }
+
+  const handleFolderToggle = (path: string) => {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
+
+  const handleFileClick = async (path: string) => {
+    await openFileInPreviewTab(path)
+  }
+
+  return (
+    <div className="text-xs">
+      <FileTree
+        items={files}
+        expandedFolders={expandedFolders}
+        selectedPath={null}
+        onFileClick={handleFileClick}
+        onFolderToggle={handleFolderToggle}
+      />
+      {payload.truncated && payload.totalFound !== undefined && (
+        <div className="mt-2 text-[11px] text-muted-foreground">
+          (showing {files.length} of {payload.totalFound} files)
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { FileTree } from '../../files/FileTree'
 import { useTabs } from '../../../hooks/useTabs'
 import { useFileListStore } from '../../../stores/fileListStore'
-import type { FileItem } from '../../../../shared/tools/types'
+import type { FileItem } from '../../../types'
 
 interface ListFilesResultProps {
   content: string
@@ -15,17 +15,18 @@ interface ListFilesPayload {
 }
 
 interface ListFilesEnvelope extends Partial<ListFilesPayload> {
-  success?: boolean
   data?: ListFilesPayload
-  error?: string
 }
 
 /**
- * The tool-result string in the chat may arrive either as the raw
- * payload `{ files: [...] }` or wrapped in a `{ success, data }`
- * envelope, depending on whether the renderer is invoked from a live
- * tool call (envelope) or a parsed-from-markdown rehydration (raw).
- * Accept both shapes.
+ * The tool-result string may arrive either as the raw payload
+ * `{ files: [...] }` or wrapped in a `{ data: { files } }` envelope,
+ * depending on whether the renderer is invoked from a live tool call
+ * (envelope) or a parsed-from-markdown rehydration (raw). Accept both.
+ *
+ * Error envelopes never reach here — ChatMessage only invokes the
+ * renderer when `part.success === true`. Failures fall back to the
+ * markdown render path.
  */
 function extractPayload(env: ListFilesEnvelope): ListFilesPayload {
   if (env.data?.files) return env.data
@@ -62,14 +63,6 @@ export function ListFilesResult({ content }: ListFilesResultProps) {
       <div className="text-xs text-muted-foreground">
         <div className="mb-1">Unable to parse file list result.</div>
         <pre className="text-[10px] overflow-x-auto whitespace-pre-wrap">{content}</pre>
-      </div>
-    )
-  }
-
-  if (parsed?.error || parsed?.success === false) {
-    return (
-      <div className="text-xs text-destructive">
-        {parsed.error ?? 'list_files failed.'}
       </div>
     )
   }

--- a/src/renderer/components/chat/toolResultRenderers/index.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/index.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+import { ListFilesResult } from './ListFilesResult'
+
+/**
+ * Per-tool result renderer registry. Keyed by the tool name; each entry
+ * returns a React node that replaces the default `renderMarkdown` output
+ * (which dumps JSON inside a `<pre>` code block).
+ *
+ * Unknown tools return null from `renderToolResult` and the caller falls
+ * back to the default markdown render.
+ *
+ * Adding a renderer: write the component under
+ * `src/renderer/components/chat/toolResultRenderers/<Name>.tsx`, import
+ * it here, add the entry to `toolResultRenderers`. Components receive
+ * the raw `content` string and are responsible for parsing it (the
+ * content is typically a JSON-stringified `ToolResult<T>` envelope,
+ * sometimes wrapped in markdown code fences).
+ */
+
+type ToolResultRenderer = (content: string) => ReactNode
+
+const toolResultRenderers: Record<string, ToolResultRenderer> = {
+  list_files: (content) => <ListFilesResult content={content} />
+}
+
+export function renderToolResult(name: string, content: string): ReactNode | null {
+  const renderer = toolResultRenderers[name]
+  return renderer ? renderer(content) : null
+}


### PR DESCRIPTION
## Summary

Caught during the #467 manual QA pass. Every tool result rendered in the chat panel as raw JSON inside a \`<pre>\` code block (via \`renderMarkdown\`). For \`list_files\` in particular, that's an unreadable wall of JSON — see the [QA screenshot](https://github.com/solo-ist/prose/issues/467).

This PR adds a small per-tool renderer registry dispatched from \`ChatMessage.tsx\`'s tool-result branch. The first concrete renderer is \`list_files\`, which reuses the existing \`FileTree\` component (the same one the file explorer side panel uses) so the chat-side output looks and behaves like the panel.

Behavior matches the user's expectation that the chat result mirrors what's visible in the file explorer:

1. \`/list_files\` with no arg now defaults to \`useFileListStore.rootPath\` (the file explorer's current root). Falls back to the active file's parent dir, then \`~\`, if no root is set.
2. The chat tree's \`expandedFolders\` is seeded from \`useFileListStore.expandedFolders\` at mount so it opens with the same folders expanded as the side panel. After mount, chat-side state is independent — toggling folders in chat doesn't propagate back.

## Architecture

### Registry

\`\`\`ts
type ToolResultRenderer = (content: string) => ReactNode

const toolResultRenderers: Record<string, ToolResultRenderer> = {
  list_files: (content) => <ListFilesResult content={content} />
}

export function renderToolResult(name: string, content: string): ReactNode | null {
  return toolResultRenderers[name]?.(content) ?? null
}
\`\`\`

### Dispatch in \`ChatMessage.tsx\`

\`\`\`tsx
const customBody = part.name && part.content && part.success
  ? renderToolResult(part.name, part.content)
  : null
return <ToolCallIndicator ...>{customBody ?? renderMarkdown(part.content, editor)}</ToolCallIndicator>
\`\`\`

Unknown tools return \`null\` and the existing markdown fallback fires. Adding a renderer in the future is a single import + a registry entry.

### \`ListFilesResult\` defensive parsing

The tool-result content may arrive either as the raw \`{ files: [...] }\` payload or wrapped in a \`{ success, data: { files } }\` envelope. \`extractPayload\` accepts either. JSON parse failures fall back to a textual apology + raw content dump so the chat doesn't black-box on shape changes.

## Files

- New: \`src/renderer/components/chat/toolResultRenderers/index.tsx\` — registry + dispatch
- New: \`src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx\` — the \`list_files\` renderer
- \`src/renderer/components/chat/ChatMessage.tsx\` — dispatch wiring
- \`src/renderer/components/chat/ChatInput.tsx\` — no-arg \`/list_files\` defaults to explorer root

## Verification

1. \`/list_files\` in any mode → renders file tree, not JSON.
2. Click a file → opens in preview tab (matches explorer).
3. Click a folder → toggles expand/collapse (chat-side only).
4. Open file explorer to a folder, expand some children, then \`/list_files\` → chat tree opens at the same root with the same folders expanded.
5. Toggle a folder in chat → side panel unchanged.
6. \`/read_document\` or \`/get_outline\` still render as JSON (no renderer registered).

## Scope

UX polish surfaced during #467 QA. Stacked on the already-merged Phase 1 (persistent selection, #529) which landed on release earlier in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)