### PR TITLE
feat(chat): mid-conversation mode-switch awareness via system prompt

### DIFF
--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -340,6 +340,15 @@ export function useChat() {
         const settingsState = useSettingsStore.getState()
         const editorState = useEditorStore.getState()
         const tools = getToolsForToolMode(state.toolMode)
+        // Mid-stream mode switches are rare (user toggles during tool loop)
+        // but the same idempotency logic applies. lastSentToolMode was set
+        // at the start of this stream, so this fires only on genuine mid-
+        // stream toggles.
+        const loopLastSent = state.lastSentToolMode
+        const loopModeJustSwitched = loopLastSent !== null && loopLastSent !== state.toolMode
+        if (loopModeJustSwitched) {
+          state.setLastSentToolMode(state.toolMode)
+        }
 
         try {
           await api.llmChatStream({
@@ -352,7 +361,8 @@ export function useChat() {
               editorState.document.content,
               state.toolMode,
               editorState.document.path,
-              resolveModelName(settingsState.settings.llm.model, settingsState.fetchedModels)
+              resolveModelName(settingsState.settings.llm.model, settingsState.fetchedModels),
+              loopModeJustSwitched
             ),
             streamId: newStreamId,
             tools,
@@ -538,6 +548,14 @@ export function useChat() {
       }
 
       console.log('[useChat] About to call llmChatStream')
+      // Detect mid-conversation mode switches so we can prepend a one-line
+      // note to the system prompt. Idempotent across multiple toggles:
+      // only the diff at send time matters, and we update lastSentToolMode
+      // immediately so the tool-loop continuation (later in this stream)
+      // doesn't re-fire the marker on every roundtrip.
+      const lastSent = useChatStore.getState().lastSentToolMode
+      const modeJustSwitched = lastSent !== null && lastSent !== toolMode
+      useChatStore.getState().setLastSentToolMode(toolMode)
       try {
         // Call streaming LLM (via Electron IPC or browser fallback)
         const api = getApi()
@@ -552,7 +570,8 @@ export function useChat() {
             useEditorStore.getState().document.content,
             toolMode,
             useEditorStore.getState().document.path,
-            resolveModelName(settings.llm.model, useSettingsStore.getState().fetchedModels)
+            resolveModelName(settings.llm.model, useSettingsStore.getState().fetchedModels),
+            modeJustSwitched
           ),
           streamId,
           tools,

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -149,7 +149,8 @@ export function buildSystemPrompt(
   documentContent?: string,
   toolMode?: ToolMode,
   documentPath?: string | null,
-  modelName?: string
+  modelName?: string,
+  modeJustSwitched?: boolean
 ): string {
   let prompt = BASE_PROMPT
 
@@ -160,6 +161,18 @@ export function buildSystemPrompt(
   // Mode-specific tool instructions. Defaults to Editor when no mode supplied
   // (matches the chatStore initial value).
   const resolvedMode: ToolMode = toolMode ?? 'editor'
+
+  // Mid-conversation mode switch notice — surface a one-line note BEFORE
+  // the base persona so the agent sees the mode change first. Caller
+  // computes the boolean by comparing chatStore.lastSentToolMode with
+  // the current toolMode; this is idempotent across multiple toggles
+  // between sends.
+  if (modeJustSwitched) {
+    const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
+    prompt =
+      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Earlier turns may have been in a different mode with different capabilities. Adopt the current mode's posture immediately.\n\n` +
+      prompt
+  }
   if (resolvedMode === 'chat') {
     prompt += CHAT_MODE_INSTRUCTIONS
   } else if (resolvedMode === 'editor') {

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -24,6 +24,12 @@ interface ChatState {
   context: string | null
   agentMode: boolean // Legacy - kept for backwards compatibility
   toolMode: ToolMode // New mode system
+  // Tracks the toolMode active at the last successful user message send,
+  // so we can detect mid-conversation mode switches and note them in the
+  // next system prompt. Idempotent across multiple toggles between sends —
+  // only the difference at send time matters. In-memory only (matches
+  // toolMode itself).
+  lastSentToolMode: ToolMode | null
 
   // Initialization state - prevents race conditions during app startup
   isInitializing: boolean
@@ -52,6 +58,7 @@ interface ChatState {
   setContext: (context: string | null) => void
   setToolMode: (mode: ToolMode) => void
   cycleToolMode: () => void
+  setLastSentToolMode: (mode: ToolMode | null) => void
 
   // Streaming actions
   startStreaming: (messageId: string, streamId: string) => void
@@ -88,6 +95,7 @@ export const useChatStore = create<ChatState>()(
     // renders edit blocks as reviewable diffs).
     agentMode: false,
     toolMode: 'editor',
+    lastSentToolMode: null,
     isInitializing: true, // Start as true, will be set to false after app init
     isStreaming: false,
     currentStreamId: null,
@@ -237,6 +245,8 @@ export const useChatStore = create<ChatState>()(
       const next: ToolMode = current === 'chat' ? 'editor' : current === 'editor' ? 'create' : 'chat'
       get().setToolMode(next)
     },
+
+    setLastSentToolMode: (mode) => set({ lastSentToolMode: mode }),
 
     // Streaming actions
     startStreaming: (messageId, streamId) =>


### PR DESCRIPTION
## Summary

Caught during the #467 manual QA pass. When a user switches modes mid-conversation (e.g., starts in Editor, switches to Chat after a few turns), the agent's behavior can lag because:

- The system prompt rebuilds per turn with current-mode instructions ✓
- But the conversation history reflects the *previous* mode's dynamics — prior tool calls, prior posture
- The agent pattern-matches on history and can drift back toward the old mode's framing

## Fix

Track \`lastSentToolMode\` in \`chatStore\`. On every send, if \`toolMode !== lastSentToolMode && lastSentToolMode !== null\`, prepend a one-line note to the system prompt:

> Note: the user just switched to <Mode> Mode mid-conversation. Earlier turns may have been in a different mode with different capabilities. Adopt the current mode's posture immediately.

**Idempotent.** Only the diff at SEND time matters. Multiple toggles between sends collapse to a single marker for the final mode. \`lastSentToolMode\` updates immediately, so the tool-loop continuation within the same stream doesn't re-fire the marker on every roundtrip.

**Invisible to chat UI.** The marker lives only in the system prompt sent to the API. No bubble clutter, no rendering changes.

## Files

- \`src/renderer/stores/chatStore.ts\` — \`lastSentToolMode\` field + setter, initialized \`null\`, in-memory only (matches \`toolMode\` itself)
- \`src/renderer/lib/prompts.ts\` — \`buildSystemPrompt\` takes optional \`modeJustSwitched\`, prepends the note when true
- \`src/renderer/hooks/useChat.ts\` — both send paths (initial + tool-loop continuation) compute the flag, update \`lastSentToolMode\` atomically with send

## Verification

1. In Editor mode, send a message. \`lastSentToolMode\` becomes \`editor\`.
2. Switch through Chat → Create → Chat (4 toggles, no sends).
3. Send a message in Chat. The API request's \`system\` field has \`Note: the user just switched to Chat Mode...\` prepended. Only one marker, for the final mode.
4. Send another message in Chat without switching. **No marker** (mode unchanged since last send).
5. Switch to Editor, send a message → marker fires (\`switched to Editor\`).
6. Toggle mode mid-stream during a tool-loop continuation → marker also fires in the loop's next continuation request (rare but supported).

The marker is invisible in the chat UI; verify by inspecting the request payload in DevTools' Network tab, or behaviorally by sending an edit request after switching to Chat and confirming the agent adapts (declines + redirects) rather than pattern-matching on history.

## Scope

UX polish caught during #467 QA. Out of umbrella scope strictly, but small enough to land on the release branch before merging to main. Behavior is purely additive: no changes when modes don't switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)