### PR TITLE
feat(chat): request_mode_switch tool + persona softening

### DIFF
--- a/docs/architecture/llm-pipeline.md
+++ b/docs/architecture/llm-pipeline.md
@@ -49,7 +49,7 @@ const MAX_HISTORY_MESSAGES = 20   // context window pruning
 Two refs live outside the React hook so globally-registered IPC event handlers can access them:
 
 - **`pendingToolCallsRef`** — accumulates `{id, name, args}` from streaming `tool-call` events, tagged with `streamId`
-- **`toolLoopContextRef`** — tracks `{apiMessages, assistantMsgId, roundtripCount, lastErrorSignature}` across recursive stream restarts, tagged with `streamId`
+- **`toolLoopContextRef`** — tracks `{apiMessages, assistantMsgId, roundtripCount, lastErrorSignature, modeJustSwitched}` across recursive stream restarts, tagged with `streamId`. `modeJustSwitched` is set at turn start and preserved across continuations so the "you just switched modes" notice stays on the system prompt for every LLM call within a turn that began with a mode switch.
 
 Both are reset by `clearStreamRefs()` on abort, error, completion, or circuit-breaker stop.
 

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { cn } from '../../lib/utils'
 import type { ChatMessage as ChatMessageType } from '../../types'
-import { User, Wand2, Check, AlertCircle, ArrowRight, Sparkles, CheckCircle2, XCircle, RotateCcw } from 'lucide-react'
+import { User, Wand2, Check, AlertCircle, ArrowRight, Sparkles, CheckCircle2, XCircle, RotateCcw, ChevronDown } from 'lucide-react'
 import { parseEditBlocks, hasEditBlocks, stripEditBlocks, type EditBlock } from '../../lib/editBlocks'
 import { applyEditsAsDiffs, applyEditsDirect, type ApplyResult, type EditProvenance } from '../../lib/applyEdit'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
@@ -16,7 +16,16 @@ import avatarDark from '../../assets/avatar-dark.png'
 import avatarLight from '../../assets/avatar-light.png'
 
 // Tool call indicator component with AI sparkle styling
