### PR TITLE
Add shared agent guidance for Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# AGENTS.md
+
+Shared instructions for OpenAI Codex and other non-Claude agents working in this repository.
+
+Claude-specific automation, slash commands, and skills live in `CLAUDE.md` and `.claude/`. When those files contain project architecture or workflow details that are not repeated here, treat them as additional repository guidance unless they conflict with higher-priority instructions from the user, system, or developer.
+
+## Instruction Precedence
+
+1. Follow system, developer, and direct user instructions first.
+2. Follow this file for cross-agent repository behavior.
+3. Follow `CLAUDE.md` for project architecture, Claude-specific workflows, and established local conventions.
+4. Follow more specific docs under `docs/` when working in a feature area they cover.
+
+If instructions conflict, choose the higher-priority source and mention the conflict in your handoff or PR.
+
+## Multi-Agent Coordination
+
+- Assume Claude and OpenAI agents may work in this repo at the same time.
+- Before editing, check `git status --short --branch` and avoid overwriting unrelated changes.
+- Do not revert user or other-agent changes unless explicitly asked.
+- Keep edits scoped to the task. Avoid opportunistic refactors.
+- Prefer separate branches or git worktrees for independent tasks.
+- Before comparing branches or opening PRs, run `git fetch origin` because another agent may have pushed recently.
+- Use `gh` CLI for GitHub operations. Avoid interactive commands; pass flags explicitly.
+- If you start a long-running process, make it clear how it is managed and do not leave required verification processes running unintentionally.
+
+## Project Snapshot
+
+Prose is an Electron desktop app with a React/TypeScript renderer and a shared code layer for main, preload, renderer, and MCP behavior.
+
+Key areas:
+
+- `src/main/` - Electron main process, IPC, settings, integrations, updater, Sentry, MCP bridge.
+- `src/preload/` - Context bridge for renderer-safe APIs.
+- `src/renderer/` - React app, TipTap editor, Zustand stores, UI components.
+- `src/shared/` - Shared schemas, tools, LLM utilities, and cross-process types.
+- `src/mcp-stdio/` - Stdio MCP server used by Claude Desktop.
+- `docs/` - Architecture notes, patterns, issue plans, troubleshooting, and release docs.
+- `.claude/` - Claude Code settings, hooks, and skills. Do not treat these as Codex configuration.
+
+## Commands
+
+Use the repo's npm scripts instead of ad hoc command lines:
+
+```bash
+npm run dev              # Electron + Vite development server
+npm run build            # Production build to out/
+npm run build:web        # Web build
+npm run test:e2e         # Build and run Electron Playwright tests
+npm run test:web         # Build and run web Playwright tests
+npm run typecheck:e2e    # Type-check E2E tests
+```
+
+There is no unit test suite. Choose the smallest verification that covers the change:
+
+- Docs-only changes: no build required unless touching generated docs or examples that must compile.
+- Renderer/main/preload/shared TypeScript changes: run `npm run build`.
+- Web-specific changes: run `npm run build:web` or `npm run test:web` when behavior changed.
+- Electron user flows: run `npm run test:e2e` when practical, otherwise build and document manual verification.
+- E2E test changes: run `npm run typecheck:e2e` and the relevant Playwright command.
+
+## Dev Server Safety
+
+The Electron dev server writes `.dev.pid`. Prefer the PID file for this repo's process cleanup.
+
+```bash
+cat .dev.pid 2>/dev/null
+ps -p <PID> -o pid=
+kill <PID>
+```
+
+Avoid broad process kills such as `pkill -f node` or `pkill -f Electron`; they can terminate another agent's session or MCP tools. If the PID file is missing, inspect processes carefully before killing anything.
+
+## Coding Conventions
+
+- Keep platform-specific behavior behind `getApi()` from `src/renderer/lib/browserApi.ts`; do not access `window.api` directly from renderer code.
+- Store settings through the existing settings paths and types. Do not introduce new `homedir()` + `.prose` paths for app data.
+- Preserve Electron sandbox settings: `contextIsolation: true` and `nodeIntegration: false`.
+- Validate filesystem IPC paths with the existing `validatePath()` pattern.
+- Store credentials through the OS-backed credential store; never commit plaintext secrets.
+- Do not use `innerHTML` with dynamic or LLM-provided content.
+- Gate unfinished features with `src/renderer/lib/featureFlags.ts`; do not delete dormant feature code just to hide it.
+- When changing IndexedDB stores in `src/renderer/lib/persistence.ts`, bump `DB_VERSION` and consider fresh-install and upgrade paths.
+- Use shadcn/ui, Tailwind, and existing component patterns. Do not add a new UI library without a strong reason.
+- Keep animations minimal and consistent with the existing app.
+
+## Documentation And Handoffs
+
+- For complex issue work, create or update `docs/issues/<number>/plan.md`.
+- When adding architecture or workflow knowledge useful to future agents, update `docs/` or this file instead of burying it in a PR comment.
+- In final handoffs, include what changed, what was verified, and any residual risk.
+- If you could not run a relevant check, state why.
+
+## PR Expectations
+
+- Work on a branch, not `main`.
+- Keep one logical task per PR.
+- Commit messages should reference the issue number when one exists.
+- Include concise PR bodies with verification performed.
+- Before merging or declaring a PR ready, check unresolved review comments when applicable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+OpenAI Codex and other non-Claude agents use `AGENTS.md` as their repository entry point.
+Claude agents should also read `AGENTS.md` for shared cross-agent coordination rules, then use
+this file for Claude-specific workflows, skills, and deeper project context.
+
 ## Development Environment
 
 This project uses an **agentic, multi-agent development workflow**:


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md for Codex and other non-Claude agents.
- Document shared multi-agent coordination, verification commands, dev-server safety, and project conventions.
- Add a CLAUDE.md cross-reference so Claude agents read the shared guidance too.

## Verification
- npm run build

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._