### PR TITLE
fix(editor): track chunked-stream position via selection, not doc-size delta

### DIFF
--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -87,9 +87,11 @@ function nextFrame(): Promise<void> {
  * the same chain (a single transaction), so range replacement is atomic and
  * shares undo state with the first chunk.
  *
- * Subsequent chunks track the running insertion endpoint explicitly via the
- * doc-size delta, so user clicks or keystrokes mid-stream can't redirect
- * later chunks into the user's cursor position.
+ * Subsequent chunks track the running insertion endpoint via an explicit
+ * length accumulator (anchored once at end-of-insertion from TipTap's own
+ * selection placement, then advanced by each chunk's character count), so
+ * user clicks or keystrokes mid-stream can't redirect later chunks into
+ * the user's cursor position.
  */
 async function applyInsertion(
   editor: Editor,
@@ -109,24 +111,30 @@ async function applyInsertion(
     editor.chain().focus().setTextSelection(selection).insertContent(text).run()
     return
   }
-  const rangeSize = hasRange ? to! - from : 0
-  const sizeBefore = editor.state.doc.content.size
   editor.chain().focus().setTextSelection(selection).insertContent(chunks[0]).run()
-  // End of inserted content = from + (size of inserted chunk in PM coords).
-  // Inserted size = doc delta + chars removed by any range replace.
-  let pos = from + (editor.state.doc.content.size - sizeBefore) + rangeSize
-  // Subsequent chunks use a raw ProseMirror text insert rather than
-  // `insertContent`. `insertContent(string)` routes through the markdown
-  // parser, which treats top-level text as a paragraph node — so each
-  // chunk would land as its own paragraph instead of appending inline to
-  // the paragraph the first chunk just created (#553). `tr.insertText`
-  // inserts inline text into the surrounding block, preserving paragraph
-  // continuity and the intended word-by-word fill animation.
+  // Anchor the running endpoint at end-of-insertion using TipTap's own
+  // cursor placement (`selectionToInsertionEnd` in
+  // `node_modules/@tiptap/core/src/commands/insertContentAt.ts`), which
+  // leaves the cursor INSIDE the just-inserted textblock at the end of
+  // its text. Earlier doc-size arithmetic landed `pos` AFTER the closing
+  // paragraph token — a between-blocks position, where `tr.insertText`
+  // wraps the text in a new paragraph to fit the parent context,
+  // producing one paragraph per chunk.
+  //
+  // From there, advance `pos` by each chunk's character count rather than
+  // re-reading `editor.state.selection.from` after every dispatch. Two
+  // reasons: (1) subsequent chunks use raw `tr.insertText` (not
+  // `insertContent(string)`), which inserts plain text inline and adds
+  // exactly `chunks[i].length` PM units — so the accumulator is exact;
+  // (2) if the user clicks or types mid-stream, the live selection moves
+  // away from our insertion endpoint, but the accumulator stays
+  // independent — keeping later chunks landing at the running insertion
+  // point instead of redirecting into the user's cursor.
+  let pos = editor.state.selection.from
   for (let i = 1; i < chunks.length; i++) {
     await nextFrame()
-    const prev = editor.state.doc.content.size
     editor.view.dispatch(editor.state.tr.insertText(chunks[i], pos))
-    pos += editor.state.doc.content.size - prev
+    pos += chunks[i].length
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to **#554** (and ultimately #544's chunked streaming for `insert` / `edit`). #554 correctly switched subsequent chunks from `insertContent(chunk)` to a raw `tr.insertText`, but the running position math wasn't updated to match — chunks still stacked as one-paragraph-per-chunk.

## Symptom (still present after #554 merged)

Reproduced 2026-05-19 in Create Mode against the running dev on `release/v1.2-agent-persona @ 06bff28`:

> The chunks now arrive progressively over ~400ms (the rAF-gated streaming animation IS visible), but **each chunk still lands as its own paragraph block** — visually stacked, one word/group per line, blank-line spacing between.

## Root cause

`applyInsertion` was computing the running insertion endpoint as `pos = from + (doc.content.size - sizeBefore) + rangeSize`. When the first chunk's `insertContent` creates a new paragraph block, the doc-size delta includes the paragraph's opening + closing tokens (2 PM units of overhead). So `pos` lands at the position **after** the closing paragraph token — a between-blocks position.

`tr.insertText` at a between-blocks position calls `replaceRangeWith`, which wraps the inserted text in a new paragraph to fit the parent context (per ProseMirror's smart-replace behavior). Result: every chunk creates its own paragraph despite using the inline-text primitive.

## Fix

Anchor the running endpoint at end-of-insertion using TipTap's own cursor placement (`selectionToInsertionEnd` in `node_modules/@tiptap/core/src/commands/insertContentAt.ts:179`), which leaves the cursor INSIDE the just-inserted textblock at the end of its text. From there, advance `pos` via an explicit length accumulator (`pos += chunks[i].length`) rather than re-reading `editor.state.selection.from` after every dispatch.

Two reasons for the accumulator over a live-selection read:

1. Subsequent chunks use raw `tr.insertText` (not `insertContent(string)`), which inserts plain text inline and adds exactly `chunks[i].length` PM units — so the accumulator is exact.
2. If the user clicks or types mid-stream, the live selection moves away from our insertion endpoint. The accumulator stays independent, keeping later chunks landing at the running insertion point instead of redirecting into the user's cursor — preserving the invariant the original doc-size approach was designed to protect.

Function-level docstring updated to reflect the new tracking strategy. First-chunk path is unchanged. Single file: `src/renderer/lib/tools/executors/editor.ts`. +25 / -17.

## Verified locally

Tested live via HMR in Create Mode before pushing:
- "Write me a paragraph about coffee" → paragraph fills word-by-word inside a single paragraph block over ~400ms. No stacking.
- Multiple subsequent insert / edit / suggest_edit / delete / move_cursor cycles exercised in the same session — all behaved as expected.

## Test plan

- [ ] Create Mode, "Write me a paragraph about coffee." → paragraph fills word-by-word inside a single paragraph block over ~400ms.
- [ ] With reduced motion or `streamingEdits: false`: paragraph appears instantly in one block (instant-apply path unchanged).
- [ ] Highlight a sentence, "use insert to replace this with: '…'" → replaced span is a single paragraph.
- [ ] Mid-stream: click elsewhere in the document during a streamed insert — remaining chunks continue landing at the original insertion endpoint, not at the click position.

Refs #467, #541, #544, #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)