-function ToolCallIndicator({ name, status, onClick, children }: { name: string; status: 'executing' | 'success' | 'error'; onClick?: () => void; children?: React.ReactNode }) {
+function ToolCallIndicator({ name, status, onClick, children, actions, defaultExpanded = false }: { name: string; status: 'executing' | 'success' | 'error'; onClick?: () => void; children?: React.ReactNode; actions?: React.ReactNode; defaultExpanded?: boolean }) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const hasBody = children != null && status !== 'executing'
+  const hasActions = actions != null
+
+  const toggleExpanded = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setExpanded(v => !v)
+  }
+
   return (
     <div
       className={cn(
@@ -39,18 +48,33 @@ function ToolCallIndicator({ name, status, onClick, children }: { name: string; 
         ) : status === 'success' ? (
           <>
             <CheckCircle2 className="h-3.5 w-3.5" />
-            <span>{name}</span>
+            <span className="flex-1">{name}</span>
           </>
         ) : (
           <>
             <XCircle className="h-3.5 w-3.5" />
-            <span>{name}</span>
+            <span className="flex-1">{name}</span>
           </>
         )}
+        {hasBody && (
+          <button
+            type="button"
+            onClick={toggleExpanded}
+            aria-label={expanded ? 'Collapse details' : 'Expand details'}
+            className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded text-current/70 hover:bg-current/10 hover:text-current focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current/40"
+          >
+            <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", !expanded && "-rotate-90")} />
+          </button>
+        )}
       </div>
-      {children && (
+      {hasBody && expanded && (
         <div className="px-3 py-2 text-xs font-mono text-muted-foreground border-t border-border bg-muted/10 max-h-48 overflow-auto">
           {children}
+        </div>
+      )}
+      {hasActions && (
+        <div className="px-3 py-2 border-t border-border bg-muted/5" onClick={(e) => e.stopPropagation()}>
+          {actions}
         </div>
       )}
     </div>
@@ -552,9 +576,13 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                       }
                       // Per-tool custom renderer if one is registered; falls
                       // back to markdown (JSON in <pre>) for unknown tools.
-                      const customBody =
+                      // ctx scopes per-tool-call state (e.g., the
+                      // mode-switch acted/dismissed flag) into the owning
+                      // message's toolActions map, so it persists with the
+                      // conversation.
+                      const custom =
                         part.name && part.content && part.success
-                          ? renderToolResult(part.name, part.content)
+                          ? renderToolResult(part.name, part.content, { messageId: message.id, toolPartIdx: idx })
                           : null
                       return (
                         <ToolCallIndicator
@@ -562,8 +590,10 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                           name={part.name || 'tool'}
                           status={part.success ? 'success' : 'error'}
                           onClick={onClickHandler}
+                          actions={custom?.actions}
+                          defaultExpanded={custom?.defaultExpanded}
                         >
-                          {customBody ?? (part.content && renderMarkdown(part.content, editor))}
+                          {custom?.body ?? (part.content && renderMarkdown(part.content, editor))}
                         </ToolCallIndicator>
                       )
                     }

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -20,6 +20,7 @@ import { useSummaryStore } from '../../stores/summaryStore'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { ReviewContainer } from '../review/ReviewContainer'
+import { MODE_SWITCH_RUN_EVENT } from './toolResultRenderers/RequestModeSwitchResult'
 import { cn } from '../../lib/utils'
 
 export function ChatPanel() {
@@ -64,6 +65,20 @@ export function ChatPanel() {
       generateSummary(document.documentId, content)
     }
   }, [infoOpen, summary, isStale, isGenerating, hasApiKey, document.documentId, generateSummary])
+
+  // Listen for the "Switch & Run" button in request_mode_switch tool
+  // results. Renderer dispatches a CustomEvent so it doesn't have to
+  // own a useChat reference; we send the agent's suggested prompt here.
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ prompt: string }>).detail
+      if (detail?.prompt) {
+        sendMessage(detail.prompt)
+      }
+    }
+    window.addEventListener(MODE_SWITCH_RUN_EVENT, handler)
+    return () => window.removeEventListener(MODE_SWITCH_RUN_EVENT, handler)
+  }, [sendMessage])
 
   // Track pending suggestion count
   const suggestionCount = useMemo(() => {

--- a/src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react'
 import { Button } from '../../ui/button'
-import { ArrowRightIcon, RefreshCwIcon } from 'lucide-react'
+import { ArrowRightIcon, RefreshCwIcon, XIcon } from 'lucide-react'
 import { useChatStore } from '../../../stores/chatStore'
 import type { ToolMode } from '../../../../shared/tools/types'
 
@@ -10,8 +9,16 @@ interface RequestModeSwitchPayload {
   prompt_to_retry: string
 }
 
-interface RequestModeSwitchResultProps {
+interface BodyProps {
   content: string
+}
+
+interface ActionsProps {
+  content: string
+  /** Owning message ID — used to read/write `toolActions[toolPartIdx]`. */
+  messageId: string
+  /** Index of this tool result inside the message's parsed tool parts. */
+  toolPartIdx: number
 }
 
 const MODE_LABEL: Record<ToolMode, string> = {
@@ -20,29 +27,31 @@ const MODE_LABEL: Record<ToolMode, string> = {
   create: 'Create'
 }
 
-/**
- * Renders the agent's request_mode_switch tool result as a one-click
- * affordance: the user picks "Switch & Run" (mode-switch + auto-send the
- * agent's prompt_to_retry) or "Just Switch" (mode-switch only). Mode
- * changes never happen without an explicit user click.
- *
- * sendMessage is dispatched via a CustomEvent so this renderer doesn't
- * have to be a useChat consumer (which would couple it tightly to a hook
- * tree shape that may evolve). The ChatPanel listens for the event and
- * calls its local sendMessage. See `chatStore.ts` for the event name
- * constant if introduced; for now, a simple inline string suffices.
- */
 const MODE_SWITCH_RUN_EVENT = 'prose:mode-switch-and-run'
 
-export function RequestModeSwitchResult({ content }: RequestModeSwitchResultProps) {
-  const [acted, setActed] = useState(false)
-  const setToolMode = useChatStore((s) => s.setToolMode)
-
-  let parsed: { data?: RequestModeSwitchPayload } | RequestModeSwitchPayload | null = null
+function parsePayload(content: string): RequestModeSwitchPayload | null {
   try {
     const cleaned = content.replace(/```json\n?|\n?```/g, '').trim()
-    parsed = JSON.parse(cleaned)
+    const parsed = JSON.parse(cleaned)
+    if (parsed && typeof parsed === 'object' && 'data' in parsed && parsed.data && typeof parsed.data === 'object') {
+      return parsed.data as RequestModeSwitchPayload
+    }
+    if (parsed && typeof parsed === 'object' && 'target' in parsed) {
+      return parsed as RequestModeSwitchPayload
+    }
   } catch {
+    return null
+  }
+  return null
+}
+
+/**
+ * Body slot: the reason and prompt_to_retry quote. Rendered inside the
+ * collapsible body area of the tool-call shell.
+ */
+export function RequestModeSwitchBody({ content }: BodyProps) {
+  const payload = parsePayload(content)
+  if (!payload) {
     return (
       <div className="text-xs text-muted-foreground">
         <div className="mb-1">Unable to parse mode-switch request.</div>
@@ -50,43 +59,63 @@ export function RequestModeSwitchResult({ content }: RequestModeSwitchResultProp
       </div>
     )
   }
+  return (
+    <div className="space-y-2">
+      <div className="text-xs text-foreground">{payload.reason}</div>
+      <div className="rounded-md border border-border bg-background/50 p-2 text-xs italic text-muted-foreground">
+        &ldquo;{payload.prompt_to_retry}&rdquo;
+      </div>
+    </div>
+  )
+}
 
-  // Accept both envelope and raw shapes, like ListFilesResult.
-  const payload: RequestModeSwitchPayload | null =
-    parsed && 'data' in parsed && parsed.data
-      ? parsed.data
-      : parsed && 'target' in parsed
-        ? (parsed as RequestModeSwitchPayload)
-        : null
+/**
+ * Actions slot: the Switch & Run / Just Switch / Cancel buttons. Always
+ * visible (outside the collapsible body region). Mode changes never
+ * happen without an explicit user click.
+ *
+ * Action state (switched | dismissed) lives on the owning message as
+ * `toolActions[toolPartIdx]`, persisted with the conversation. That
+ * way reopening the chat shows a truthful record of past decisions
+ * instead of re-clickable buttons for a "Switch & Run" that already
+ * fired three messages ago.
+ *
+ * sendMessage is dispatched via a CustomEvent so this renderer doesn't
+ * have to be a useChat consumer. ChatPanel listens for the event and
+ * calls its local sendMessage.
+ */
+export function RequestModeSwitchActions({ content, messageId, toolPartIdx }: ActionsProps) {
+  const action = useChatStore(
+    (s) => s.messages.find((m) => m.id === messageId)?.toolActions?.[toolPartIdx]
+  )
+  const setToolMode = useChatStore((s) => s.setToolMode)
+  const setToolCallAction = useChatStore((s) => s.setToolCallAction)
+  const payload = parsePayload(content)
+  if (!payload) return null
 
-  if (!payload) {
-    return <div className="text-xs text-muted-foreground">Empty mode-switch request.</div>
-  }
-
-  const { target, reason, prompt_to_retry } = payload
+  const { target, prompt_to_retry } = payload
+  const acted = action != null
 
   const handleJustSwitch = () => {
     setToolMode(target)
-    setActed(true)
+    setToolCallAction(messageId, toolPartIdx, 'switched')
   }
 
   const handleSwitchAndRun = () => {
     setToolMode(target)
-    setActed(true)
-    // Dispatch through a CustomEvent — ChatPanel listens for this and calls
-    // its sendMessage. Keeps the renderer decoupled from the chat-hook tree.
+    setToolCallAction(messageId, toolPartIdx, 'switched')
     window.dispatchEvent(
       new CustomEvent(MODE_SWITCH_RUN_EVENT, { detail: { prompt: prompt_to_retry } })
     )
   }
 
+  const handleCancel = () => {
+    setToolCallAction(messageId, toolPartIdx, 'dismissed')
+  }
+
   return (
-    <div className="space-y-2">
-      <div className="text-xs text-foreground">{reason}</div>
-      <div className="rounded-md border border-border bg-background/50 p-2 text-xs italic text-muted-foreground">
-        &ldquo;{prompt_to_retry}&rdquo;
-      </div>
-      <div className="flex gap-2 pt-1">
+    <div className="space-y-1">
+      <div className="flex flex-wrap gap-2">
         <Button
           size="sm"
           variant="default"
@@ -107,10 +136,25 @@ export function RequestModeSwitchResult({ content }: RequestModeSwitchResultProp
           <ArrowRightIcon className="mr-1 h-3 w-3" />
           Just Switch
         </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={acted}
+          onClick={handleCancel}
+          className="h-7 text-xs"
+        >
+          <XIcon className="mr-1 h-3 w-3" />
+          Cancel
+        </Button>
       </div>
-      {acted && (
+      {action === 'switched' && (
         <div className="text-[11px] text-muted-foreground">
           Switched to {MODE_LABEL[target]} Mode.
+        </div>
+      )}
+      {action === 'dismissed' && (
+        <div className="text-[11px] text-muted-foreground">
+          Dismissed.
         </div>
       )}
     </div>

--- a/src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import { Button } from '../../ui/button'
+import { ArrowRightIcon, RefreshCwIcon } from 'lucide-react'
+import { useChatStore } from '../../../stores/chatStore'
+import type { ToolMode } from '../../../../shared/tools/types'
+
+interface RequestModeSwitchPayload {
+  target: ToolMode
+  reason: string
+  prompt_to_retry: string
+}
+
+interface RequestModeSwitchResultProps {
+  content: string
+}
+
+const MODE_LABEL: Record<ToolMode, string> = {
+  chat: 'Chat',
+  editor: 'Editor',
+  create: 'Create'
+}
+
+/**
+ * Renders the agent's request_mode_switch tool result as a one-click
+ * affordance: the user picks "Switch & Run" (mode-switch + auto-send the
+ * agent's prompt_to_retry) or "Just Switch" (mode-switch only). Mode
+ * changes never happen without an explicit user click.
+ *
+ * sendMessage is dispatched via a CustomEvent so this renderer doesn't
+ * have to be a useChat consumer (which would couple it tightly to a hook
+ * tree shape that may evolve). The ChatPanel listens for the event and
+ * calls its local sendMessage. See `chatStore.ts` for the event name
+ * constant if introduced; for now, a simple inline string suffices.
+ */
+const MODE_SWITCH_RUN_EVENT = 'prose:mode-switch-and-run'
+
+export function RequestModeSwitchResult({ content }: RequestModeSwitchResultProps) {
+  const [acted, setActed] = useState(false)
+  const setToolMode = useChatStore((s) => s.setToolMode)
+
+  let parsed: { data?: RequestModeSwitchPayload } | RequestModeSwitchPayload | null = null
+  try {
+    const cleaned = content.replace(/```json\n?|\n?```/g, '').trim()
+    parsed = JSON.parse(cleaned)
+  } catch {
+    return (
+      <div className="text-xs text-muted-foreground">
+        <div className="mb-1">Unable to parse mode-switch request.</div>
+        <pre className="text-[10px] overflow-x-auto whitespace-pre-wrap">{content}</pre>
+      </div>
+    )
+  }
+
+  // Accept both envelope and raw shapes, like ListFilesResult.
+  const payload: RequestModeSwitchPayload | null =
+    parsed && 'data' in parsed && parsed.data
+      ? parsed.data
+      : parsed && 'target' in parsed
+        ? (parsed as RequestModeSwitchPayload)
+        : null
+
+  if (!payload) {
+    return <div className="text-xs text-muted-foreground">Empty mode-switch request.</div>
+  }
+
+  const { target, reason, prompt_to_retry } = payload
+
+  const handleJustSwitch = () => {
+    setToolMode(target)
+    setActed(true)
+  }
+
+  const handleSwitchAndRun = () => {
+    setToolMode(target)
+    setActed(true)
+    // Dispatch through a CustomEvent — ChatPanel listens for this and calls
+    // its sendMessage. Keeps the renderer decoupled from the chat-hook tree.
+    window.dispatchEvent(
+      new CustomEvent(MODE_SWITCH_RUN_EVENT, { detail: { prompt: prompt_to_retry } })
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="text-xs text-foreground">{reason}</div>
+      <div className="rounded-md border border-border bg-background/50 p-2 text-xs italic text-muted-foreground">
+        &ldquo;{prompt_to_retry}&rdquo;
+      </div>
+      <div className="flex gap-2 pt-1">
+        <Button
+          size="sm"
+          variant="default"
+          disabled={acted}
+          onClick={handleSwitchAndRun}
+          className="h-7 text-xs"
+        >
+          <RefreshCwIcon className="mr-1 h-3 w-3" />
+          Switch to {MODE_LABEL[target]} &amp; Run
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={acted}
+          onClick={handleJustSwitch}
+          className="h-7 text-xs"
+        >
+          <ArrowRightIcon className="mr-1 h-3 w-3" />
+          Just Switch
+        </Button>
+      </div>
+      {acted && (
+        <div className="text-[11px] text-muted-foreground">
+          Switched to {MODE_LABEL[target]} Mode.
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { MODE_SWITCH_RUN_EVENT }

--- a/src/renderer/components/chat/toolResultRenderers/index.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/index.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { ListFilesResult } from './ListFilesResult'
+import { RequestModeSwitchResult } from './RequestModeSwitchResult'
 
 /**
  * Per-tool result renderer registry. Keyed by the tool name; each entry
@@ -20,7 +21,8 @@ import { ListFilesResult } from './ListFilesResult'
 type ToolResultRenderer = (content: string) => ReactNode
 
 const toolResultRenderers: Record<string, ToolResultRenderer> = {
-  list_files: (content) => <ListFilesResult content={content} />
+  list_files: (content) => <ListFilesResult content={content} />,
+  request_mode_switch: (content) => <RequestModeSwitchResult content={content} />
 }
 
 export function renderToolResult(name: string, content: string): ReactNode | null {

--- a/src/renderer/components/chat/toolResultRenderers/index.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/index.tsx
@@ -1,31 +1,62 @@
 import type { ReactNode } from 'react'
 import { ListFilesResult } from './ListFilesResult'
-import { RequestModeSwitchResult } from './RequestModeSwitchResult'
+import { RequestModeSwitchBody, RequestModeSwitchActions } from './RequestModeSwitchResult'
 
 /**
- * Per-tool result renderer registry. Keyed by the tool name; each entry
- * returns a React node that replaces the default `renderMarkdown` output
- * (which dumps JSON inside a `<pre>` code block).
+ * Per-tool result renderer registry. Keyed by tool name; each entry
+ * returns `{ body?, actions? }`:
+ *   - `body` replaces the default `renderMarkdown` output (which dumps
+ *     JSON inside a `<pre>` code block) and lives inside the
+ *     collapsible/scrollable region of the tool-call shell.
+ *   - `actions` (optional) lives outside the collapsible region and
+ *     stays visible regardless of expansion state. Use for affordances
+ *     the user shouldn't have to expand to find (e.g., one-click
+ *     mode-switch buttons).
  *
- * Unknown tools return null from `renderToolResult` and the caller falls
- * back to the default markdown render.
+ * `ctx` exposes `messageId` + `toolPartIdx` so actions can persist
+ * their interaction state into the owning message's `toolActions` map
+ * (saved with the conversation).
  *
- * Adding a renderer: write the component under
+ * Unknown tools return `null` and the caller falls back to the default
+ * markdown render in the body slot.
+ *
+ * Adding a renderer: write the component(s) under
  * `src/renderer/components/chat/toolResultRenderers/<Name>.tsx`, import
- * it here, add the entry to `toolResultRenderers`. Components receive
- * the raw `content` string and are responsible for parsing it (the
- * content is typically a JSON-stringified `ToolResult<T>` envelope,
- * sometimes wrapped in markdown code fences).
+ * here, add the entry. The body component is responsible for parsing
+ * the raw `content` string (typically a JSON-stringified
+ * `ToolResult<T>` envelope, sometimes wrapped in markdown code fences).
  */
 
-type ToolResultRenderer = (content: string) => ReactNode
-
-const toolResultRenderers: Record<string, ToolResultRenderer> = {
-  list_files: (content) => <ListFilesResult content={content} />,
-  request_mode_switch: (content) => <RequestModeSwitchResult content={content} />
+export interface ToolResultSlots {
+  body?: ReactNode
+  actions?: ReactNode
+  /**
+   * Initial expand state for the collapsible body. Defaults to false
+   * (collapsed) so noisy JSON dumps stay out of the way. Set to true
+   * for tools where the body content is the point of the response and
+   * the user shouldn't have to hunt for it (e.g., `request_mode_switch`
+   * — the reason and prompt-to-retry quote are the substance).
+   */
+  defaultExpanded?: boolean
 }
 
-export function renderToolResult(name: string, content: string): ReactNode | null {
+export interface ToolResultContext {
+  messageId: string
+  toolPartIdx: number
+}
+
+type ToolResultRenderer = (content: string, ctx: ToolResultContext) => ToolResultSlots
+
+const toolResultRenderers: Record<string, ToolResultRenderer> = {
+  list_files: (content) => ({ body: <ListFilesResult content={content} /> }),
+  request_mode_switch: (content, ctx) => ({
+    body: <RequestModeSwitchBody content={content} />,
+    actions: <RequestModeSwitchActions content={content} messageId={ctx.messageId} toolPartIdx={ctx.toolPartIdx} />,
+    defaultExpanded: true
+  })
+}
+
+export function renderToolResult(name: string, content: string, ctx: ToolResultContext): ToolResultSlots | null {
   const renderer = toolResultRenderers[name]
-  return renderer ? renderer(content) : null
+  return renderer ? renderer(content, ctx) : null
 }

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -90,6 +90,15 @@ const toolLoopContextRef = {
     assistantMsgId: string
     roundtripCount: number
     lastErrorSignature: string | null
+    // True if the turn started with a mode switch (Switch & Run or
+    // StatusBar toggle between sends). Propagates through every
+    // tool-loop continuation in the turn so the "you just switched"
+    // notice stays on the system prompt — without it, continuations
+    // after a legitimate read_document call lose the notice and the
+    // LLM pattern-matches against prior-mode assistant messages,
+    // hallucinating "I'm still in <old> Mode" despite the tool list
+    // and per-mode instructions reflecting the new mode.
+    modeJustSwitched: boolean
   } | null,
   streamId: null as string | null
 }
@@ -338,12 +347,16 @@ export function useChat() {
         const newStreamId = createMessageId()
         state.startStreaming(assistantMsgId, newStreamId)
 
-        // Update context for potential next tool loop with new streamId
+        // Update context for potential next tool loop with new streamId.
+        // Preserve `modeJustSwitched` across the whole turn so subsequent
+        // continuations keep the "you just switched" notice.
+        const priorTurnContext = toolLoopContextRef.current
         toolLoopContextRef.current = {
           apiMessages: updatedMessages,
           assistantMsgId,
           roundtripCount: roundtripCount + 1,
-          lastErrorSignature: currentErrorSignature
+          lastErrorSignature: currentErrorSignature,
+          modeJustSwitched: priorTurnContext?.modeJustSwitched ?? false
         }
         toolLoopContextRef.streamId = newStreamId
         pendingToolCallsRef.streamId = newStreamId
@@ -361,6 +374,11 @@ export function useChat() {
         if (loopModeJustSwitched) {
           state.setLastSentToolMode(state.toolMode)
         }
+        // The notice fires if the turn started with a switch (Switch &
+        // Run or pre-send StatusBar toggle) OR if the user toggled mode
+        // mid-loop. Either way we want the grounding text in the prompt.
+        const continuationModeJustSwitched =
+          toolLoopContextRef.current.modeJustSwitched || loopModeJustSwitched
 
         try {
           await api.llmChatStream({
@@ -374,7 +392,7 @@ export function useChat() {
               state.toolMode,
               editorState.document.path,
               resolveModelName(settingsState.settings.llm.model, settingsState.fetchedModels),
-              loopModeJustSwitched
+              continuationModeJustSwitched
             ),
             streamId: newStreamId,
             tools,
@@ -555,18 +573,6 @@ export function useChat() {
         console.error('[useChat] Error getting tools:', toolErr)
         tools = undefined
       }
-      if (tools && tools.length > 0) {
-        toolLoopContextRef.current = {
-          apiMessages,
-          assistantMsgId,
-          roundtripCount: 0,
-          lastErrorSignature: null
-        }
-        toolLoopContextRef.streamId = streamId
-        pendingToolCallsRef.streamId = streamId
-      }
-
-      console.log('[useChat] About to call llmChatStream')
       // Detect mid-conversation mode switches so we can prepend a one-line
       // note to the system prompt. Idempotent across multiple toggles:
       // only the diff at send time matters, and we update lastSentToolMode
@@ -575,6 +581,20 @@ export function useChat() {
       const lastSent = useChatStore.getState().lastSentToolMode
       const modeJustSwitched = lastSent !== null && lastSent !== toolMode
       useChatStore.getState().setLastSentToolMode(toolMode)
+
+      if (tools && tools.length > 0) {
+        toolLoopContextRef.current = {
+          apiMessages,
+          assistantMsgId,
+          roundtripCount: 0,
+          lastErrorSignature: null,
+          modeJustSwitched
+        }
+        toolLoopContextRef.streamId = streamId
+        pendingToolCallsRef.streamId = streamId
+      }
+
+      console.log('[useChat] About to call llmChatStream')
       try {
         // Call streaming LLM (via Electron IPC or browser fallback)
         const api = getApi()

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -442,6 +442,13 @@ export function useChat() {
       console.log('[useChat] sendMessage called with:', content?.substring(0, 50), 'isLoading:', isLoading)
       if (!content.trim() || isLoading) return
       console.log('[useChat] sendMessage passed initial check')
+      // Read toolMode fresh from the store rather than relying on the
+      // React-closure-captured value. Necessary because callers (notably
+      // RequestModeSwitchResult's "Switch & Run" path) may setToolMode
+      // and then synchronously dispatch sendMessage in the same tick —
+      // React hasn't re-rendered yet, and the captured `toolMode` would
+      // be stale. Reading from the store always reflects the latest.
+      const toolMode = useChatStore.getState().toolMode
 
       // Auto-create a conversation if there isn't one
       if (!activeConversationId) {

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -33,7 +33,11 @@ const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'get_metadata',
   'search_document',
   'get_outline',
-  'list_comments'
+  'list_comments',
+  // UX coordination: lets the agent offer the user a one-click mode
+  // switch when their request is out of scope for the current mode.
+  // It doesn't read or mutate anything — just renders a button.
+  'request_mode_switch'
 ])
 
 function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
@@ -291,14 +295,22 @@ export function useChat() {
             currentErrorSignature = `${toolCall.name}:${result.error}`
           }
 
-          // Append tool execution info to the message
-          const resultSummary = result.success
-            ? (typeof result.data === 'string' ? result.data.slice(0, 100) : 'Success')
+          // Append tool execution info to the message using the same
+          // <tool-result> tag format as user-initiated slash commands.
+          // This unifies both paths so custom renderers in
+          // src/renderer/components/chat/toolResultRenderers/ get the
+          // full structured payload regardless of who triggered the
+          // tool call. Tools without a custom renderer fall back to
+          // the markdown render of the JSON, matching slash-command UX.
+          const resultText = result.success
+            ? (typeof result.data === 'string'
+                ? result.data
+                : '```json\n' + JSON.stringify(result.data, null, 2) + '\n```')
             : `Error: ${result.error}`
           state.updateMessage(assistantMsgId, {
             content:
               state.messages.find((m) => m.id === assistantMsgId)?.content +
-              `\n\n*[Tool: ${toolCall.name}] ${resultSummary}*`
+              `\n\n<tool-result name="${toolCall.name}" success="${result.success}">${resultText}</tool-result>`
           })
 
           // Add tool result message to API messages (summarized to reduce context)

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -444,7 +444,7 @@ export function useChat() {
       console.log('[useChat] sendMessage passed initial check')
       // Read toolMode fresh from the store rather than relying on the
       // React-closure-captured value. Necessary because callers (notably
-      // RequestModeSwitchResult's "Switch & Run" path) may setToolMode
+      // RequestModeSwitchActions' "Switch & Run" path) may setToolMode
       // and then synchronously dispatch sendMessage in the same tick —
       // React hasn't re-rendered yet, and the captured `toolMode` would
       // be stale. Reading from the store always reflects the latest.

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -28,7 +28,7 @@ You are an editor in the original sense. You edit, you question, you scaffold. *
 
 *Would a reader see words I wrote?* If yes, that is authorship. Apply the test to the document body — not to edit-comment captions in the diff UI, escape-hatch prompts written to working files, or transient chat messages.
 
-If a request would have you draft prose into the document, stop and ask whether the user wants you to leave the drafting to them. The exception is Create Mode, where the user has explicitly opted in to LLM-authored prose.
+If a request would have you draft prose into the document, the right move depends on mode. In Editor or Chat Mode, call \`request_mode_switch\` with \`target: 'create'\` and a prompt the user can run after switching — don't lecture about modes in prose. In Create Mode, drafting is on the table; proceed.
 
 ## Heuristics (all modes)
 
@@ -69,8 +69,16 @@ Sounding board, fact-check, pushback, brainstorm. You have read-only tools to gr
 - \`search_document\` — Locate text or regex matches
 - \`get_metadata\` — Document path, word count, frontmatter, dirty state
 - \`list_comments\` — Existing comments in the document
+- \`request_mode_switch\` — Offer the user a one-click switch to a different mode
 
-If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.
+## When a request needs a different mode
+
+Don't lecture about modes in prose. Call \`request_mode_switch\` with:
+- \`target\`: the minimum mode that enables the request (\`editor\` for edits / comments, \`create\` for drafting)
+- \`reason\`: one short sentence about what the switch enables (under 20 words)
+- \`prompt_to_retry\`: the exact prompt to run after switching, phrased as the user would write it
+
+The user sees a small inline button: "Switch & Run" (mode-switch + auto-send the retry prompt) or "Just Switch" (mode-switch only). Use this for typo fixes, comments, drafting requests, file writes — anything Chat Mode can't do.
 
 You have a budget of 5 tool roundtrips per response.`
 
@@ -81,7 +89,9 @@ const EDITOR_MODE_INSTRUCTIONS = `
 
 ## Editor Mode
 
-You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user. If the user asks you to write a paragraph, decline or ask them to draft it for you to edit.
+You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user.
+
+If the user asks for drafting, don't lecture: call \`request_mode_switch\` with \`target: 'create'\` and the prompt they'd run after switching. The user gets a one-click button to switch and run, or just switch.
 
 ## Tools
 
@@ -91,6 +101,7 @@ You propose concrete copy edits and leave editorial notes. You do not draft pros
 - \`suggest_edit\` — Inline diff for a copy edit the user can accept or reject
 - \`add_comment\` — Editorial note attached to a range; the user decides the replacement
 - \`resolve_comment\` — Remove a comment by ID
+- \`request_mode_switch\` — Offer the user a one-click switch to Create Mode for drafting requests
 
 ## \`suggest_edit\` vs \`add_comment\`
 

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -181,7 +181,7 @@ export function buildSystemPrompt(
   if (modeJustSwitched) {
     const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
     prompt =
-      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Earlier turns may have been in a different mode with different capabilities. Adopt the current mode's posture immediately.\n\n` +
+      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Their next message likely reflects a request you should now be able to fulfill directly with this mode's tools. **Do NOT call \`request_mode_switch\` in this turn** — they've already switched. Use the tools available in ${modeLabel} Mode to act on their request.\n\n` +
       prompt
   }
   if (resolvedMode === 'chat') {

--- a/src/renderer/lib/tools/executors/ui.ts
+++ b/src/renderer/lib/tools/executors/ui.ts
@@ -1,0 +1,26 @@
+import type { ToolResult } from '../../../../shared/tools/types'
+import { toolSuccess } from '../../../../shared/tools/types'
+import type { ToolMode } from '../../../../shared/tools/types'
+
+/**
+ * Executor for request_mode_switch.
+ *
+ * Does NOT actually change the mode — that would bypass the user's intent.
+ * It just packages the agent's request as a tool result, which the chat-side
+ * renderer (`RequestModeSwitchResult.tsx`) turns into a one-click button.
+ *
+ * The user clicks the button; the renderer calls `setToolMode` and (for
+ * "Switch & Run") `sendMessage(prompt_to_retry)`. Mode change is always
+ * gated on an explicit user action.
+ */
+export interface RequestModeSwitchPayload {
+  target: ToolMode
+  reason: string
+  prompt_to_retry: string
+}
+
+export function executeRequestModeSwitch(
+  args: RequestModeSwitchPayload
+): ToolResult<RequestModeSwitchPayload> {
+  return toolSuccess(args)
+}

--- a/src/renderer/lib/tools/executors/ui.ts
+++ b/src/renderer/lib/tools/executors/ui.ts
@@ -7,7 +7,8 @@ import type { ToolMode } from '../../../../shared/tools/types'
  *
  * Does NOT actually change the mode — that would bypass the user's intent.
  * It just packages the agent's request as a tool result, which the chat-side
- * renderer (`RequestModeSwitchResult.tsx`) turns into a one-click button.
+ * renderer (`RequestModeSwitchResult.tsx` — `RequestModeSwitchBody` /
+ * `RequestModeSwitchActions`) turns into a one-click button.
  *
  * The user clicks the button; the renderer calls `setToolMode` and (for
  * "Switch & Run") `sendMessage(prompt_to_retry)`. Mode change is always

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -47,6 +47,9 @@ import {
   executeSelectTab
 } from './executors/tabs'
 
+// UI-coordination executors
+import { executeRequestModeSwitch } from './executors/ui'
+
 /** Provenance context for AI-generated content tracking */
 export interface ToolProvenance {
   model: string
@@ -143,6 +146,10 @@ export async function executeTool(
         return executeListTabs()
       case 'select_tab':
         return await executeSelectTab(validatedArgs)
+
+      // UI-coordination tools
+      case 'request_mode_switch':
+        return executeRequestModeSwitch(validatedArgs as Parameters<typeof executeRequestModeSwitch>[0])
 
       default:
         return toolError(`Tool "${toolName}" not implemented`, 'NOT_IMPLEMENTED')

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -59,6 +59,13 @@ interface ChatState {
   setToolMode: (mode: ToolMode) => void
   cycleToolMode: () => void
   setLastSentToolMode: (mode: ToolMode | null) => void
+  /**
+   * Record an action taken on a tool result. Persists with the
+   * conversation so reopening the chat shows the truthful state
+   * (e.g., "Dismissed." or "Switched to Editor Mode.") instead of
+   * re-clickable buttons for decisions already made.
+   */
+  setToolCallAction: (messageId: string, toolPartIdx: number, action: 'switched' | 'dismissed') => void
 
   // Streaming actions
   startStreaming: (messageId: string, streamId: string) => void
@@ -247,6 +254,25 @@ export const useChatStore = create<ChatState>()(
     },
 
     setLastSentToolMode: (mode) => set({ lastSentToolMode: mode }),
+
+    setToolCallAction: (messageId, toolPartIdx, action) =>
+      set((state) => {
+        const updateOne = (msg: ChatMessage): ChatMessage =>
+          msg.id === messageId
+            ? { ...msg, toolActions: { ...(msg.toolActions ?? {}), [toolPartIdx]: action } }
+            : msg
+        const newMessages = state.messages.map(updateOne)
+
+        if (state.activeConversationId) {
+          const updatedConversations = state.conversations.map((c) =>
+            c.id === state.activeConversationId
+              ? { ...c, messages: newMessages, updatedAt: Date.now() }
+              : c
+          )
+          return { messages: newMessages, conversations: updatedConversations }
+        }
+        return { messages: newMessages }
+      }),
 
     // Streaming actions
     startStreaming: (messageId, streamId) =>

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -73,6 +73,16 @@ export interface ChatMessage {
   timestamp: Date
   hidden?: boolean
   isError?: boolean
+  /**
+   * Per-tool-call action state, keyed by the tool-result's index in
+   * `parseToolTags(content)`. Populated when the user interacts with an
+   * actionable tool result (currently `request_mode_switch` —
+   * 'switched' if they hit Switch & Run / Just Switch, 'dismissed' if
+   * Cancel). Persisted with the conversation so re-opening the chat
+   * shows a truthful record instead of re-clickable affordances for
+   * decisions already made.
+   */
+  toolActions?: Record<number, 'switched' | 'dismissed'>
 }
 
 export interface FileResult {

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -6,13 +6,14 @@ import type { ToolConfig, ToolMode, ToolCategory } from './types'
 import { documentTools } from './schemas/document'
 import { editorTools } from './schemas/editor'
 import { fileTools } from './schemas/file'
+import { uiTools } from './schemas/ui'
 import { tabTools } from './schemas/tabs'
 import { zodToJsonSchema } from './utils'
 
 /**
  * All registered tools.
  */
-export const allTools = [...documentTools, ...editorTools, ...fileTools, ...tabTools] as const
+export const allTools = [...documentTools, ...editorTools, ...fileTools, ...tabTools, ...uiTools] as const
 
 /**
  * Tool name type (union of all tool names).

--- a/src/shared/tools/schemas/ui.ts
+++ b/src/shared/tools/schemas/ui.ts
@@ -1,0 +1,45 @@
+/**
+ * UI-coordination tool schemas — tools that don't read or mutate the
+ * document; they help the agent coordinate UX flows with the user.
+ */
+
+import { z } from 'zod'
+import type { ToolConfig } from '../types'
+
+// ============================================================================
+// request_mode_switch
+// ============================================================================
+
+export const requestModeSwitchSchema = z.object({
+  target: z
+    .enum(['chat', 'editor', 'create'])
+    .describe(
+      'The mode the user should switch to in order to do what they asked.'
+    ),
+  reason: z
+    .string()
+    .describe(
+      'One short sentence explaining what the new mode enables. Shown above the button in the chat. Keep under 20 words.'
+    ),
+  prompt_to_retry: z
+    .string()
+    .describe(
+      'The exact prompt to run after the switch. The user can click "Switch & Run" to mode-switch + auto-send this, or "Just Switch" to mode-switch and re-ask manually. Phrase this as if the user wrote it.'
+    )
+})
+
+export const requestModeSwitchConfig: ToolConfig<typeof requestModeSwitchSchema> = {
+  name: 'request_mode_switch',
+  description:
+    "Offer the user a one-click switch to a different mode when their request requires capabilities the current mode doesn't have. Use this INSTEAD of explaining the mode system in prose. Renders as a small in-chat button: 'Switch & Run' performs the switch and re-sends prompt_to_retry; 'Just Switch' only changes the mode. Available in every mode — it's the agent's escape valve when the user asks for something out of scope.",
+  schema: requestModeSwitchSchema,
+  category: 'ui',
+  requiresMode: null,
+  dangerous: false
+}
+
+// ============================================================================
+// Export all UI tools
+// ============================================================================
+
+export const uiTools = [requestModeSwitchConfig] as const

--- a/src/shared/tools/schemas/ui.ts
+++ b/src/shared/tools/schemas/ui.ts
@@ -31,7 +31,7 @@ export const requestModeSwitchSchema = z.object({
 export const requestModeSwitchConfig: ToolConfig<typeof requestModeSwitchSchema> = {
   name: 'request_mode_switch',
   description:
-    "Offer the user a one-click switch to a different mode when their request requires capabilities the current mode doesn't have. Use this INSTEAD of explaining the mode system in prose. Renders as a small in-chat button: 'Switch & Run' performs the switch and re-sends prompt_to_retry; 'Just Switch' only changes the mode. Available in every mode — it's the agent's escape valve when the user asks for something out of scope.",
+    "Offer the user a one-click switch to a different mode when their request requires capabilities the current mode doesn't have. Use this INSTEAD of explaining the mode system in prose. Renders as a small in-chat button: 'Switch & Run' performs the switch and re-sends prompt_to_retry; 'Just Switch' only changes the mode. DO NOT call this tool if you can fulfill the user's request with the tools already available to you in the current mode — that creates a confusing double-switch loop. If the system prompt notes that the user just switched modes, do NOT call this tool in that turn at all — they've already switched. Available in every mode — it's the agent's escape valve when the user asks for something out of scope.",
   schema: requestModeSwitchSchema,
   category: 'ui',
   requiresMode: null,


### PR DESCRIPTION
## Summary

Caught during the #467 QA pass. The agent's refusal language when a request was out of scope for the current mode felt didactic. The user had to read the explanation, click the StatusBar dropdown to switch modes, then re-type their prompt — five steps for what should be one click. Example from the QA log:

> User: \"Write me a paragraph about coffee.\"
> Agent: \"That's authorship — you'd be putting my prose into your document under your name. Not something I'll do by default. If you want to draft it yourself, I'm happy to react: tell me the angle (sensory? historical? a complaint about a specific café?), give me a rough first pass, and I'll push back on what's working and what isn't. If you genuinely want LLM-authored prose, switch to Create Mode and re-ask — that's the mode where you've opted in.\"

This PR adds a new tool the agent can call instead of lecturing, plus prompt updates so it actually uses it.

## New tool: \`request_mode_switch\`

Schema in \`src/shared/tools/schemas/ui.ts\`:

\`\`\`ts
{
  target: 'chat' | 'editor' | 'create',
  reason: string,           // one-sentence what-this-enables
  prompt_to_retry: string   // the exact prompt the agent would run after the switch
}
\`\`\`

- \`requiresMode: null\` — available in every mode; it's the agent's escape valve
- \`category: 'ui'\`
- Added to \`CHAT_MODE_TOOL_NAMES\` allowlist so the read-only Chat Mode also gets it
- Executor is a no-op pass-through: never changes the mode itself, just packages the agent's request

## Renderer

\`src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx\` renders the tool result as a small inline affordance:

\`\`\`
[reason]
\"[prompt_to_retry]\"
[Switch & Run] [Just Switch]
\`\`\`

- **Switch & Run** → \`setToolMode(target)\` + \`sendMessage(prompt_to_retry)\`. One click, agent gets to work in the new mode.
- **Just Switch** → \`setToolMode(target)\` only. User can edit or re-ask manually.

\`sendMessage\` is dispatched through a \`CustomEvent\` (\`MODE_SWITCH_RUN_EVENT\`) so the renderer doesn't have to be a \`useChat\` consumer — \`ChatPanel\` listens for the event and calls its local \`sendMessage\`. Renderer disables both buttons after first click to prevent double-fire.

## Unified tool-result format

Agent-driven tool calls were producing inline summaries (\`*[Tool: foo] Success*\`) that custom renderers couldn't parse — they got a literal string \"Success\" instead of structured data. Caught in QA when the mode-switch renderer kept showing \"Unable to parse mode-switch request.\"

Switched the agent-path message format in \`useChat.ts\` to use the same \`<tool-result name=\"...\" success=\"...\">JSON</tool-result>\` tag format that user-initiated slash commands use. Now custom renderers get the full structured payload regardless of who triggered the tool call. Tools without a custom renderer fall back to the markdown render of the JSON — same as slash commands have always shown. Per-tool render polish tracked in #533.

## Persona softening

\`src/renderer/lib/prompts.ts\`:

- **\`BASE_PROMPT\` authorship section** — replaced the \"stop and ask whether the user wants you to leave the drafting to them\" line with a directive to call \`request_mode_switch\` and not lecture about modes
- **\`CHAT_MODE_INSTRUCTIONS\`** — new \"When a request needs a different mode\" section pointing at the tool, replacing the previous \"tell the user to switch to Editor Mode (StatusBar → editor)\" prose
- **\`EDITOR_MODE_INSTRUCTIONS\`** — drafting requests now route through the tool instead of a prose decline

Effect: refusals become a short prose sentence + a tool call rendering a button. No more multi-paragraph lectures about authorship.

## Files

- New: \`src/shared/tools/schemas/ui.ts\` — \`requestModeSwitchConfig\`
- New: \`src/renderer/lib/tools/executors/ui.ts\` — pass-through executor
- New: \`src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx\` — button-pair UI
- \`src/shared/tools/registry.ts\` — register \`uiTools\`
- \`src/renderer/lib/tools/index.ts\` — dispatch \`request_mode_switch\`
- \`src/renderer/components/chat/toolResultRenderers/index.tsx\` — registry entry
- \`src/renderer/components/chat/ChatPanel.tsx\` — \`MODE_SWITCH_RUN_EVENT\` listener
- \`src/renderer/hooks/useChat.ts\` — allowlist + unified tool-result format
- \`src/renderer/lib/prompts.ts\` — persona softening + tool teaching in 3 instruction blocks

## Verification

1. Chat Mode, new conversation. Open a doc with a typo. Send \"Fix the typo in paragraph 2\" → agent emits \`request_mode_switch\` with \`target: 'editor'\`. UI renders reason + boxed prompt + two buttons.
2. Click **Switch & Run** → mode flips to Editor, agent immediately re-runs the prompt, uses \`suggest_edit\`.
3. Repeat in Chat Mode. Send \"Write me a paragraph about coffee\" → agent emits with \`target: 'create'\`.
4. Click **Just Switch** → mode flips to Create, no auto-send.
5. Editor Mode, drafting request → same path, target Create.
6. Verify the agent no longer produces multi-paragraph refusal lectures.

## Follow-ups

- **#533** — per-tool result renderer design pass. The unified tool-result format exposes JSON for tools without a custom renderer; worth polishing case-by-case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)