### PR TITLE
feat(tools): insert supports after_node / before_node anchor positions

### DIFF
--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -136,7 +136,7 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 - \`list_comments\` / \`add_comment\` / \`resolve_comment\` — Editorial notes
 - \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
 - \`edit\` — Directly replaces a node's content (unambiguous fixes; or drafted content the user has asked for)
-- \`insert\` — Insert new content at a position
+- \`insert\` — Insert new content at a position. Default to \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when the user asks to add content to a specific section. Reserve \`position=cursor\` for cases where the user explicitly said "here" — the cursor may be parked anywhere.
 
 ## When to use what
 
@@ -148,7 +148,8 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 
 1. Always call \`read_document\` first
 2. Match the tool to intent: drafting → \`edit\` / \`insert\`; copy edits → \`suggest_edit\`; editorial direction → \`add_comment\`
-3. Always include \`search\` on \`suggest_edit\` calls
+3. Anchor \`insert\` on a section heading's \`nodeId\` (\`position=after_node\`) when adding content to a specific section — don't rely on cursor placement
+4. Always include \`search\` on \`suggest_edit\` and anchored \`insert\` calls
 
 ## Escape hatch
 

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -97,6 +97,20 @@ export function resolveToolPosition(toolName: string, args: Record<string, unkno
       case 'start': return 0
       case 'end': return editor.state.doc.content.size
       case 'cursor': return editor.state.selection.from
+      case 'after_node':
+      case 'before_node': {
+        const nodeId = args.nodeId as string | undefined
+        const search = args.search as string | undefined
+        if (!nodeId) return Infinity
+        let found = findNodeById(editor.state.doc, nodeId)
+        if (!found && search) {
+          found = findNodeByContent(editor.state.doc, search)
+        }
+        if (!found) return Infinity
+        return position === 'after_node'
+          ? found.pos + found.node.nodeSize
+          : found.pos
+      }
       default: return Infinity
     }
   }
@@ -233,11 +247,21 @@ function parseFrontmatterPayload(
 
 /**
  * insert - Insert text at the specified position.
+ *
+ * Positions:
+ *   - `cursor` — at the current selection (legacy; depends on where the
+ *     user has parked the cursor, so only correct when they said "here")
+ *   - `start` / `end` — document boundaries
+ *   - `after_node` / `before_node` — relative to a node located by
+ *     `nodeId` (preferred for "add to section X" — anchor on the
+ *     section's heading nodeId from `read_document`)
  */
 export function executeInsert(
   args: {
     text: string
-    position?: 'cursor' | 'start' | 'end'
+    position?: 'cursor' | 'start' | 'end' | 'after_node' | 'before_node'
+    nodeId?: string
+    search?: string
   },
   provenance?: ToolProvenance
 ): ToolResult<{ inserted: boolean; position: string }> {
@@ -251,13 +275,14 @@ export function executeInsert(
     return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
-  const { text, position = 'cursor' } = args
+  const { text, position = 'cursor', nodeId, search } = args
 
   if (!text) {
     return toolError('Text to insert is required', 'INVALID_INPUT')
   }
 
-  // Capture insertion position before modifying the document
+  // Resolve insertion position uniformly so both the chain and the
+  // annotation use the same number.
   let insertPos: number
   switch (position) {
     case 'start':
@@ -266,6 +291,32 @@ export function executeInsert(
     case 'end':
       insertPos = editor.state.doc.content.size
       break
+    case 'after_node':
+    case 'before_node': {
+      if (!nodeId) {
+        return toolError(
+          `nodeId is required when position is "${position}"`,
+          'INVALID_INPUT'
+        )
+      }
+      let found = findNodeById(editor.state.doc, nodeId)
+      if (!found && search) {
+        found = findNodeByContent(editor.state.doc, search)
+      }
+      if (!found) {
+        const available = flattenNodes(getNodesWithIds(editor.state.doc))
+        const nodeList = available
+          .map(n => `${n.nodeId} (${n.type}: "${n.textContent.substring(0, 40)}")`)
+          .join(', ')
+        return toolError(
+          `Anchor node "${nodeId}" not found. Available nodes: [${nodeList}]`,
+          'NODE_NOT_FOUND'
+        )
+      }
+      insertPos =
+        position === 'after_node' ? found.pos + found.node.nodeSize : found.pos
+      break
+    }
     case 'cursor':
     default:
       insertPos = editor.state.selection.from
@@ -274,23 +325,7 @@ export function executeInsert(
 
   try {
     const sizeBefore = editor.state.doc.content.size
-    switch (position) {
-      case 'start':
-        editor.chain().focus().setTextSelection(0).insertContent(text).run()
-        break
-      case 'end':
-        editor
-          .chain()
-          .focus()
-          .setTextSelection(editor.state.doc.content.size)
-          .insertContent(text)
-          .run()
-        break
-      case 'cursor':
-      default:
-        editor.chain().focus().insertContent(text).run()
-        break
-    }
+    editor.chain().focus().setTextSelection(insertPos).insertContent(text).run()
     const sizeAfter = editor.state.doc.content.size
 
     // Create AI annotation for provenance tracking

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -39,17 +39,32 @@ export const editConfig: ToolConfig<typeof editSchema> = {
 // ============================================================================
 
 export const insertSchema = z.object({
-  text: z.string().describe('Text to insert at the current cursor position'),
+  text: z.string().describe('Text to insert at the specified position'),
   position: z
-    .enum(['cursor', 'start', 'end'])
+    .enum(['cursor', 'start', 'end', 'after_node', 'before_node'])
     .optional()
     .default('cursor')
-    .describe('Where to insert: at cursor, document start, or document end')
+    .describe(
+      'Where to insert. Use after_node or before_node (paired with nodeId from read_document) when adding to a specific section — e.g., after_node with a heading nodeId to append content under that heading. Use cursor only when the user explicitly said "here". start/end target the document boundaries.'
+    ),
+  nodeId: z
+    .string()
+    .optional()
+    .describe(
+      'Required when position is after_node or before_node. Get from read_document. To append to a section, use the heading nodeId with position=after_node — the text lands as a new node immediately after the heading.'
+    ),
+  search: z
+    .string()
+    .optional()
+    .describe(
+      'Original text content of the anchor node (from read_document). Used as fallback to locate the node if nodeId is stale.'
+    )
 })
 
 export const insertConfig: ToolConfig<typeof insertSchema> = {
   name: 'insert',
-  description: 'Insert text at the specified position in the document',
+  description:
+    'Insert text at the specified position in the document. For "add to section X", call read_document first to get the section heading\'s nodeId, then call insert with position=after_node and that nodeId. Avoid position=cursor unless the user said "here" — the cursor may be far from the intended target.',
   schema: insertSchema,
   category: 'editor',
   requiresMode: 'create',


### PR DESCRIPTION
## Summary

`insert` now accepts `position: 'after_node' | 'before_node'` paired with a `nodeId` (from `read_document`), with optional `search` text as stale-ID fallback — same pattern as `edit`.

The agent can now drop a new paragraph "after the Background heading" without depending on wherever the user happened to park the cursor.

## Motivation

Caught during #467 QA Stage 6.1. User asked: *"Add a paragraph about coffee after Background."* The agent (in Create Mode) reached for `insert(position: 'cursor')` because the prior schema only supported `cursor | start | end`. The paragraph landed at the user's cursor — which was in a completely different section. The agent's recovery `edit` call then mangled the doc further (the H1 ended up empty and the coffee paragraph appeared twice, once truncated).

`insert` having no node-anchored option was the root cause. Without it, the agent's only options for "add to section X" were:
- `position: 'cursor'` — relies on cursor placement, fragile
- `position: 'start' | 'end'` — wrong section
- `edit(nodeId, content)` — replaces existing content, not additive

## Changes

- `src/shared/tools/schemas/editor.ts` — `insertSchema` extended with `after_node` / `before_node` positions, optional `nodeId`, optional `search`. Tool description nudges the LLM toward the anchored pattern.
- `src/renderer/lib/tools/executors/editor.ts`
  - `executeInsert` resolves all positions to a single `insertPos` and applies via `setTextSelection(insertPos).insertContent(text)`, replacing the prior per-case chain calls.
  - For `after_node` / `before_node`, uses the same `findNodeById` → `findNodeByContent(search)` fallback pattern as `edit` / `suggest_edit`. Failed lookups return `NODE_NOT_FOUND` with the available-nodes list.
  - `resolveToolPosition` handles the new positions so editor-mutating tool sort (bottom-first) still works.
- `src/renderer/lib/prompts.ts` — Create-mode prompt nudges the LLM toward `read_document` → pick anchor heading nodeId → `insert(after_node)`. Reserves `position: 'cursor'` for "the user said here." Adds a workflow step about anchoring.

## Related

- Builds on #467 (umbrella).
- Companion tools `delete_node` and `move_cursor` are filed as #540 (PR #543 in flight).

## Test plan

- [ ] In Create Mode, on a multi-section doc, send "Add a paragraph about coffee after Background." Verify the agent calls `read_document` → `insert(position=after_node, nodeId=<background-heading>)`. Paragraph lands immediately after the Background heading.
- [ ] Park cursor in some unrelated section. Send "Add a paragraph about coffee to the 'This Year's Count' section." Should still land in the right section (proves cursor-independence).
- [ ] Send "Add a paragraph here about coffee" with cursor in a specific location. Agent should use `position=cursor` (the "here" carve-out).
- [ ] Stale-ID test: paste new content into the doc to force ID churn, then re-ask the agent to add to a section. The `search` fallback should rescue the call.
- [ ] Regression: `position=start` and `position=end` still work.
- [ ] Regression: bottom-first tool sort still groups multi-edit turns correctly when one tool is `insert(after_node)` deep in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)