### PR TITLE
docs(qa): update #467 plan for second-sojourn PRs + deferred follow-ups

### DIFF
--- a/docs/qa/467-agent-persona.md
+++ b/docs/qa/467-agent-persona.md
@@ -1,6 +1,6 @@
 # #467 — Manual QA Plan
 
-> **Status:** in flight. Mid-pass at Step 1.5 when three UX issues surfaced and we took an implementation sojourn (persistent selection, tool-result renderer registry, autocomplete filter). Resume here after those features land. This document is the canonical reference for the QA run; a generalized skill will be extracted from this approach once the pass completes.
+> **Status:** in flight. After the first implementation sojourn (#529 persistent selection, #530 tool-result renderer registry, #527 autocomplete filter) landed, the pass continued through Stages 1–5 with a second sojourn that produced #534 (request_mode_switch tool + UI), #546 (insert anchor positions), #547 (cursor selection-replace), #543 (delete_node + move_cursor), #545 (drafting indicator), and #544 (chunked streaming). All six merged to `release/v1.2-agent-persona`. Resuming at Stage 6 with the expanded tool surface. Two follow-ups (#548 annotation unification, #549 toolMode persistence) are deferred but targeted at the same release for v1.2. This document is the canonical reference for the QA run; a generalized skill will be extracted from this approach once the pass completes.
 
 ## Context
 
@@ -11,6 +11,15 @@ All four implementation chunks of the #467 umbrella merged into `release/v1.2-ag
 - Chunk 3 (#522) — `ToolMode` rename + Editor default + Shift+Tab cycle + dead-code cleanup
 - Chunk 4 (#524) — every mutating tool gated to Editor + UX polish (autocomplete, error messages)
 - Chunk 5 — no PR, audit confirmed accept-flow plays nicely with #447's caption tooltip
+
+Second-sojourn chunks added during the QA pass (each surfaced as a QA finding then implemented before resuming):
+
+- #534 — `request_mode_switch` tool + persona softening + Switch & Run / Just Switch / Cancel UI
+- #546 — `insert` accepts `after_node` / `before_node` anchor positions (fixes cursor-dependent placement)
+- #547 — `insert(position=cursor)` restores selection-replace semantics + annotation-range math fix
+- #543 — `delete_node` + `move_cursor` tools (closes #540)
+- #545 — Drafting indicator while LLM generates tool args (closes #542)
+- #544 — Cosmetic chunked streaming for agent `insert` / `edit` (closes #541)
 
 What's left is end-to-end manual verification against the umbrella's acceptance criteria (#467, #468) before merging the release branch to `main`. There are no automated tests (no vitest setup), so this pass is the gate.
 
@@ -77,6 +86,7 @@ Stages run roughly cheap → expensive. Within a stage, batch related checks onc
 - **1.6** Switch to `editor`. Type `/`. Autocomplete includes `/suggest_edit`, `/add_comment`, `/resolve_comment`, `/quick-review`, `/review-diff`. Excludes `/edit`, `/insert`.
 - **1.7** Switch to `create`. Type `/`. Autocomplete includes everything (including `/edit`, `/insert`).
 - **1.8** (new — added during implementation sojourn) Type `/list_files`, submit. Result renders in chat as a file tree with the same visual style as the file explorer side panel. Clicking a file opens it. Clicking a folder toggles expand/collapse.
+- **1.9** (new — #534 UI) Trigger any tool that returns a result (e.g., `/read_document` in Editor Mode). Tool-call card defaults to **collapsed** with a chevron toggle on the right of the header — except `request_mode_switch` cards (triggered by 4.x scenarios), which default to **expanded** because the reason and prompt-to-retry are the substance. For `request_mode_switch`, the Switch & Run / Just Switch / Cancel buttons sit **outside** the collapsible body, always visible. Click Cancel → "Dismissed." text replaces buttons; close+reopen the panel or switch conversations and back → state persists (no re-clickable buttons for past decisions).
 
 ### Stage 2 — Keyboard cycle (no LLM)
 
@@ -98,10 +108,12 @@ Setup: open a doc with some content.
 
 - **4.1** "What's in my document?" → agent calls `read_document`, replies with summary.
 - **4.2** "Give me an outline" → agent calls `get_outline`.
-- **4.3** "Fix the typo in paragraph 2" → agent declines, redirects to Editor Mode.
-- **4.4** "Add a comment on the second paragraph" → agent declines, redirects.
-- **4.5** "Write me a paragraph about coffee" → agent declines, no doc mutation.
+- **4.3** "Fix the typo in paragraph 2" → agent calls `request_mode_switch(target='editor', prompt_to_retry='Fix the typo in paragraph 2')`. The in-chat card shows Switch & Run / Just Switch / Cancel.
+- **4.4** "Add a comment on the second paragraph" → agent calls `request_mode_switch(target='editor', ...)`.
+- **4.5** "Write me a paragraph about coffee" → agent calls `request_mode_switch(target='create', ...)`. No doc mutation.
 - **4.6** (new — added during implementation sojourn) Select text in the editor. Click into chat input. **Selection remains visibly highlighted in the editor** while chat has focus. Type "what did I select?" → agent calls `read_selection`, result body matches the highlighted text.
+- **4.7** (new — #545) Drafting indicator. Send a request that the agent will respond to with a tool call whose argument body is long (e.g., the 4.3 typo-fix prompt — the agent will compose a `prompt_to_retry` mid-stream). A small "Drafting…" chip appears between the user message and the eventual tool-call result, then disappears once the tool call lands. On a forced stream error (toggle airplane mode mid-stream), no orphan "Drafting…" chip remains in the conversation.
+- **4.8** (new — #534 Switch & Run continuation) On the 4.3 result, click **Switch & Run**. Mode flips to Editor, the prompt auto-sends, and the agent goes directly to `read_document` + `suggest_edit` for the typo — it does **not** re-emit `request_mode_switch` on the continuation. (This was a fixed double-fire bug, regression-checking the modeJustSwitched propagation through the tool loop.)
 
 ### Stage 5 — Editor Mode behavior
 
@@ -110,15 +122,23 @@ Setup: open a doc with some content.
 - **5.3** Accept the diff. Annotation appears.
 - **5.4** Hover the annotation. Tooltip shows model id + timestamp + explanation as a third line.
 - **5.5** "The second paragraph has a competing thesis with the first" → agent uses `add_comment` (margin note), **not `suggest_edit`** (no replacement prose).
-- **5.6** "Write me a paragraph about coffee" → agent declines or asks you to draft it.
+- **5.6** "Write me a paragraph about coffee" → agent declines (no-authorship posture) and offers to edit a user-supplied draft.
 - **5.7** "What comments are in this document?" → agent calls `list_comments`, lists them.
 - **5.8** "Resolve the comment about the thesis" → agent calls `resolve_comment`.
+- **5.9** (new — #534 mid-conversation escalation) Right after 5.6's pushback, reply "yes write it" (or equivalent confirmation). Agent now calls `request_mode_switch(target='create', prompt_to_retry='Write a paragraph about coffee')`. The Switch & Run / Just Switch / Cancel buttons appear. The Editor-Mode posture held the line on first ask and only escalated on confirmation — that's the prompt-design contract working.
 
 ### Stage 6 — Create Mode behavior
 
-- **6.1** "Write me a paragraph about coffee" → agent drafts via `edit` or `insert`.
-- **6.2** "Fix typos in paragraph 2" → agent should still prefer `suggest_edit` for changes to existing content.
-- **6.3** Repeat 5.5 — agent still uses `add_comment` for judgment-bearing concerns.
+Setup: in Create mode, on a doc with at least an H1 title and a couple of H2 sections with prose (the lighthouse-keeper test doc used in the session is a known-good fixture).
+
+- **6.1** "Write me a paragraph about coffee" → agent drafts via `edit` or `insert`. **Verify the new chunked-streaming visual** (#544): the paragraph arrives in word-level chunks over ~400ms, not all at once. With `prefers-reduced-motion: reduce` set at the OS level, chunks collapse to instant apply.
+- **6.2** "Fix typos in paragraph 2" → agent still prefers `suggest_edit` (clear right answer, user should review), not `edit` / `insert`.
+- **6.3** Judgment-bearing concern (e.g., "the second paragraph has a competing thesis with the first") → agent uses `add_comment`, not `suggest_edit`.
+- **6.4** (new — #546) Park cursor in an unrelated section. Send "Add a paragraph about coffee to the Background section." → agent calls `read_document` → `insert(position='after_node', nodeId=<Background heading>)`. Paragraph lands immediately after the heading regardless of cursor location.
+- **6.5** (new — #547) Highlight a sentence in the editor. Send "replace this with: '…'" (or "use the insert tool to replace my selection with: '…'" if the agent reaches for suggest_edit instead). Agent uses `insert(position='cursor')` and the highlighted span is **replaced**, not left next to the new prose. Annotation range covers the inserted content (no `to < from` artifacts even when replaced span was larger than insertion).
+- **6.6** (new — #543 delete) After 6.4 lands, send "Actually, delete the coffee paragraph you just added." → agent calls `delete_node(nodeId=…)`. Paragraph is removed. Hover the deletion site → tooltip reads "AI Deletion" with model + timestamp.
+- **6.7** (new — #543 move + #546 cursor coordination) Send "park the cursor at the end of the Background section, then insert: '…'" → agent calls `move_cursor(nodeId=<Background heading>, position='end')` then `insert(position='cursor', text=…)`. The caret visibly moves to the new location; the insertion lands at the new cursor.
+- **6.8** (new — #543 mode gating) Switch to Chat Mode. Type `/delete_node foo` and submit. Error: "Tool 'delete_node' is not available in Chat Mode. Switch to **Create** Mode to use this tool." Switch to Editor Mode and try `/delete_node foo` → same error (delete is Create-only). `/move_cursor foo` in Chat → "Switch to **Editor** Mode" (move_cursor is Editor-and-up).
 
 ### Stage 7 — Persona heuristics (qualitative)
 
@@ -165,16 +185,34 @@ Run as one 5–10 minute working session on a real doc, then report.
 - `src/renderer/lib/prompts.ts` — BASE_PROMPT + per-mode instructions (persona heuristics)
 - `src/renderer/extensions/persistent-selection/` — TipTap extension for blur-time selection visibility (added during sojourn)
 - `src/renderer/components/chat/toolResultRenderers/` — per-tool result render registry (added during sojourn)
+- `src/renderer/lib/tools/executors/editor.ts` — `executeInsert` / `executeEdit` / `executeDeleteNode` / `executeMoveCursor`, `applyInsertion` chunked helper (added during second sojourn)
+- `src/renderer/extensions/ai-annotations/plugin.ts` — annotation tooltip labels including `'AI Deletion'` (#543)
+- `src/main/ipc.ts` — `llm:stream:tool-call:start` event (#545), `streamingEdits: true` default (#544)
+- `src/renderer/components/settings/SettingsDialog.tsx` — "Stream agent edits" toggle (#544)
+- `src/shared/tools/schemas/ui.ts` — `request_mode_switch` schema (#534, UI-coordination category)
+- `src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx` — body + actions split with persisted action state (#534)
+- `src/renderer/hooks/useChat.ts` — `modeJustSwitched` propagation through tool-loop continuations (#534 fix)
+
+## Deferred follow-ups targeting this release
+
+Two follow-ups filed in-session ship before merging `release/v1.2-agent-persona` → `main`:
+
+- **#548** — Unify AI-write annotations: `insert` and `edit` should accept an optional `comment` field and produce the same word-level annotation style as `suggest_edit` accepts (with explanation in the tooltip). Closes a UX inconsistency caught during 6.x where insert/edit annotations look different from suggest_edit ones. Cloud-agent friendly.
+- **#549** — Persist `toolMode` across reloads + surface unexpected resets. Closes the "agent thinks I'm in wrong mode" failure mode observed during Stage 6 (mode reverted to Editor on refresh without the user noticing the StatusBar change). Open design question in the issue: per-conversation vs global persistence (weak vote for global). Note that when #549 lands, Stage 9.2's "`toolMode` does not persist" assertion flips — update accordingly.
+
+Sequence: finish QA Stages 6–9 against the current release tip → `/accelerate 548 549` → review + merge → re-spot-check Stage 4 (drafting indicator + mode-switch behavior under persisted mode) and Stage 6 (annotation visual unification) → run Stage 10.
 
 ## Verification (meta — when is the QA pass done?)
 
 1. All steps in stages 1–8 pass (with fixes applied for any failures).
 2. Stage 9 confirms no new regressions in out-of-scope areas.
-3. Stage 10 reaches a confident go/no-go.
-4. Skill extraction begins after Stage 10 says "go."
+3. **#548 and #549 merged** to `release/v1.2-agent-persona`; re-spot-checks on Stages 4 and 6 against the new behavior pass.
+4. Stage 10 reaches a confident go/no-go.
+5. Commit a final "Run log" appendix to this doc capturing the pass/fail table from the conversation, so the next session has a durable record of what was verified vs deferred.
+6. Skill extraction begins after Stage 10 says "go."
 
 The umbrella `#467` is fully verified when Stage 10 says "go" and `release/v1.2-agent-persona` merges to `main`.
 
 ## Skill extraction (after the pass)
 
-Once Stage 10 ships, extract the QA-loop approach as a reusable skill at `.claude/skills/qa-mode-refactor/SKILL.md`. Parameterize: mode names, default mode, tool-gating expectations, persona heuristics. The implementation-sojourn experience (selection persistence, tool-result renderer) is UX-surface specific and **not** part of the skill — it's project-specific work caught during the pass.
+Once Stage 10 ships, extract the QA-loop approach as a reusable skill at `.claude/skills/qa-mode-refactor/SKILL.md`. Parameterize: mode names, default mode, tool-gating expectations, persona heuristics. Both implementation sojourns (first: persistent selection / tool-result renderer; second: request_mode_switch + insert anchor + delete_node/move_cursor + drafting indicator + chunked streaming) are UX-surface specific and **not** part of the skill — they're project-specific work caught during the pass. The generalized loop (per-step interactive queueing, surgical-scope bug-fix protocol, pass/fail table maintenance, deferred-follow-up handling) is what transfers.


### PR DESCRIPTION
## Summary

Brings `docs/qa/467-agent-persona.md` in sync with what landed during the active QA pass. Doc-only — no code touched.

After Stages 1–5 were informally completed in-session, a second implementation sojourn produced six PRs on the release branch (all merged):

- #534 — `request_mode_switch` tool + persona softening + Switch & Run UI
- #546 — `insert` anchor positions (`after_node` / `before_node`)
- #547 — `insert(position=cursor)` selection-replace restored + annotation-range fix
- #543 — `delete_node` + `move_cursor` tools (closes #540)
- #545 — Drafting indicator (closes #542)
- #544 — Cosmetic chunked streaming (closes #541)

Two deferred follow-ups remain open against this release: #548 (annotation unification) and #549 (`toolMode` persistence).

## What this updates

- **Status note** — reflects both sojourns and explicit resumption at Stage 6.
- **Context** — lists the second-sojourn chunks alongside the original four.
- **Stage 1** — adds 1.9 (collapsible tool-call card + persisted action state, #534).
- **Stage 4** — revises 4.3–4.5 to expect `request_mode_switch` instead of prose decline; adds 4.7 (drafting indicator), 4.8 (modeJustSwitched propagation regression check).
- **Stage 5** — adds 5.9 (mid-conversation drafting escalation: push-back-then-confirm flow).
- **Stage 6** — expands 6.1–6.3 with the chunked-streaming visual check, adds 6.4 (anchored `insert`), 6.5 (cursor selection-replace), 6.6 (`delete_node`), 6.7 (`move_cursor` + cursor coordination), 6.8 (mode gating for new tools).
- **Critical files** — appends new files (executor + annotation plugin + IPC + settings + ui schema + RequestModeSwitchResult + useChat).
- **New section: "Deferred follow-ups targeting this release"** — names #548 and #549 with post-QA sequencing.
- **Verification (meta)** — adds the #548/#549 merge gate and a Run log appendix commitment.
- **Skill extraction** — notes both sojourns are project-specific and excluded from the generalized skill.

## Test plan

- [ ] Render the doc on GitHub; confirm formatting (headings, code blocks, bullet alignment) is intact.
- [ ] Confirm all PR references (#534, #543–#547, #548, #549) resolve correctly.
- [ ] Spot-check a Stage 6 substep against the live release tip — instructions should be executable as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)