### PR TITLE
feat(chat): persist toolMode globally across reloads

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -124,7 +124,8 @@ const defaultSettings: Settings = {
   autosave: {
     mode: 'off',
     intervalSeconds: 30
-  }
+  },
+  toolMode: 'editor'
 }
 
 export function setupIpcHandlers(): void {

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useEffect, useRef, useState } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
@@ -26,9 +26,48 @@ const isMacKeyboard =
 
 export function StatusBar() {
   const { document, cursorPosition } = useEditor()
-  const { settings, autosaveActive, setLLMConfig, saveSettings } = useSettings()
+  const { settings, isLoaded: settingsLoaded, autosaveActive, setLLMConfig, saveSettings } = useSettings()
   const { toolMode, setToolMode } = useChat()
   const isRemarkableReadOnly = useEditorStore((state) => state.isRemarkableReadOnly)
+
+  // Track whether the upcoming toolMode change was initiated by a user click on
+  // the mode chip (no cue needed) vs. a programmatic change (pulse to signal it).
+  const userInitiatedRef = useRef(false)
+  // Suppress pulse on the initial settings-boot hydration (first load applies the
+  // persisted value silently; only subsequent in-session programmatic changes pulse).
+  const suppressNextPulseRef = useRef(true)
+  const [modeChipPulse, setModeChipPulse] = useState(false)
+  const prevToolModeRef = useRef(toolMode)
+
+  // Once settings finish loading for the first time, clear the boot-suppression
+  // flag so subsequent programmatic changes can pulse.
+  const settingsLoadedRef = useRef(false)
+  useEffect(() => {
+    if (settingsLoaded && !settingsLoadedRef.current) {
+      settingsLoadedRef.current = true
+      // Allow one toolMode change (the boot hydration) to pass silently, then
+      // lift the suppression on the next tick so real programmatic changes pulse.
+      setTimeout(() => { suppressNextPulseRef.current = false }, 0)
+    }
+  }, [settingsLoaded])
+
+  useEffect(() => {
+    if (toolMode === prevToolModeRef.current) return
+    prevToolModeRef.current = toolMode
+    if (userInitiatedRef.current) {
+      // User clicked the chip — clear the flag, no visual cue needed
+      userInitiatedRef.current = false
+      return
+    }
+    if (suppressNextPulseRef.current) {
+      // Boot-time hydration — suppress silently
+      return
+    }
+    // Programmatic change — briefly pulse the mode chip
+    setModeChipPulse(true)
+    const timer = setTimeout(() => setModeChipPulse(false), 1500)
+    return () => clearTimeout(timer)
+  }, [toolMode])
   const isAutosaving = useEditorStore((state) => state.isAutosaving)
   const sourceMode = useEditorStore((state) => state.sourceMode)
   const toggleSourceMode = useEditorStore((state) => state.toggleSourceMode)
@@ -179,7 +218,7 @@ export function StatusBar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer">
+                <button className={`hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer${modeChipPulse ? ' animate-pulse text-primary' : ''}`}>
                   {currentMode.label}
                 </button>
               </DropdownMenuTrigger>
@@ -193,7 +232,10 @@ export function StatusBar() {
               ([mode, config]) => (
                 <DropdownMenuItem
                   key={mode}
-                  onClick={() => setToolMode(mode)}
+                  onClick={() => {
+                    userInitiatedRef.current = true
+                    setToolMode(mode)
+                  }}
                   className="cursor-pointer font-mono text-xs"
                 >
                   <span className="flex-1">{config.label}</span>

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -369,3 +369,23 @@ useChatStore.subscribe(
     debouncedSave()
   }
 )
+
+// Persist toolMode globally whenever it changes.
+// Uses a lazy dynamic import to avoid a static circular dependency between
+// chatStore and settingsStore (settingsStore already lazy-imports chatStore
+// inside loadSettings()). The subscription fires after the store is
+// initialized so the import always resolves before the callback runs.
+// The guard (toolMode !== settings.toolMode) prevents a redundant write when
+// settingsStore.loadSettings() hydrates chatStore on boot — the value is
+// already persisted and does not need to be written back.
+useChatStore.subscribe(
+  (state) => state.toolMode,
+  (toolMode) => {
+    import('./settingsStore').then(({ useSettingsStore }) => {
+      const current = useSettingsStore.getState().settings.toolMode
+      if (current !== toolMode) {
+        useSettingsStore.getState().setPersistedToolMode(toolMode)
+      }
+    }).catch(() => { /* non-fatal */ })
+  }
+)

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -4,6 +4,7 @@ import type { Settings } from '../types'
 import { initRendererSentry, setRendererSentryEnabled } from '../lib/sentry'
 import { getDefaultModel } from '../../shared/llm/models'
 import type { ModelInfo } from '../../shared/llm/models'
+import type { ToolMode } from '../../shared/tools/types'
 
 const MAX_RECENT_FILES = 15
 
@@ -70,6 +71,7 @@ interface SettingsState {
   setAIConsent: (consented: boolean) => void
   isAIConsentDialogOpen: boolean
   setAIConsentDialogOpen: (open: boolean) => void
+  setPersistedToolMode: (mode: ToolMode) => void
 }
 
 const defaultSettings: Settings = {
@@ -188,6 +190,13 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
       // Apply theme and set up listener
       applyTheme(theme)
       setupSystemThemeListener(theme, set)
+
+      // Hydrate chatStore toolMode from persisted settings (global, applies to all tabs).
+      // Import lazily to avoid a static top-level import that could cause sandbox issues.
+      // The persisted value takes priority; fall back to the store's in-memory default.
+      const persistedToolMode = settings.toolMode ?? defaultSettings.toolMode ?? 'editor'
+      const { useChatStore } = await import('./chatStore')
+      useChatStore.getState().setToolMode(persistedToolMode)
 
       // Initialize Sentry if user has opted in
       initRendererSentry(settings?.errorTracking?.enabled === true)
@@ -405,5 +414,12 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
     get().saveSettings()
   },
 
-  setAIConsentDialogOpen: (open) => set({ isAIConsentDialogOpen: open })
+  setAIConsentDialogOpen: (open) => set({ isAIConsentDialogOpen: open }),
+
+  setPersistedToolMode: (mode) => {
+    set((state) => ({
+      settings: { ...state.settings, toolMode: mode }
+    }))
+    get().saveSettings()
+  }
 })))

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -61,6 +61,11 @@ export interface Settings {
     googleDocs?: boolean
     remarkable?: boolean
   }
