### PR TITLE
ci(claude): pin model on claude-code-action to stop default-model drift

### DIFF
--- a/.claude/skills/pipeline-eng/SKILL.md
+++ b/.claude/skills/pipeline-eng/SKILL.md
@@ -152,6 +152,8 @@ When Anthropic releases new model versions, update all three files. Consider usi
 
 The `validate-pipeline.sh` script checks for stale model IDs — update its patterns when adding new models.
 
+**`claude-code-action@v1` model pinning.** The action does not expose a `model:` input — it delegates to the bundled Claude Code CLI, which the action rolls forward on every release. CLI defaults can change silently (the May 8–9 default shift to Opus 4.7 sent daily CI spend from ~$2 to $36 on identical workload). Always pass `--model <id>` via `claude_args` on every `claude-code-action@v1` invocation. Current pin: `claude-sonnet-4-6` in `claude.yml` (auto-review + `@claude` handler) and `pipeline-fix.yml`.
+
 ---
 
 ## Agent Dispatch

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
           trigger_phrase: '/review'
           allowed_bots: 'claude,github-actions'
           show_full_output: true
-          claude_args: '--dangerously-skip-permissions'
+          claude_args: '--dangerously-skip-permissions --model claude-sonnet-4-6'
           prompt: |
             You are a code reviewer. Review PR #${{ github.event.issue.number }} in this repository.
 
@@ -231,7 +231,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: 'github-actions'
           show_full_output: true
-          claude_args: '--dangerously-skip-permissions'
+          claude_args: '--dangerously-skip-permissions --model claude-sonnet-4-6'
           prompt: |
             You are an autonomous coding agent. Implement the changes described in the
             GitHub issue or comment that triggered this workflow. Do NOT list or browse

--- a/.github/workflows/pipeline-fix.yml
+++ b/.github/workflows/pipeline-fix.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: 'claude,github-actions'
-          claude_args: '--dangerously-skip-permissions'
+          claude_args: '--dangerously-skip-permissions --model claude-sonnet-4-6'
           prompt: |
             You are an auto-fix agent. A code review found issues in this PR that have been
             triaged as low-complexity and suitable for automated fixing.


### PR DESCRIPTION
## Summary

- Pin `--model claude-sonnet-4-6` in `claude_args` on all three `claude-code-action@v1` invocations (`claude.yml` auto-review, `claude.yml` `@claude` handler, `pipeline-fix.yml` auto-fix).
- Document the lesson in `.claude/skills/pipeline-eng/SKILL.md` so this doesn't recur.

## Why

`claude-code-action@v1` does not expose a `model:` input — it delegates to the bundled Claude Code CLI, which the action rolls forward on every release. The CLI's default silently shifted to Opus 4.7 between versions 2.1.119 and 2.1.139 (Apr 25 – May 11). Our daily CI spend went from ~\$2 to **\$36 on May 19** on the same workload volume. Cost-per-run jumped because Opus 4.7 is ~5× Sonnet 4.6 pricing.

The cost chart's pink→lavender flip lines up exactly with the CLI bumps on May 6–9. Nothing in our repo changed; we just inherited a default change.

Direct API scripts (`run-scorer.mjs`, `analyze-review-feedback.mjs`, `run-pe-analysis.mjs`) already pin their models — no change needed there.

Closes #557

## Test plan

- [ ] PR triggers an auto-review run; verify it completes successfully
- [ ] After merge, watch tomorrow's Anthropic cost chart — should drop back into the \$1–\$5/day range and shift back to mostly-pink (Sonnet)
- [ ] Confirm the skill update renders sensibly in `.claude/skills/pipeline-eng/SKILL.md`