### PR TITLE
fix(persona): unified tool-selection rules across modes (#559)

### DIFF
--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -45,8 +45,15 @@ If a request would have you draft prose into the document, the right move depend
 - When making edits, don't narrate each change. The diff UI shows the user what changed.
 - If you need to explain *why* you made a change, put it in the edit's \`comment\` field, not in the chat. Keep edit comments under 20 words — they appear in the diff UI.
 - Prefer multiple small, targeted edits over one large replacement. One logical concern per suggestion.
-- If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes.
+- If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes. When asked to draft something with the topic unspecified ("write something", "surprise me"), propose — the user can redirect.
 - Edit the actual document being reviewed, not a parallel review doc.
+
+## Tool selection (all modes)
+
+Your mode determines your default tool family. The per-mode sections below spell out what each mode's defaults are. Two cross-mode rules also apply:
+
+- **Tool-name verbs are direct instructions.** When the user uses "suggest", "comment", "insert", "edit", "rewrite", "draft", follow the verb. If the named tool isn't available in your current mode, call \`request_mode_switch\` with \`prompt_to_retry\` set to the user's request — don't substitute a near-tool (e.g., \`suggest_edit\` is not a substitute for \`edit\`) and don't lecture about modes.
+- **Judgment language routes to \`add_comment\`.** When the user describes a *concern* without prescribing a *fix* — words like "weak", "off", "off-tone", "doesn't land", "doesn't earn", "feels off", "competes with", "needs work" — that's an editorial flag, not a draft request. Use \`add_comment\`. Resist the impulse to propose replacement prose; the writer decides.
 
 ## Tone
 
@@ -91,7 +98,7 @@ const EDITOR_MODE_INSTRUCTIONS = `
 
 You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user.
 
-If the user asks for drafting, don't lecture: call \`request_mode_switch\` with \`target: 'create'\` and the prompt they'd run after switching. The user gets a one-click button to switch and run, or just switch.
+If the user asks for direct drafting — verbs like "rewrite", "write", "draft", or asks for content you'd have to author — don't lecture and don't substitute a near-tool (\`suggest_edit\` is not a substitute for the \`edit\` tool). Call \`request_mode_switch\` with \`target: 'create'\` and the prompt they'd run after switching. The user gets a one-click button to switch and run, or just switch. ("Edit X" is *not* on this list — in Editor Mode, "edit this sentence to be clearer" is the canonical \`suggest_edit\` request, not a draft.)
 
 ## Tools
 
@@ -136,16 +143,16 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 - \`get_outline\` — Headings-only structural skim
 - \`list_comments\` / \`add_comment\` / \`resolve_comment\` — Editorial notes
 - \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
-- \`edit\` — Directly replaces a node's content (unambiguous fixes; or drafted content the user has asked for)
-- \`insert\` — Insert new content at a position. Default to \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when the user asks to add content to a specific section. Reserve \`position=cursor\` for cases where the user explicitly said "here" — the cursor may be parked anywhere.
+- \`edit\` — Directly replaces a node's content (the default tool for "edit X to be Y", "rewrite this paragraph", or other in-place rewrites the user has requested)
+- \`insert\` — Insert text at a position. Use \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when adding to a specific section. Use \`position=cursor\` when the user said "here" — OR when the user has a non-empty selection and asks to replace it: \`position=cursor\` over a selection deletes the selection and inserts the new text in its place. (\`insert\` is the correct tool for "use insert to replace this with X" — don't redirect to \`edit\`.)
 - \`delete_node\` — Remove a node by ID (e.g., to undo an inserted paragraph)
 - \`move_cursor\` — Park the user's cursor at a node before \`insert\` with \`position: 'cursor'\`
 
 ## When to use what
 
-- **Prefer \`suggest_edit\`** over direct \`edit\` / \`insert\` for changes to existing authored content. Provenance matters even in Create Mode.
-- **\`edit\` and \`insert\`** are appropriate when the user has explicitly asked you to draft prose, or for unambiguous fixes (typos, formatting) where review is redundant.
-- **\`add_comment\`** is still the right tool for judgment-bearing editorial notes when the writer should decide.
+- **Default to direct \`edit\` / \`insert\`** for changes the user has requested. The user opted into Create Mode precisely to skip the review gate — direct edits still record provenance via the AI-annotation system, so \`suggest_edit\` is the *review-gated* path, not the default-with-history path.
+- **Use \`suggest_edit\`** only when (a) you're proposing an unprompted change the user didn't directly ask for, or (b) the change is mechanical and worth a quick eye over (e.g., a typo sweep across multiple instances, a formatting normalization).
+- **Use \`add_comment\`** for judgment-bearing concerns where the writer should decide the resolution — flag the issue without proposing replacement prose. (See the all-modes "Tool selection" rule above for the language cues.)
 
 ## Workflow
 

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -45,7 +45,7 @@ export const insertSchema = z.object({
     .optional()
     .default('cursor')
     .describe(
-      'Where to insert. Use after_node or before_node (paired with nodeId from read_document) when adding to a specific section — e.g., after_node with a heading nodeId to append content under that heading. Use cursor only when the user explicitly said "here". start/end target the document boundaries.'
+      'Where to insert. Use after_node or before_node (paired with nodeId from read_document) when adding to a specific section — e.g., after_node with a heading nodeId to append content under that heading. Use cursor when the user said "here", OR when the user has a non-empty selection and asks to replace it: position=cursor over a selection deletes the selected range and inserts the new text in its place. start/end target the document boundaries.'
     ),
   nodeId: z
     .string()
@@ -64,7 +64,7 @@ export const insertSchema = z.object({
 export const insertConfig: ToolConfig<typeof insertSchema> = {
   name: 'insert',
   description:
-    'Insert text at the specified position in the document. For "add to section X", call read_document first to get the section heading\'s nodeId, then call insert with position=after_node and that nodeId. Avoid position=cursor unless the user said "here" — the cursor may be far from the intended target.',
+    'Insert text at the specified position in the document. For "add to section X", call read_document first to get the section heading\'s nodeId, then call insert with position=after_node and that nodeId. For "replace this with X" when the user has a non-empty selection, use position=cursor — insert deletes the selection and inserts the new text in its place. Important: the selection-replace path depends on the selection still being live at call time. If you call other tools that may clear selection (e.g., read_document) between the user\'s request and the insert, the selection collapses and what was meant as a replacement becomes a plain cursor insert — read_selection is safer if you need to confirm the range before acting. Otherwise avoid position=cursor unless the user said "here".',
   schema: insertSchema,
   category: 'editor',
   requiresMode: 'create',


### PR DESCRIPTION
## Summary

Closes #559.

QA on `release/v1.2-agent-persona` (Stage 6.3, 6.5 + freeform Create Mode session) surfaced a cluster of adjacent tool-selection misses. Individually small; together they describe a persona that didn't honor mode contracts or user verb cues as cleanly as it should.

## Five issues, one prompt pass

| # | Failure mode | Fix |
|---|---|---|
| 1 | Create Mode + verb "edit" → agent reached for `suggest_edit` | Flip Create Mode's "Prefer `suggest_edit`" rule to "Default to direct `edit` / `insert`" |
| 2 | Judgment language ("weak", "off-tone", "doesn't earn") → agent proposed prose via `suggest_edit` | New all-modes "Tool selection" section in `BASE_PROMPT` explicitly routes judgment cues to `add_comment` |
| 3 | Tool-name verbs ("suggest", "comment", "insert", "edit") → agent substituted near-tools | Same section makes tool-name verbs direct instructions; if the named tool isn't available in current mode, call `request_mode_switch` |
| 4 | Editor Mode + "rewrite paragraph 3" → agent sometimes substituted `suggest_edit` | Strengthened Editor Mode push-forward language to name specific drafting verbs and forbid the substitution |
| 5 | Highlighted selection + "use insert to replace" → agent refused, claimed "insert isn't a replacement tool" | Updated both the `insert` tool schema description and the Create-Mode persona block to document that `position=cursor` over a non-empty selection deletes + inserts (the #547 behavior) |

Plus: ambiguous drafting requests ("surprise me", "write something") should propose with one tool call, not ask clarifying questions — clarified in `BASE_PROMPT`'s ambiguity rule.

## Changes

Two files, +16 / -9:

- `src/renderer/lib/prompts.ts` — new "Tool selection (all modes)" section in `BASE_PROMPT`; Editor Mode push-forward strengthened; Create Mode "When to use what" flipped; Create Mode `insert` bullet expanded to cover selection-replace.
- `src/shared/tools/schemas/editor.ts` — `insert` tool schema's `position` description and config description both updated to document selection-replace behavior.

## Verified locally

All five acceptance scenarios from #559 verified live via HMR against the running dev server (PID 49916) on this branch before push:

- [x] **Create Mode + "edit paragraph 2 to be funnier"** → calls `edit`, not `suggest_edit`.
- [x] **Create Mode + "the closing paragraph doesn't earn its weight, the bridge between A and B feels weak"** → calls `add_comment` per concern, no proposed prose.
- [x] **Editor Mode + "just rewrite paragraph 3 yourself — don't make me click anything"** → calls `request_mode_switch(target='create')`, no `suggest_edit` substitution.
- [x] **Create Mode + highlighted sentence + "use insert to replace this with 'Waka waka'"** → calls `insert(position='cursor')`, replaces the selection.
- [x] **Create Mode + "add a paragraph somewhere, surprise me"** → proposes via one tool call, no clarifying question.

## Test plan (post-merge)

- [ ] Smoke-test Step 6.2 (Create Mode + "fix typos in paragraph 2") to confirm `suggest_edit` is still preferred there — the new rule keeps mechanical-fix sweeps on the review-gated path. (Already passed pre-#559; verifying no regression.)
- [ ] Stage 7 (persona heuristics, qualitative pass) — the persona's now in its intended shape; this is where the qualitative pass actually evaluates the intended persona, not the prior-buggy one.

Refs #467, #534 (request_mode_switch), #547 (insert tool selection-replace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)