+  /**
+   * Persisted tool mode for the AI assistant (global, shared across all tabs/conversations).
+   * Defaults to 'editor' on first launch.
+   */
+  toolMode?: 'chat' | 'editor' | 'create'
 }
 
 export interface Document {


### PR DESCRIPTION
## Summary

- Adds `toolMode` to the `Settings` type and `defaultSettings` (main process `ipc.ts`) with default `'editor'`
- On boot, `settingsStore.loadSettings()` lazy-imports `chatStore` and hydrates it with the persisted mode value, so mode survives Cmd+R and app relaunch
- On every `toolMode` change, a Zustand subscription in `chatStore` lazy-imports `settingsStore` and writes back the new value via `setPersistedToolMode()` (which calls `saveSettings()`) — a value-equality guard prevents a redundant write on the boot hydration
- `StatusBar` pulses (`animate-pulse text-primary`, 1.5s) the mode chip when `toolMode` changes from a non-user source; user dropdown clicks set a ref flag that suppresses the cue

## Persistence mechanism

`toolMode` is stored as a top-level key in `settings.json` (`~/Library/Application Support/Prose/settings.json`). It uses the exact same IPC/file path as all other settings — no new storage, no new IPC channel.

## Boot ordering

`settingsStore.loadSettings()` is called from the `useSettings()` hook's `useEffect` on first render. The hydration of `chatStore.toolMode` happens inside the same `loadSettings()` async function, after `set({ isLoaded: true })` — so by the time React rerenders with `settingsLoaded = true`, the correct mode is already in `chatStore`. There is no race: the existing `checkForRecovery` effect in `App.tsx` already gates on `settingsLoaded`, and the mode is set before that gate opens.

The lazy dynamic import (`await import('./chatStore')` inside `settingsStore.loadSettings()`) avoids a static circular dependency since `settingsStore` is also lazy-imported from `chatStore`'s subscription.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)