### PR TITLE
fix(editor): chunked streaming appends inline text, not new paragraphs (#553)

### DIFF
--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -115,10 +115,17 @@ async function applyInsertion(
   // End of inserted content = from + (size of inserted chunk in PM coords).
   // Inserted size = doc delta + chars removed by any range replace.
   let pos = from + (editor.state.doc.content.size - sizeBefore) + rangeSize
+  // Subsequent chunks use a raw ProseMirror text insert rather than
+  // `insertContent`. `insertContent(string)` routes through the markdown
+  // parser, which treats top-level text as a paragraph node — so each
+  // chunk would land as its own paragraph instead of appending inline to
+  // the paragraph the first chunk just created (#553). `tr.insertText`
+  // inserts inline text into the surrounding block, preserving paragraph
+  // continuity and the intended word-by-word fill animation.
   for (let i = 1; i < chunks.length; i++) {
     await nextFrame()
     const prev = editor.state.doc.content.size
-    editor.chain().setTextSelection(pos).insertContent(chunks[i]).run()
+    editor.view.dispatch(editor.state.tr.insertText(chunks[i], pos))
     pos += editor.state.doc.content.size - prev
   }
 }


### PR DESCRIPTION
## Summary

Follow-up fix to **#544** (cosmetic chunked streaming for agent `insert`/`edit`, originally tracked under #541). #544's implementation chunks the streaming correctly but each chunk lands as its own paragraph block, defeating the "word-by-word fill in one paragraph" design intent.

## Root cause

`applyInsertion` (added by #544) called `editor.chain().insertContent(chunk)` for every streaming chunk past the first. `insertContent` with a plain string routes through the configured markdown content parser, which wraps top-level text in a paragraph node — so each chunk landed as its own paragraph block instead of appending inline to the paragraph the first chunk just created.

Visible symptom (reproduced 2026-05-19 during #467 Stage 6.1 QA): a ~50-word "Write a paragraph about coffee" response came in as 18 paragraph blocks (3 words each, since `STREAM_TARGET_FRAME_COUNT = 24` produces `Math.ceil(50/24) = 3` words per chunk) rather than one paragraph filling word-by-word. The streaming animation also wasn't perceptible because the paragraph-block inserts complete in roughly one paint cycle.

## Change

Single file: `src/renderer/lib/tools/executors/editor.ts`. +8 / -1.

Subsequent chunks now use a raw ProseMirror `tr.insertText` dispatch instead of `editor.chain().insertContent(chunk)`. `tr.insertText` inserts inline text into the surrounding block, preserving paragraph continuity and letting the rAF-gated chunked apply produce a visible word-by-word fill within a single paragraph.

The first chunk still goes through `insertContent` so range-replacement (`insert(position='cursor')` over a selection) and block-level setup behave the same as in #544.

## Scope and limitations

Targets the common single-paragraph drafting case. For multi-paragraph drafting where the agent's text contains `\n\n`, chunks containing newlines would now insert as literal characters (paragraph breaks lost during streaming) instead of as separate paragraphs. Best-effort; tracked separately if it bites further QA.

## Test plan

- [ ] Create Mode, "Write me a paragraph about coffee." → paragraph fills word-by-word **in a single paragraph block** over ~400ms.
- [ ] System Settings → Accessibility → Display → Reduce Motion enabled → paragraph appears instantly in one paragraph block (existing instant-apply path).
- [ ] Settings → Editor → "Stream agent edits" off → paragraph appears instantly in one block.
- [ ] Highlight a sentence, ask the agent to "use insert to replace this with: '…'" → replaced span is a single paragraph (selection delete + chunked apply still works).

Refs #467, #541, #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)