### PR TITLE
fix(chat): anchor current mode at top of system prompt (#551)

### DIFF
--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -176,16 +176,25 @@ export function buildSystemPrompt(
   // Mode-specific tool instructions. Defaults to Editor when no mode supplied
   // (matches the chatStore initial value).
   const resolvedMode: ToolMode = toolMode ?? 'editor'
+  const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
 
-  // Mid-conversation mode switch notice — surface a one-line note BEFORE
-  // the base persona so the agent sees the mode change first. Caller
-  // computes the boolean by comparing chatStore.lastSentToolMode with
-  // the current toolMode; this is idempotent across multiple toggles
-  // between sends.
+  // Top-of-prompt mode anchor. Always present, so the LLM has an
+  // authoritative signal that overrides any prior assistant turn in
+  // conversation history that may have claimed a different mode (the
+  // failure mode tracked in #551: the agent pattern-matches on its own
+  // prior "I'm in Editor Mode" reply and refuses to act in the new mode).
+  prompt =
+    `**CURRENT MODE: ${modeLabel}.** Your available tools and posture are defined by ${modeLabel} Mode (see "## ${modeLabel} Mode" section below). If any prior assistant turn in this conversation claimed a different mode, that claim is stale — disregard it and act according to ${modeLabel} Mode now.\n\n` +
+    prompt
+
+  // Mid-conversation mode switch notice — fires the turn after a switch.
+  // Reinforces the mode anchor with explicit "do not re-fire the switch
+  // tool" guidance. Caller computes the boolean by comparing
+  // chatStore.lastSentToolMode with the current toolMode; this is
+  // idempotent across multiple toggles between sends.
   if (modeJustSwitched) {
-    const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
     prompt =
-      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Their next message likely reflects a request you should now be able to fulfill directly with this mode's tools. **Do NOT call \`request_mode_switch\` in this turn** — they've already switched. Use the tools available in ${modeLabel} Mode to act on their request.\n\n` +
+      `**MODE CHANGED.** The user just switched to ${modeLabel} Mode mid-conversation. Their next message reflects a request you should fulfill directly with ${modeLabel} Mode's tools. Do NOT call \`request_mode_switch\` in this turn — they've already switched.\n\n` +
       prompt
   }
   if (resolvedMode === 'chat') {


### PR DESCRIPTION
## Summary

Closes #551.

After a mid-conversation mode switch via `request_mode_switch`, the LLM was pattern-matching on its own prior assistant reply ("I'm in Editor Mode") and clinging to that claim across subsequent turns despite the StatusBar, store, and tool surface all reflecting the new mode.

## Changes (single file: `src/renderer/lib/prompts.ts`)

- Always include a top-of-prompt **`CURRENT MODE: X`** anchor regardless of whether a switch just happened. Explicitly tells the LLM to disregard prior assistant claims about a different mode. This was the missing piece for multi-turn anchoring — the previous "you just switched" notice only fired the turn immediately after a switch (`modeJustSwitched` is gated on `lastSentToolMode !== toolMode`).
- Upgrade the existing `modeJustSwitched` notice from a soft "Note:" to a directive "**MODE CHANGED.**". The instruction to not re-fire `request_mode_switch` stays.

The anchor handles the multi-turn drift; the upgraded notice grounds the immediate post-switch turn. Together they cover both failure modes.

## Test plan

- [ ] Editor Mode → "Write me a paragraph about coffee." → LLM emits `request_mode_switch`.
- [ ] User clicks **Just Switch** → StatusBar flips to Create. User types: "Write me a paragraph about coffee." → LLM acts in Create Mode (calls `edit`/`insert`), doesn't repeat "I'm in Editor Mode."
- [ ] Same flow with **Switch & Run** → `prompt_to_retry` runs in Create Mode immediately.
- [ ] After several additional turns, the LLM doesn't drift back to a prior mode-claim.
- [ ] Regression: starting fresh in a given mode (no prior switch), LLM still reads the per-mode block correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)