### PR TITLE
fix(tools): insert(position=cursor) replaces non-empty selection again

### DIFF
--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -281,15 +281,20 @@ export function executeInsert(
     return toolError('Text to insert is required', 'INVALID_INPUT')
   }
 
-  // Resolve insertion position uniformly so both the chain and the
-  // annotation use the same number.
-  let insertPos: number
+  // Resolve insertion range. Most positions collapse to a single point
+  // (insertFrom === insertTo), but `cursor` honors any active selection
+  // so a highlighted-then-asked-to-insert flow replaces the selection
+  // instead of leaving it stranded next to the new content.
+  let insertFrom: number
+  let insertTo: number
   switch (position) {
     case 'start':
-      insertPos = 0
+      insertFrom = 0
+      insertTo = 0
       break
     case 'end':
-      insertPos = editor.state.doc.content.size
+      insertFrom = editor.state.doc.content.size
+      insertTo = editor.state.doc.content.size
       break
     case 'after_node':
     case 'before_node': {
@@ -313,30 +318,39 @@ export function executeInsert(
           'NODE_NOT_FOUND'
         )
       }
-      insertPos =
+      insertFrom =
         position === 'after_node' ? found.pos + found.node.nodeSize : found.pos
+      insertTo = insertFrom
       break
     }
     case 'cursor':
     default:
-      insertPos = editor.state.selection.from
+      // Use the full selection range so non-empty selections are
+      // replaced by the inserted text. Matches the pre-#546 behavior
+      // and is what users intuitively expect when they highlight a
+      // span and ask the agent to write replacement prose.
+      insertFrom = editor.state.selection.from
+      insertTo = editor.state.selection.to
       break
   }
 
   try {
     const sizeBefore = editor.state.doc.content.size
-    editor.chain().focus().setTextSelection(insertPos).insertContent(text).run()
+    editor.chain().focus().setTextSelection({ from: insertFrom, to: insertTo }).insertContent(text).run()
     const sizeAfter = editor.state.doc.content.size
 
-    // Create AI annotation for provenance tracking
+    // Create AI annotation for provenance tracking.
+    // Inserted PM range = [insertFrom, insertFrom + insertedSize], where
+    // insertedSize accounts for both the doc-size delta and the original
+    // selection that got replaced. For a collapsed selection (the common
+    // case) this reduces to `sizeAfter - sizeBefore`.
     if (provenance && provenance.documentId && text.length > 0) {
+      const insertedSize = (sizeAfter - sizeBefore) + (insertTo - insertFrom)
       useAnnotationStore.getState().addAnnotation({
         documentId: provenance.documentId,
         type: 'insertion',
-        from: insertPos,
-        // Use the actual PM size delta instead of string length: insertContent()
-        // may produce multi-paragraph nodes where string length != PM position delta.
-        to: insertPos + (sizeAfter - sizeBefore),
+        from: insertFrom,
+        to: insertFrom + insertedSize,
         content: text,
         provenance: {
           model: provenance.model,


### PR DESCRIPTION
## Summary

Restore the pre-#546 semantic that `insert(position: 'cursor')` *replaces* a non-empty selection rather than collapsing it and inserting next to the surviving span.

## Context

#546 unified `executeInsert` to resolve every position to a single `insertPos`, then call `setTextSelection(insertPos).insertContent(text)`. Worked correctly for the new `after_node` / `before_node` positions (additive, collapsed-point inserts by definition) and for `start` / `end`. But for `cursor`, when the user has a span highlighted, the prior chain `focus().insertContent(text)` would *consume* the selection range — replacing it. The new collapsed-to-`from` behavior leaves the highlighted text intact next to the new content.

The #546 reviewer flagged this as "likely a fix" (it's more consistent with the docstring "at cursor position") AND fixed an annotation bug where `to < from` could happen. PR #544's reviewer (cosmetic streaming) independently flagged it as a regression for the highlight-then-rewrite flow. Two reviewers, opposite read.

Calling it: selection-replace is the surprising-if-it-broke direction. Writers highlighting a sentence and asking the agent to rewrite expect the new prose to *replace* the old, not sit beside it. Restoring it.

## Changes

`src/renderer/lib/tools/executors/editor.ts`, `executeInsert`:

- Resolve insertion as a range `{from, to}` instead of a single `insertPos`.
- For `start` / `end` / `after_node` / `before_node`: `from === to` (collapsed point — additive insert).
- For `cursor`: `from = selection.from`, `to = selection.to` — non-empty selection is replaced by the inserted text.
- `setTextSelection({from, to}).insertContent(text)` uniformly.

Annotation math also updated:

- Inserted PM range is `[insertFrom, insertFrom + insertedSize]` where `insertedSize = (sizeAfter - sizeBefore) + (insertTo - insertFrom)`.
- For collapsed cursor (the common case): reduces to `sizeAfter - sizeBefore` — same as before.
- For ranged cursor (replaced selection): handles correctly; the old `sizeAfter - sizeBefore` alone could yield `to < from` when the replaced span was larger than the inserted text. (This was the latent bug the #546 reviewer mentioned.)

## Related

- Builds on #546 (insert anchor positions) — both ship to v1.2.
- Resolves the regression flagged in PR #544's review for the same code path; the cloud agent's #544 work will inherit this fix on rebase, so the "selection-replace regression" bullet in [my earlier request-changes comment](https://github.com/solo-ist/prose/pull/544#issuecomment-4484534725) can be ignored — they only need to handle the race condition.

## Test plan

- [ ] Highlight a span of text. Call `insert(position: 'cursor', text: 'X')`. Span is replaced by `X`.
- [ ] Caret-only cursor (no selection). Call `insert(position: 'cursor', text: 'X')`. `X` inserted at caret. Existing behavior unchanged.
- [ ] Highlight a long span, insert short replacement. Annotation range stays valid (no `to < from`).
- [ ] Highlight short, insert long. Annotation range covers the inserted content.
- [ ] Regression: `start` / `end` / `after_node` / `before_node` still work as additive inserts (don't replace anything).
- [ ] Regression: bottom-first tool sort still groups correctly (`resolveToolPosition` unchanged for cursor — still uses `selection.from`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)