### PR TITLE
v1.2 — Agent persona: modes, tool-surface gating, and authorship provenance (#467)

### DIFF
--- a/docs/architecture/llm-pipeline.md
+++ b/docs/architecture/llm-pipeline.md
@@ -83,7 +83,7 @@ When the stream completes with tool calls:
 1. **Circuit breaker** — if `roundtripCount >= MAX_TOOL_ROUNDTRIPS`, append error and stop.
 2. **Build assistant content** — text blocks + `tool_use` blocks for the API message history.
 3. **Sort editor-mutating tools** — `edit`, `insert`, `suggest_edit`, `delete_node` are sorted by document position descending (bottom-first) via `resolveToolPosition()`, so an earlier tool call can't shift positions out from under a later one. `move_cursor` is intentionally **not** in this set — it changes the selection, not document content, so it has no effect on subsequent positions. Non-editor tools sort before editor tools.
-4. **Execute each tool** — `executeTool(name, args, toolMode, provenance)` from `src/renderer/lib/tools/index.ts`.
+4. **Execute each tool** — `executeTool(name, args, toolMode, provenance)` from `src/renderer/lib/tools/index.ts`. `edit` and `insert` are async: when `settings.editor.streamingEdits` is on (default) and the user does not prefer reduced motion, content is inserted in word-level chunks across ~24 animation frames so the user perceives the edit arriving rather than appearing. Tool results resolve once all chunks have landed.
 5. **Duplicate failure detection** — tracks `"${toolName}:${errorMessage}"` signature. If identical to the previous roundtrip's error, stops the loop.
 6. **Build tool results** — each result is summarized (strips `markdown` from `read_document`) and appended as a `role: 'tool'` message.
 7. **Recursive restart** — generates new `streamId`, calls `startStreaming()` with the same `assistantMsgId`, updates both refs, calls `api.llmChatStream()` again.

--- a/docs/architecture/llm-pipeline.md
+++ b/docs/architecture/llm-pipeline.md
@@ -81,7 +81,7 @@ When the stream completes with tool calls:
 
 1. **Circuit breaker** — if `roundtripCount >= MAX_TOOL_ROUNDTRIPS`, append error and stop.
 2. **Build assistant content** — text blocks + `tool_use` blocks for the API message history.
-3. **Sort editor-mutating tools** — `edit`, `insert`, `suggest_edit` are sorted by document position descending (bottom-first) via `resolveToolPosition()`. Non-editor tools sort before editor tools.
+3. **Sort editor-mutating tools** — `edit`, `insert`, `suggest_edit`, `delete_node` are sorted by document position descending (bottom-first) via `resolveToolPosition()`, so an earlier tool call can't shift positions out from under a later one. `move_cursor` is intentionally **not** in this set — it changes the selection, not document content, so it has no effect on subsequent positions. Non-editor tools sort before editor tools.
 4. **Execute each tool** — `executeTool(name, args, toolMode, provenance)` from `src/renderer/lib/tools/index.ts`.
 5. **Duplicate failure detection** — tracks `"${toolName}:${errorMessage}"` signature. If identical to the previous roundtrip's error, stops the loop.
 6. **Build tool results** — each result is summarized (strips `markdown` from `read_document`) and appended as a `role: 'tool'` message.

--- a/docs/architecture/llm-pipeline.md
+++ b/docs/architecture/llm-pipeline.md
@@ -49,7 +49,7 @@ const MAX_HISTORY_MESSAGES = 20   // context window pruning
 Two refs live outside the React hook so globally-registered IPC event handlers can access them:
 
 - **`pendingToolCallsRef`** — accumulates `{id, name, args}` from streaming `tool-call` events, tagged with `streamId`
-- **`toolLoopContextRef`** — tracks `{apiMessages, assistantMsgId, roundtripCount, lastErrorSignature}` across recursive stream restarts, tagged with `streamId`
+- **`toolLoopContextRef`** — tracks `{apiMessages, assistantMsgId, roundtripCount, lastErrorSignature, modeJustSwitched}` across recursive stream restarts, tagged with `streamId`. `modeJustSwitched` is set at turn start and preserved across continuations so the "you just switched modes" notice stays on the system prompt for every LLM call within a turn that began with a mode switch.
 
 Both are reset by `clearStreamRefs()` on abort, error, completion, or circuit-breaker stop.
 

--- a/docs/architecture/llm-pipeline.md
+++ b/docs/architecture/llm-pipeline.md
@@ -70,6 +70,7 @@ All handlers validate `streamId === chatStore.currentStreamId` before processing
 |---------|-----------|---------|
 | `llm:stream` (invoke) | renderer → main | `LLMStreamRequest` (provider, model, messages, tools, streamId) |
 | `llm:stream:chunk` | main → renderer | `{streamId, delta}` — appended to streaming message |
+| `llm:stream:tool-call:start` | main → renderer | `{streamId, toolCallId, toolName}` — fired on `content_block_start` for `tool_use`. Renderer appends `<tool-drafting>` marker for the "Drafting…" chip. |
 | `llm:stream:tool-call` | main → renderer | `{streamId, id, name, args}` — accumulated in `pendingToolCallsRef` |
 | `llm:stream:complete` | main → renderer | `{streamId, content, toolCalls}` — triggers tool execution or completion |
 | `llm:stream:error` | main → renderer | `{streamId, error}` — appends actionable error guidance |
@@ -91,7 +92,7 @@ When the stream completes with tool calls:
 
 Two code paths:
 
-- **Anthropic with tools** — uses `@anthropic-ai/sdk` directly (not Vercel AI SDK) to avoid tool format translation. Converts `role: 'tool'` messages to Anthropic's `tool_result` format. Emits `chunk`, `tool-call`, and `complete` events.
+- **Anthropic with tools** — uses `@anthropic-ai/sdk` directly (not Vercel AI SDK) to avoid tool format translation. Converts `role: 'tool'` messages to Anthropic's `tool_result` format. Emits `chunk`, `tool-call:start` (on each `content_block_start` for `tool_use`, before any `input_json_delta`), `tool-call`, and `complete` events.
 - **Other providers** — uses Vercel AI SDK `streamText()`. No tool support. Emits `chunk` and `complete` only.
 
 Active streams tracked in `Map<string, AbortController>` for abort support.

--- a/docs/qa/467-agent-persona.md
+++ b/docs/qa/467-agent-persona.md
@@ -1,6 +1,6 @@
 # #467 — Manual QA Plan
 
-> **Status:** in flight. After the first implementation sojourn (#529 persistent selection, #530 tool-result renderer registry, #527 autocomplete filter) landed, the pass continued through Stages 1–5 with a second sojourn that produced #534 (request_mode_switch tool + UI), #546 (insert anchor positions), #547 (cursor selection-replace), #543 (delete_node + move_cursor), #545 (drafting indicator), and #544 (chunked streaming). All six merged to `release/v1.2-agent-persona`. Resuming at Stage 6 with the expanded tool surface. Two follow-ups (#548 annotation unification, #549 toolMode persistence) are deferred but targeted at the same release for v1.2. This document is the canonical reference for the QA run; a generalized skill will be extracted from this approach once the pass completes.
+> **Status:** complete — Stage 10 **GO** (2026-05-24). All stages (1–9) passed. A third sojourn merged #548 (annotation unification, including the insertion-style legibility fix) and #549 (global `toolMode` persistence) into `release/v1.2-agent-persona`, with the Stage 4 and Stage 6 re-spot-checks passing. Three pre-existing, non-blocking follow-ups were filed and deferred: #570 (provenance for create-from-scratch / MCP / paste), #571 (`insert after_node` heading absorption), #572 (full-node `edit` drops adjacent annotation). `release/v1.2-agent-persona` → `main` opened on the GO. See the **Run log** appendix at the bottom for the pass/fail table. (Earlier sojourns: #529 persistent selection, #530 tool-result renderer, #527 autocomplete filter; then #534 request_mode_switch, #546 insert anchors, #547 cursor selection-replace, #543 delete_node/move_cursor, #545 drafting indicator, #544 chunked streaming.)
 
 ## Context
 
@@ -153,7 +153,7 @@ Run as one 5–10 minute working session on a real doc, then report.
 
 ### Stage 8 — Regression (legacy paths still work)
 
-- **8.1** In `create`, prompt that gets the agent to emit a legacy `<edit src="..." target="...">` XML block. Auto-applies (`agentMode=true`).
+- **8.1** In `create`, prompt that gets the agent to emit a legacy aider-style SEARCH/REPLACE block (`<<<<<<< SEARCH … ======= … >>>>>>> REPLACE`, parsed by `editBlocks.ts` — *not* an `<edit src target>` XML tag; that earlier wording was inaccurate). Auto-applies via `applyEditsDirect` (`agentMode=true`).
 - **8.2** Switch to `editor`. Same prompt. Renders as reviewable diff with accept/reject buttons.
 - **8.3** `/help` lists slash commands. (Known limitation: list is hardcoded, not mode-aware.)
 - **8.4** `/clear` clears conversation.
@@ -163,7 +163,7 @@ Run as one 5–10 minute working session on a real doc, then report.
 ### Stage 9 — Explicit out-of-scope confirmations
 
 - **9.1** Source mode chat unchanged from pre-#467 (#314 not in scope; not newly broken).
-- **9.2** Per-conversation persistence: messages survive relaunch; `toolMode` does not (each launch starts in `editor`).
+- **9.2** Per-conversation persistence: messages survive relaunch. `toolMode` now **persists globally** across reloads/relaunch (assertion flipped by #549 — was "does not persist"; first-ever launch still defaults to `editor`).
 
 ### Stage 10 — Final go/no-go
 
@@ -216,3 +216,23 @@ The umbrella `#467` is fully verified when Stage 10 says "go" and `release/v1.2-
 ## Skill extraction (after the pass)
 
 Once Stage 10 ships, extract the QA-loop approach as a reusable skill at `.claude/skills/qa-mode-refactor/SKILL.md`. Parameterize: mode names, default mode, tool-gating expectations, persona heuristics. Both implementation sojourns (first: persistent selection / tool-result renderer; second: request_mode_switch + insert anchor + delete_node/move_cursor + drafting indicator + chunked streaming) are UX-surface specific and **not** part of the skill — they're project-specific work caught during the pass. The generalized loop (per-step interactive queueing, surgical-scope bug-fix protocol, pass/fail table maintenance, deferred-follow-up handling) is what transfers.
+
+## Run log — pass/fail (third sojourn, 2026-05-24)
+
+| Stage | Item | Result | Notes |
+|---|---|---|---|
+| 1–6 | — | ✅ | Prior sojourns (see git history) |
+| 7 | Persona heuristics | ✅ | Spot-checked in a live working session |
+| 8.1 | Legacy SEARCH/REPLACE auto-apply (create) | ✅ | Verified `applyEditsDirect`: "Applied 1 edit" + provenance annotation |
+| 8.2 | Legacy block → reviewable diff (editor) | ✅ | `applyEditsAsDiffs` + accept/reject |
+| 8.3 | `/help` lists commands | ✅ | Hardcoded list (known limitation); omits `/new` |
+| 8.4 | `/clear` | ✅ | Conversation emptied |
+| 8.5 | `/new` / `/new_file` un-gated | ✅ | New tab created while in Create mode |
+| 8.6 | MCP path mode-independent | ✅ | Code-verified: `App.tsx` hardcodes `executeTool(…, 'create', …)`, bypasses `checkToolAccess` |
+| 9.1 | Source-mode chat unchanged | ✅ | Out-of-scope confirmation |
+| 9.2 | Messages persist; `toolMode` persists | ✅ | `toolMode` persistence is the new #549 behavior |
+| — | #548 merged (PR #569) | ✅ | + insertion annotation legibility/unification fix |
+| — | #549 merged (PR #568) | ✅ | Global persistence; Stage 4 re-check passed |
+| 10 | Go/no-go | ✅ **GO** | Shipped with #570/#571/#572 deferred |
+
+**Deferred (pre-existing, non-blocking):** #570 (provenance for create / MCP / paste), #571 (`insert after_node` heading absorption), #572 (full-node `edit` drops adjacent annotation).

--- a/docs/qa/467-agent-persona.md
+++ b/docs/qa/467-agent-persona.md
@@ -1,6 +1,6 @@
 # #467 — Manual QA Plan
 
-> **Status:** in flight. Mid-pass at Step 1.5 when three UX issues surfaced and we took an implementation sojourn (persistent selection, tool-result renderer registry, autocomplete filter). Resume here after those features land. This document is the canonical reference for the QA run; a generalized skill will be extracted from this approach once the pass completes.
+> **Status:** in flight. After the first implementation sojourn (#529 persistent selection, #530 tool-result renderer registry, #527 autocomplete filter) landed, the pass continued through Stages 1–5 with a second sojourn that produced #534 (request_mode_switch tool + UI), #546 (insert anchor positions), #547 (cursor selection-replace), #543 (delete_node + move_cursor), #545 (drafting indicator), and #544 (chunked streaming). All six merged to `release/v1.2-agent-persona`. Resuming at Stage 6 with the expanded tool surface. Two follow-ups (#548 annotation unification, #549 toolMode persistence) are deferred but targeted at the same release for v1.2. This document is the canonical reference for the QA run; a generalized skill will be extracted from this approach once the pass completes.
 
 ## Context
 
@@ -11,6 +11,15 @@ All four implementation chunks of the #467 umbrella merged into `release/v1.2-ag
 - Chunk 3 (#522) — `ToolMode` rename + Editor default + Shift+Tab cycle + dead-code cleanup
 - Chunk 4 (#524) — every mutating tool gated to Editor + UX polish (autocomplete, error messages)
 - Chunk 5 — no PR, audit confirmed accept-flow plays nicely with #447's caption tooltip
+
+Second-sojourn chunks added during the QA pass (each surfaced as a QA finding then implemented before resuming):
+
+- #534 — `request_mode_switch` tool + persona softening + Switch & Run / Just Switch / Cancel UI
+- #546 — `insert` accepts `after_node` / `before_node` anchor positions (fixes cursor-dependent placement)
+- #547 — `insert(position=cursor)` restores selection-replace semantics + annotation-range math fix
+- #543 — `delete_node` + `move_cursor` tools (closes #540)
+- #545 — Drafting indicator while LLM generates tool args (closes #542)
+- #544 — Cosmetic chunked streaming for agent `insert` / `edit` (closes #541)
 
 What's left is end-to-end manual verification against the umbrella's acceptance criteria (#467, #468) before merging the release branch to `main`. There are no automated tests (no vitest setup), so this pass is the gate.
 
@@ -77,6 +86,7 @@ Stages run roughly cheap → expensive. Within a stage, batch related checks onc
 - **1.6** Switch to `editor`. Type `/`. Autocomplete includes `/suggest_edit`, `/add_comment`, `/resolve_comment`, `/quick-review`, `/review-diff`. Excludes `/edit`, `/insert`.
 - **1.7** Switch to `create`. Type `/`. Autocomplete includes everything (including `/edit`, `/insert`).
 - **1.8** (new — added during implementation sojourn) Type `/list_files`, submit. Result renders in chat as a file tree with the same visual style as the file explorer side panel. Clicking a file opens it. Clicking a folder toggles expand/collapse.
+- **1.9** (new — #534 UI) Trigger any tool that returns a result (e.g., `/read_document` in Editor Mode). Tool-call card defaults to **collapsed** with a chevron toggle on the right of the header — except `request_mode_switch` cards (triggered by 4.x scenarios), which default to **expanded** because the reason and prompt-to-retry are the substance. For `request_mode_switch`, the Switch & Run / Just Switch / Cancel buttons sit **outside** the collapsible body, always visible. Click Cancel → "Dismissed." text replaces buttons; close+reopen the panel or switch conversations and back → state persists (no re-clickable buttons for past decisions).
 
 ### Stage 2 — Keyboard cycle (no LLM)
 
@@ -98,10 +108,12 @@ Setup: open a doc with some content.
 
 - **4.1** "What's in my document?" → agent calls `read_document`, replies with summary.
 - **4.2** "Give me an outline" → agent calls `get_outline`.
-- **4.3** "Fix the typo in paragraph 2" → agent declines, redirects to Editor Mode.
-- **4.4** "Add a comment on the second paragraph" → agent declines, redirects.
-- **4.5** "Write me a paragraph about coffee" → agent declines, no doc mutation.
+- **4.3** "Fix the typo in paragraph 2" → agent calls `request_mode_switch(target='editor', prompt_to_retry='Fix the typo in paragraph 2')`. The in-chat card shows Switch & Run / Just Switch / Cancel.
+- **4.4** "Add a comment on the second paragraph" → agent calls `request_mode_switch(target='editor', ...)`.
+- **4.5** "Write me a paragraph about coffee" → agent calls `request_mode_switch(target='create', ...)`. No doc mutation.
 - **4.6** (new — added during implementation sojourn) Select text in the editor. Click into chat input. **Selection remains visibly highlighted in the editor** while chat has focus. Type "what did I select?" → agent calls `read_selection`, result body matches the highlighted text.
+- **4.7** (new — #545) Drafting indicator. Send a request that the agent will respond to with a tool call whose argument body is long (e.g., the 4.3 typo-fix prompt — the agent will compose a `prompt_to_retry` mid-stream). A small "Drafting…" chip appears between the user message and the eventual tool-call result, then disappears once the tool call lands. On a forced stream error (toggle airplane mode mid-stream), no orphan "Drafting…" chip remains in the conversation.
+- **4.8** (new — #534 Switch & Run continuation) On the 4.3 result, click **Switch & Run**. Mode flips to Editor, the prompt auto-sends, and the agent goes directly to `read_document` + `suggest_edit` for the typo — it does **not** re-emit `request_mode_switch` on the continuation. (This was a fixed double-fire bug, regression-checking the modeJustSwitched propagation through the tool loop.)
 
 ### Stage 5 — Editor Mode behavior
 
@@ -110,15 +122,23 @@ Setup: open a doc with some content.
 - **5.3** Accept the diff. Annotation appears.
 - **5.4** Hover the annotation. Tooltip shows model id + timestamp + explanation as a third line.
 - **5.5** "The second paragraph has a competing thesis with the first" → agent uses `add_comment` (margin note), **not `suggest_edit`** (no replacement prose).
-- **5.6** "Write me a paragraph about coffee" → agent declines or asks you to draft it.
+- **5.6** "Write me a paragraph about coffee" → agent declines (no-authorship posture) and offers to edit a user-supplied draft.
 - **5.7** "What comments are in this document?" → agent calls `list_comments`, lists them.
 - **5.8** "Resolve the comment about the thesis" → agent calls `resolve_comment`.
+- **5.9** (new — #534 mid-conversation escalation) Right after 5.6's pushback, reply "yes write it" (or equivalent confirmation). Agent now calls `request_mode_switch(target='create', prompt_to_retry='Write a paragraph about coffee')`. The Switch & Run / Just Switch / Cancel buttons appear. The Editor-Mode posture held the line on first ask and only escalated on confirmation — that's the prompt-design contract working.
 
 ### Stage 6 — Create Mode behavior
 
-- **6.1** "Write me a paragraph about coffee" → agent drafts via `edit` or `insert`.
-- **6.2** "Fix typos in paragraph 2" → agent should still prefer `suggest_edit` for changes to existing content.
-- **6.3** Repeat 5.5 — agent still uses `add_comment` for judgment-bearing concerns.
+Setup: in Create mode, on a doc with at least an H1 title and a couple of H2 sections with prose (the lighthouse-keeper test doc used in the session is a known-good fixture).
+
+- **6.1** "Write me a paragraph about coffee" → agent drafts via `edit` or `insert`. **Verify the new chunked-streaming visual** (#544): the paragraph arrives in word-level chunks over ~400ms, not all at once. With `prefers-reduced-motion: reduce` set at the OS level, chunks collapse to instant apply.
+- **6.2** "Fix typos in paragraph 2" → agent still prefers `suggest_edit` (clear right answer, user should review), not `edit` / `insert`.
+- **6.3** Judgment-bearing concern (e.g., "the second paragraph has a competing thesis with the first") → agent uses `add_comment`, not `suggest_edit`.
+- **6.4** (new — #546) Park cursor in an unrelated section. Send "Add a paragraph about coffee to the Background section." → agent calls `read_document` → `insert(position='after_node', nodeId=<Background heading>)`. Paragraph lands immediately after the heading regardless of cursor location.
+- **6.5** (new — #547) Highlight a sentence in the editor. Send "replace this with: '…'" (or "use the insert tool to replace my selection with: '…'" if the agent reaches for suggest_edit instead). Agent uses `insert(position='cursor')` and the highlighted span is **replaced**, not left next to the new prose. Annotation range covers the inserted content (no `to < from` artifacts even when replaced span was larger than insertion).
+- **6.6** (new — #543 delete) After 6.4 lands, send "Actually, delete the coffee paragraph you just added." → agent calls `delete_node(nodeId=…)`. Paragraph is removed. Hover the deletion site → tooltip reads "AI Deletion" with model + timestamp.
+- **6.7** (new — #543 move + #546 cursor coordination) Send "park the cursor at the end of the Background section, then insert: '…'" → agent calls `move_cursor(nodeId=<Background heading>, position='end')` then `insert(position='cursor', text=…)`. The caret visibly moves to the new location; the insertion lands at the new cursor.
+- **6.8** (new — #543 mode gating) Switch to Chat Mode. Type `/delete_node foo` and submit. Error: "Tool 'delete_node' is not available in Chat Mode. Switch to **Create** Mode to use this tool." Switch to Editor Mode and try `/delete_node foo` → same error (delete is Create-only). `/move_cursor foo` in Chat → "Switch to **Editor** Mode" (move_cursor is Editor-and-up).
 
 ### Stage 7 — Persona heuristics (qualitative)
 
@@ -165,16 +185,34 @@ Run as one 5–10 minute working session on a real doc, then report.
 - `src/renderer/lib/prompts.ts` — BASE_PROMPT + per-mode instructions (persona heuristics)
 - `src/renderer/extensions/persistent-selection/` — TipTap extension for blur-time selection visibility (added during sojourn)
 - `src/renderer/components/chat/toolResultRenderers/` — per-tool result render registry (added during sojourn)
+- `src/renderer/lib/tools/executors/editor.ts` — `executeInsert` / `executeEdit` / `executeDeleteNode` / `executeMoveCursor`, `applyInsertion` chunked helper (added during second sojourn)
+- `src/renderer/extensions/ai-annotations/plugin.ts` — annotation tooltip labels including `'AI Deletion'` (#543)
+- `src/main/ipc.ts` — `llm:stream:tool-call:start` event (#545), `streamingEdits: true` default (#544)
+- `src/renderer/components/settings/SettingsDialog.tsx` — "Stream agent edits" toggle (#544)
+- `src/shared/tools/schemas/ui.ts` — `request_mode_switch` schema (#534, UI-coordination category)
+- `src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx` — body + actions split with persisted action state (#534)
+- `src/renderer/hooks/useChat.ts` — `modeJustSwitched` propagation through tool-loop continuations (#534 fix)
+
+## Deferred follow-ups targeting this release
+
+Two follow-ups filed in-session ship before merging `release/v1.2-agent-persona` → `main`:
+
+- **#548** — Unify AI-write annotations: `insert` and `edit` should accept an optional `comment` field and produce the same word-level annotation style as `suggest_edit` accepts (with explanation in the tooltip). Closes a UX inconsistency caught during 6.x where insert/edit annotations look different from suggest_edit ones. Cloud-agent friendly.
+- **#549** — Persist `toolMode` across reloads + surface unexpected resets. Closes the "agent thinks I'm in wrong mode" failure mode observed during Stage 6 (mode reverted to Editor on refresh without the user noticing the StatusBar change). Open design question in the issue: per-conversation vs global persistence (weak vote for global). Note that when #549 lands, Stage 9.2's "`toolMode` does not persist" assertion flips — update accordingly.
+
+Sequence: finish QA Stages 6–9 against the current release tip → `/accelerate 548 549` → review + merge → re-spot-check Stage 4 (drafting indicator + mode-switch behavior under persisted mode) and Stage 6 (annotation visual unification) → run Stage 10.
 
 ## Verification (meta — when is the QA pass done?)
 
 1. All steps in stages 1–8 pass (with fixes applied for any failures).
 2. Stage 9 confirms no new regressions in out-of-scope areas.
-3. Stage 10 reaches a confident go/no-go.
-4. Skill extraction begins after Stage 10 says "go."
+3. **#548 and #549 merged** to `release/v1.2-agent-persona`; re-spot-checks on Stages 4 and 6 against the new behavior pass.
+4. Stage 10 reaches a confident go/no-go.
+5. Commit a final "Run log" appendix to this doc capturing the pass/fail table from the conversation, so the next session has a durable record of what was verified vs deferred.
+6. Skill extraction begins after Stage 10 says "go."
 
 The umbrella `#467` is fully verified when Stage 10 says "go" and `release/v1.2-agent-persona` merges to `main`.
 
 ## Skill extraction (after the pass)
 
-Once Stage 10 ships, extract the QA-loop approach as a reusable skill at `.claude/skills/qa-mode-refactor/SKILL.md`. Parameterize: mode names, default mode, tool-gating expectations, persona heuristics. The implementation-sojourn experience (selection persistence, tool-result renderer) is UX-surface specific and **not** part of the skill — it's project-specific work caught during the pass.
+Once Stage 10 ships, extract the QA-loop approach as a reusable skill at `.claude/skills/qa-mode-refactor/SKILL.md`. Parameterize: mode names, default mode, tool-gating expectations, persona heuristics. Both implementation sojourns (first: persistent selection / tool-result renderer; second: request_mode_switch + insert anchor + delete_node/move_cursor + drafting indicator + chunked streaming) are UX-surface specific and **not** part of the skill — they're project-specific work caught during the pass. The generalized loop (per-step interactive queueing, surgical-scope bug-fix protocol, pass/fail table maintenance, deferred-follow-up handling) is what transfers.

--- a/docs/qa/467-agent-persona.md
+++ b/docs/qa/467-agent-persona.md
@@ -1,0 +1,180 @@
+# #467 — Manual QA Plan
+
+> **Status:** in flight. Mid-pass at Step 1.5 when three UX issues surfaced and we took an implementation sojourn (persistent selection, tool-result renderer registry, autocomplete filter). Resume here after those features land. This document is the canonical reference for the QA run; a generalized skill will be extracted from this approach once the pass completes.
+
+## Context
+
+All four implementation chunks of the #467 umbrella merged into `release/v1.2-agent-persona`:
+
+- Chunk 1 (#513) — persona seed + StatusBar labels
+- Chunk 2 (#521) — Chat Mode read-only tools
+- Chunk 3 (#522) — `ToolMode` rename + Editor default + Shift+Tab cycle + dead-code cleanup
+- Chunk 4 (#524) — every mutating tool gated to Editor + UX polish (autocomplete, error messages)
+- Chunk 5 — no PR, audit confirmed accept-flow plays nicely with #447's caption tooltip
+
+What's left is end-to-end manual verification against the umbrella's acceptance criteria (#467, #468) before merging the release branch to `main`. There are no automated tests (no vitest setup), so this pass is the gate.
+
+The pass runs as a tight interactive loop: Claude queues one step at a time, the user runs it and reports back, bugs found get fixed in-session and re-verified before moving on.
+
+## Protocol
+
+### Step delivery format
+
+Each step Claude queues includes:
+
+- **Step N — short name** (#chunk it verifies)
+- **Setup**: required state (current mode, document content, fresh launch yes/no)
+- **Action**: exact action(s) for the user to perform — one sentence each, no ambiguity
+- **Expected**: what should happen
+- **Watch for**: common failure modes
+- **Report back**: how to capture the result (pass / fail + observation)
+
+### Granularity — adaptive
+
+Start atomic (one action per step) for the first ~10 steps until calibrated. Once a tight cluster of related checks is all passing, batch them into mini-steps (e.g., "all 3 StatusBar visual checks in one report"). Never batch across stage boundaries.
+
+### Bug-handling — fix in-session, re-verify
+
+When a step fails and it's a real bug (not a misunderstood expectation):
+
+1. Propose a fix with surgical scope (one file usually, sometimes two).
+2. Cut a branch off `release/v1.2-agent-persona` named `qa-467-fix-<short-description>`.
+3. Apply the fix, commit, push.
+4. Wait for CI to green and a fresh `claude[bot]` review verdict of `clean`.
+5. Squash-merge into `release/v1.2-agent-persona`.
+6. User pulls + restarts the dev server.
+7. Re-run the failing step. Move on only when it passes.
+
+If the failure is a misunderstood expectation (the code is correct, the step description is wrong), update this plan's step queue and continue without a code change.
+
+### Result tracking
+
+Maintain a running pass/fail table in the conversation, updated after each step. Format:
+
+```
+| Step | Name | Result | Notes |
+|---|---|---|---|
+| 1 | Fresh-launch lands in editor | ✅ | |
+| 2 | StatusBar labels | ✅ → fix PR #526 → ✅ | Cosmetic focus-ring leak fixed |
+| 3 | Shift+Tab cycle | ❌ → fixed in PR #N → ✅ | Editor was skipped from Create state |
+```
+
+## Step queue
+
+Stages run roughly cheap → expensive. Within a stage, batch related checks once calibrated.
+
+### Stage 0 — Bootstrap
+
+- **0.1** Pull and check out `release/v1.2-agent-persona`; `npm install` if needed; start `npm run dev` in the background; confirm clean compile (142 modules transformed, no TS errors).
+
+### Stage 1 — Visual / structural (no LLM calls)
+
+- **1.1** Quit and relaunch Prose. StatusBar mode picker reads `editor`.
+- **1.2** Hover the picker. Tooltip: "Proposes copy edits and editorial notes (default)".
+- **1.3** Open the dropdown. Order is `chat → editor → create`, `✓` next to `editor`.
+- **1.4** Hover each option in the dropdown. Tooltips match the per-mode copy.
+- **1.5** Switch to `chat`. Type `/` in chat input. Autocomplete excludes `/suggest_edit`, `/add_comment`, `/resolve_comment`, `/accept_diff`, `/reject_diff`, `/edit`, `/insert`, and (after the implementation sojourn's autocomplete fix) `/quick-review`, `/review-diff`.
+- **1.6** Switch to `editor`. Type `/`. Autocomplete includes `/suggest_edit`, `/add_comment`, `/resolve_comment`, `/quick-review`, `/review-diff`. Excludes `/edit`, `/insert`.
+- **1.7** Switch to `create`. Type `/`. Autocomplete includes everything (including `/edit`, `/insert`).
+- **1.8** (new — added during implementation sojourn) Type `/list_files`, submit. Result renders in chat as a file tree with the same visual style as the file explorer side panel. Clicking a file opens it. Clicking a folder toggles expand/collapse.
+
+### Stage 2 — Keyboard cycle (no LLM)
+
+- **2.1** Start in `editor` (fresh launch state). Shift+Tab → `create`.
+- **2.2** Shift+Tab again → `chat`.
+- **2.3** Shift+Tab again → `editor`.
+- **2.4** Confirm Editor is reachable from any starting state via Shift+Tab loops.
+
+### Stage 3 — Mode-restriction error messages
+
+- **3.1** In `chat`, type `/suggest_edit foo` and submit. Error: "Tool 'suggest_edit' is not available in Chat Mode. Switch to **Editor** Mode to use this tool."
+- **3.2** In `chat`, type `/edit foo` and submit. Error: "...Switch to **Create** Mode...".
+- **3.3** In `editor`, type `/edit foo`. Error: "...Switch to **Create** Mode...".
+- **3.4** In `editor`, type `/insert foo`. Error: Switch to **Create** Mode.
+
+### Stage 4 — Chat Mode behavior
+
+Setup: open a doc with some content.
+
+- **4.1** "What's in my document?" → agent calls `read_document`, replies with summary.
+- **4.2** "Give me an outline" → agent calls `get_outline`.
+- **4.3** "Fix the typo in paragraph 2" → agent declines, redirects to Editor Mode.
+- **4.4** "Add a comment on the second paragraph" → agent declines, redirects.
+- **4.5** "Write me a paragraph about coffee" → agent declines, no doc mutation.
+- **4.6** (new — added during implementation sojourn) Select text in the editor. Click into chat input. **Selection remains visibly highlighted in the editor** while chat has focus. Type "what did I select?" → agent calls `read_selection`, result body matches the highlighted text.
+
+### Stage 5 — Editor Mode behavior
+
+- **5.1** "Fix typos in paragraph 2" → agent uses `suggest_edit`. Diff overlay appears.
+- **5.2** Click the overlay. Popover shows the model's explanation under "Explanation:".
+- **5.3** Accept the diff. Annotation appears.
+- **5.4** Hover the annotation. Tooltip shows model id + timestamp + explanation as a third line.
+- **5.5** "The second paragraph has a competing thesis with the first" → agent uses `add_comment` (margin note), **not `suggest_edit`** (no replacement prose).
+- **5.6** "Write me a paragraph about coffee" → agent declines or asks you to draft it.
+- **5.7** "What comments are in this document?" → agent calls `list_comments`, lists them.
+- **5.8** "Resolve the comment about the thesis" → agent calls `resolve_comment`.
+
+### Stage 6 — Create Mode behavior
+
+- **6.1** "Write me a paragraph about coffee" → agent drafts via `edit` or `insert`.
+- **6.2** "Fix typos in paragraph 2" → agent should still prefer `suggest_edit` for changes to existing content.
+- **6.3** Repeat 5.5 — agent still uses `add_comment` for judgment-bearing concerns.
+
+### Stage 7 — Persona heuristics (qualitative)
+
+Run as one 5–10 minute working session on a real doc, then report.
+
+- **7.1** Push once, defer. Dubious claim → one pushback with evidence, then defer if you insist. No dig-in, no collapse.
+- **7.2** Reflects words accurately. Articulate something, ask for recap. Should quote accurately, not "improve."
+- **7.3** Surfaces crisp lines. Use a particularly good phrase; agent flags it as worth using deliberately.
+- **7.4** Structural diagnosis before scaffolding. Draft with competing intentions → agent identifies tension before reorganizing.
+- **7.5** No filler openings. Responses don't start with "Sure!" / "Great!" / restating.
+- **7.6** Escape hatch. Ask for tool-unrepresentable change. Agent produces handoff prompt via `create_and_open_file`, not inline code.
+
+### Stage 8 — Regression (legacy paths still work)
+
+- **8.1** In `create`, prompt that gets the agent to emit a legacy `<edit src="..." target="...">` XML block. Auto-applies (`agentMode=true`).
+- **8.2** Switch to `editor`. Same prompt. Renders as reviewable diff with accept/reject buttons.
+- **8.3** `/help` lists slash commands. (Known limitation: list is hardcoded, not mode-aware.)
+- **8.4** `/clear` clears conversation.
+- **8.5** `/new` / `/new_file` works in all modes (file-write commands intentionally not mode-gated).
+- **8.6** MCP path: Claude Desktop can `read_document`, `suggest_edit`, `add_comment` regardless of Prose's current mode.
+
+### Stage 9 — Explicit out-of-scope confirmations
+
+- **9.1** Source mode chat unchanged from pre-#467 (#314 not in scope; not newly broken).
+- **9.2** Per-conversation persistence: messages survive relaunch; `toolMode` does not (each launch starts in `editor`).
+
+### Stage 10 — Final go/no-go
+
+- **10.1** Review the pass/fail table. 100% pass + no bugs filed → merge `release/v1.2-agent-persona` → `main`.
+- **10.2** Anything fixed in-session → ensure all fix-PRs merged into the release branch first.
+- **10.3** Anything deferred → list bugs, decide whether to ship anyway or hold the merge.
+
+## Critical files referenced during testing
+
+- `src/renderer/components/layout/StatusBar.tsx` — mode picker labels
+- `src/renderer/stores/chatStore.ts` — default mode, `cycleToolMode`
+- `src/renderer/components/editor/Editor.tsx` — Shift+Tab handler
+- `src/renderer/components/chat/ChatInput.tsx` — autocomplete filter
+- `src/renderer/lib/tools/modes.ts` — `checkToolAccess` error messages
+- `src/shared/tools/schemas/document.ts`, `src/shared/tools/schemas/editor.ts` — `requiresMode` declarations
+- `src/renderer/extensions/ai-suggestions/extension.ts` — accept flow + explanation plumbing
+- `src/renderer/extensions/ai-annotations/plugin.ts` — caption tooltip rendering
+- `src/renderer/index.css` — `.ai-annotation-tooltip-explanation`, `.persistent-selection` styles
+- `src/renderer/lib/prompts.ts` — BASE_PROMPT + per-mode instructions (persona heuristics)
+- `src/renderer/extensions/persistent-selection/` — TipTap extension for blur-time selection visibility (added during sojourn)
+- `src/renderer/components/chat/toolResultRenderers/` — per-tool result render registry (added during sojourn)
+
+## Verification (meta — when is the QA pass done?)
+
+1. All steps in stages 1–8 pass (with fixes applied for any failures).
+2. Stage 9 confirms no new regressions in out-of-scope areas.
+3. Stage 10 reaches a confident go/no-go.
+4. Skill extraction begins after Stage 10 says "go."
+
+The umbrella `#467` is fully verified when Stage 10 says "go" and `release/v1.2-agent-persona` merges to `main`.
+
+## Skill extraction (after the pass)
+
+Once Stage 10 ships, extract the QA-loop approach as a reusable skill at `.claude/skills/qa-mode-refactor/SKILL.md`. Parameterize: mode names, default mode, tool-gating expectations, persona heuristics. The implementation-sojourn experience (selection persistence, tool-result renderer) is UX-surface specific and **not** part of the skill — it's project-specific work caught during the pass.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -115,7 +115,8 @@ const defaultSettings: Settings = {
   editor: {
     fontSize: 16,
     lineHeight: 1.6,
-    fontFamily: "'IBM Plex Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace"
+    fontFamily: "'IBM Plex Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+    streamingEdits: true
   },
   recovery: {
     mode: 'silent'

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -124,7 +124,8 @@ const defaultSettings: Settings = {
   autosave: {
     mode: 'off',
     intervalSeconds: 30
-  }
+  },
+  toolMode: 'editor'
 }
 
 export function setupIpcHandlers(): void {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -809,6 +809,14 @@ export function setupIpcHandlers(): void {
           console.log('[LLM:stream] Content block start:', block.content_block.type)
           if (block.content_block.type === 'tool_use') {
             console.log('[LLM:stream] Tool use started:', block.content_block.name)
+            // Fire a drafting event before any input_json_delta arrives — the
+            // visible latency for tools like `insert`/`edit` is the LLM
+            // composing the input, not the tool's actual execution.
+            event.sender.send('llm:stream:tool-call:start', {
+              streamId,
+              toolCallId: block.content_block.id,
+              toolName: block.content_block.name
+            })
           }
         })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -52,6 +52,12 @@ export interface LLMStreamToolCall {
   }
 }
 
+export interface LLMStreamToolCallStart {
+  streamId: string
+  toolCallId: string
+  toolName: string
+}
+
 export interface LLMStreamComplete {
   streamId: string
   content: string
@@ -190,6 +196,7 @@ export interface ElectronAPI {
   llmAbortStream: (streamId: string) => Promise<{ success: boolean }>
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => () => void
   onLLMStreamToolCall: (callback: (toolCall: LLMStreamToolCall) => void) => () => void
+  onLLMStreamToolCallStart: (callback: (start: LLMStreamToolCallStart) => void) => () => void
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => () => void
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
   // Folder operations for quick save
@@ -473,6 +480,15 @@ const api: ElectronAPI = {
     ipcRenderer.on('llm:stream:tool-call', handler)
     return () => {
       ipcRenderer.removeListener('llm:stream:tool-call', handler)
+    }
+  },
+  onLLMStreamToolCallStart: (callback: (start: LLMStreamToolCallStart) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, start: LLMStreamToolCallStart): void => {
+      callback(start)
+    }
+    ipcRenderer.on('llm:stream:tool-call:start', handler)
+    return () => {
+      ipcRenderer.removeListener('llm:stream:tool-call:start', handler)
     }
   },
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => {

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -5,8 +5,10 @@ import { useChat } from '../../hooks/useChat'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useChatStore, createMessageId } from '../../stores/chatStore'
+import { useFileListStore } from '../../stores/fileListStore'
 import { useCommandHistoryStore } from '../../stores/commandHistoryStore'
 import { executeTool, getAvailableTools, isToolAvailableInMode } from '../../lib/tools'
+import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import { cn } from '../../lib/utils'
 import { useReviewStore } from '../../stores/reviewStore'
 
@@ -28,6 +30,11 @@ const toolDescriptions: Record<string, string> = {
   save_file: 'Save to file',
   list_files: 'List files in directory',
   read_file: 'Read file contents',
+  list_comments: 'List comments in document',
+  add_comment: 'Add a comment to selected text',
+  resolve_comment: 'Resolve (remove) a comment',
+  list_tabs: 'List open tabs',
+  select_tab: 'Switch to a different tab',
   help: 'Show available commands',
   clear: 'Start a new chat',
   new: 'New blank tab',
@@ -133,19 +140,31 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   // Disable input while app is initializing (loading draft/conversations) or while loading
   const isDisabled = isLoading || isInitializing
 
+  // Track pending AI suggestion count so the review shortcuts can be
+  // contextual on whether there's anything to review. Same pattern as
+  // StatusBar.tsx — keys on editor + doc reference so edits invalidate
+  // the memo.
+  const suggestionCount = useMemo(() => {
+    if (!editor) return 0
+    return getAISuggestions(editor).length
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, editor?.state.doc])
+
   // All available commands (including built-in shortcuts) filtered by the
   // current ToolMode — don't suggest /suggest_edit in Chat Mode if it would
   // fail at checkToolAccess. Normalize aliases: get_outline → outline.
-  // The review-UI shortcuts (/quick-review, /review-diff) operate on pending
-  // suggestions, which Chat Mode can't produce — exclude them there too.
+  // The review-UI shortcuts (/quick-review, /review-diff) only show when
+  // there are pending suggestions to review — and never in Chat Mode,
+  // which can't produce suggestions in the first place.
   const allCommands = useMemo(() => {
     const tools = getAvailableTools()
       .filter(t => t !== 'create_and_open_file')
       .filter(t => isToolAvailableInMode(t, toolMode))
       .map(t => t === 'get_outline' ? 'outline' : t)
-    const reviewShortcuts = toolMode === 'chat' ? [] : ['quick-review', 'review-diff']
+    const showReviewShortcuts = toolMode !== 'chat' && suggestionCount > 0
+    const reviewShortcuts = showReviewShortcuts ? ['quick-review', 'review-diff'] : []
     return [...tools, 'help', 'clear', 'new', ...reviewShortcuts]
-  }, [toolMode])
+  }, [toolMode, suggestionCount])
 
   // Parse the current command from input (e.g., "/list_files " -> "list_files")
   const activeCommand = useMemo(() => {
@@ -275,20 +294,22 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
       return
     }
 
-    // Handle /list_files - get current file's directory first
+    // Handle /list_files - default to the file explorer's current root so
+    // chat-side results mirror what the user sees in the side panel.
+    // Fall back to the active file's directory, then home, if no explorer
+    // root is set (e.g., user closed the panel without ever opening it).
     if (command.toolName === 'list_files') {
+      const { rootPath } = useFileListStore.getState()
       const { document } = useEditorStore.getState()
-      const path = document.path
-      if (path) {
-        // Extract directory from file path
-        const dir = path.substring(0, path.lastIndexOf('/')) || '~'
-        // First get metadata, then list files
-        const enhancedCommand = { ...command, args: { path: dir }, rawArg: dir }
-        await handleSlashCommand(enhancedCommand, `/list_files ${dir}`)
-      } else {
-        // No current file, list home directory
-        await handleSlashCommand({ ...command, args: { path: '~' }, rawArg: '~' }, '/list_files ~')
+      let dir = rootPath
+      if (!dir && document.path) {
+        dir = document.path.substring(0, document.path.lastIndexOf('/')) || '~'
       }
+      if (!dir) {
+        dir = '~'
+      }
+      const enhancedCommand = { ...command, args: { path: dir }, rawArg: dir }
+      await handleSlashCommand(enhancedCommand, `/list_files ${dir}`)
       return
     }
 

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -136,13 +136,16 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   // All available commands (including built-in shortcuts) filtered by the
   // current ToolMode — don't suggest /suggest_edit in Chat Mode if it would
   // fail at checkToolAccess. Normalize aliases: get_outline → outline.
-  const allCommands = useMemo(() => [
-    ...getAvailableTools()
+  // The review-UI shortcuts (/quick-review, /review-diff) operate on pending
+  // suggestions, which Chat Mode can't produce — exclude them there too.
+  const allCommands = useMemo(() => {
+    const tools = getAvailableTools()
       .filter(t => t !== 'create_and_open_file')
       .filter(t => isToolAvailableInMode(t, toolMode))
-      .map(t => t === 'get_outline' ? 'outline' : t),
-    'help', 'clear', 'new', 'quick-review', 'review-diff'
-  ], [toolMode])
+      .map(t => t === 'get_outline' ? 'outline' : t)
+    const reviewShortcuts = toolMode === 'chat' ? [] : ['quick-review', 'review-diff']
+    return [...tools, 'help', 'clear', 'new', ...reviewShortcuts]
+  }, [toolMode])
 
   // Parse the current command from input (e.g., "/list_files " -> "list_files")
   const activeCommand = useMemo(() => {

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -6,7 +6,7 @@ import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useChatStore, createMessageId } from '../../stores/chatStore'
 import { useCommandHistoryStore } from '../../stores/commandHistoryStore'
-import { executeTool, getAvailableTools } from '../../lib/tools'
+import { executeTool, getAvailableTools, isToolAvailableInMode } from '../../lib/tools'
 import { cn } from '../../lib/utils'
 import { useReviewStore } from '../../stores/reviewStore'
 
@@ -133,14 +133,16 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   // Disable input while app is initializing (loading draft/conversations) or while loading
   const isDisabled = isLoading || isInitializing
 
-  // All available commands (including built-in shortcuts)
-  // Normalize aliases: get_outline → outline for consistent display
+  // All available commands (including built-in shortcuts) filtered by the
+  // current ToolMode — don't suggest /suggest_edit in Chat Mode if it would
+  // fail at checkToolAccess. Normalize aliases: get_outline → outline.
   const allCommands = useMemo(() => [
     ...getAvailableTools()
       .filter(t => t !== 'create_and_open_file')
+      .filter(t => isToolAvailableInMode(t, toolMode))
       .map(t => t === 'get_outline' ? 'outline' : t),
     'help', 'clear', 'new', 'quick-review', 'review-diff'
-  ], [])
+  ], [toolMode])
 
   // Parse the current command from input (e.g., "/list_files " -> "list_files")
   const activeCommand = useMemo(() => {
@@ -217,7 +219,6 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
     // Handle /help specially
     if (command.toolName === 'help') {
       const { addMessage } = useChatStore.getState()
-      const availableTools = getAvailableTools()
       addMessage({
         id: createMessageId(),
         role: 'user',

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -11,6 +11,7 @@ import { useSettingsStore } from '../../stores/settingsStore'
 import { CopyButton } from '../ui/copy-button'
 import { jumpToLine } from '../../lib/lineNavigation'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
+import { renderToolResult } from './toolResultRenderers'
 import avatarDark from '../../assets/avatar-dark.png'
 import avatarLight from '../../assets/avatar-light.png'
 
@@ -549,6 +550,12 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                           // Not JSON, ignore
                         }
                       }
+                      // Per-tool custom renderer if one is registered; falls
+                      // back to markdown (JSON in <pre>) for unknown tools.
+                      const customBody =
+                        part.name && part.content && part.success
+                          ? renderToolResult(part.name, part.content)
+                          : null
                       return (
                         <ToolCallIndicator
                           key={idx}
@@ -556,7 +563,7 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                           status={part.success ? 'success' : 'error'}
                           onClick={onClickHandler}
                         >
-                          {part.content && renderMarkdown(part.content, editor)}
+                          {customBody ?? (part.content && renderMarkdown(part.content, editor))}
                         </ToolCallIndicator>
                       )
                     }

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -15,16 +15,24 @@ import { renderToolResult } from './toolResultRenderers'
 import avatarDark from '../../assets/avatar-dark.png'
 import avatarLight from '../../assets/avatar-light.png'
 
+// Single source of truth for the "drafting" verb shown while the LLM is
+// composing tool arguments. Update here to tune copy app-wide.
+const DRAFTING_LABEL = 'Drafting'
+
+type ToolCallStatus = 'drafting' | 'executing' | 'success' | 'error'
+
 // Tool call indicator component with AI sparkle styling
-function ToolCallIndicator({ name, status, onClick, children, actions, defaultExpanded = false }: { name: string; status: 'executing' | 'success' | 'error'; onClick?: () => void; children?: React.ReactNode; actions?: React.ReactNode; defaultExpanded?: boolean }) {
+function ToolCallIndicator({ name, status, onClick, children, actions, defaultExpanded = false }: { name: string; status: ToolCallStatus; onClick?: () => void; children?: React.ReactNode; actions?: React.ReactNode; defaultExpanded?: boolean }) {
   const [expanded, setExpanded] = useState(defaultExpanded)
-  const hasBody = children != null && status !== 'executing'
+  // Drafting and executing are mid-flight states: no body to expand yet.
+  const hasBody = children != null && status !== 'executing' && status !== 'drafting'
   const hasActions = actions != null
 
   const toggleExpanded = (e: React.MouseEvent) => {
     e.stopPropagation()
     setExpanded(v => !v)
   }
+
 
   return (
     <div
@@ -36,11 +44,17 @@ function ToolCallIndicator({ name, status, onClick, children, actions, defaultEx
     >
       <div className={cn(
         "flex items-center gap-2 px-3 py-2 text-xs font-medium",
+        status === 'drafting' && "text-violet-600 dark:text-violet-400 bg-violet-500/5",
         status === 'executing' && "text-violet-600 dark:text-violet-400 bg-violet-500/5",
         status === 'success' && "text-emerald-600 dark:text-emerald-400 bg-emerald-500/5",
         status === 'error' && "text-red-600 dark:text-red-400 bg-red-500/5"
       )}>
-        {status === 'executing' ? (
+        {status === 'drafting' ? (
+          <>
+            <Sparkles className="h-3.5 w-3.5 animate-pulse" />
+            <span className="animate-pulse">{DRAFTING_LABEL} {name}…</span>
+          </>
+        ) : status === 'executing' ? (
           <>
             <Sparkles className="h-3.5 w-3.5 animate-pulse" />
             <span className="animate-pulse">{name}...</span>
@@ -82,9 +96,11 @@ function ToolCallIndicator({ name, status, onClick, children, actions, defaultEx
 }
 
 // Parse tool tags from content
-function parseToolTags(content: string): { type: 'text' | 'tool-executing' | 'tool-result' | 'tool-inline'; name?: string; success?: boolean; content: string }[] {
-  const parts: { type: 'text' | 'tool-executing' | 'tool-result' | 'tool-inline'; name?: string; success?: boolean; content: string }[] = []
+function parseToolTags(content: string): { type: 'text' | 'tool-drafting' | 'tool-executing' | 'tool-result' | 'tool-inline'; name?: string; success?: boolean; content: string }[] {
+  const parts: { type: 'text' | 'tool-drafting' | 'tool-executing' | 'tool-result' | 'tool-inline'; name?: string; success?: boolean; content: string }[] = []
 
+  // Match tool-drafting tags: <tool-drafting id="..." name="..."></tool-drafting>
+  const draftingRegex = /<tool-drafting id="([^"]+)" name="([^"]+)"><\/tool-drafting>/g
   // Match tool-executing tags
   const executingRegex = /<tool-executing name="([^"]+)">([^<]*)<\/tool-executing>/g
   // Match tool-result tags
@@ -92,28 +108,35 @@ function parseToolTags(content: string): { type: 'text' | 'tool-executing' | 'to
   // Match inline tool results from streaming: *[Tool: name] result*
   const inlineRegex = /\*\[Tool: ([^\]]+)\] ([^*]+)\*/g
 
-  let lastIndex = 0
   let remaining = content
 
-  // First pass: extract tool-executing
-  remaining = remaining.replace(executingRegex, (match, name, text, offset) => {
+  // First pass: extract tool-drafting
+  remaining = remaining.replace(draftingRegex, (_match, _id, name) => {
+    return `\x00TOOL_DRAFT:${name}\x00`
+  })
+
+  // Next pass: extract tool-executing
+  remaining = remaining.replace(executingRegex, (_match, name, text) => {
     return `\x00TOOL_EXEC:${name}:${text}\x00`
   })
 
-  // Second pass: extract tool-result
-  remaining = remaining.replace(resultRegex, (match, name, success, text) => {
+  // Next pass: extract tool-result
+  remaining = remaining.replace(resultRegex, (_match, name, success, text) => {
     return `\x00TOOL_RESULT:${name}:${success}:${text}\x00`
   })
 
-  // Third pass: extract inline tool results
-  remaining = remaining.replace(inlineRegex, (match, name, result) => {
+  // Next pass: extract inline tool results
+  remaining = remaining.replace(inlineRegex, (_match, name, result) => {
     return `\x00TOOL_INLINE:${name}:${result}\x00`
   })
 
   // Split and process
   const segments = remaining.split('\x00').filter(Boolean)
   for (const segment of segments) {
-    if (segment.startsWith('TOOL_EXEC:')) {
+    if (segment.startsWith('TOOL_DRAFT:')) {
+      const [, name] = segment.match(/TOOL_DRAFT:(.+)/) || []
+      parts.push({ type: 'tool-drafting', name, content: '' })
+    } else if (segment.startsWith('TOOL_EXEC:')) {
       const [, name, text] = segment.match(/TOOL_EXEC:([^:]+):(.*)/) || []
       parts.push({ type: 'tool-executing', name, content: text || '' })
     } else if (segment.startsWith('TOOL_RESULT:')) {
@@ -556,6 +579,11 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
               return (
                 <div className="prose-chat space-y-2 break-words">
                   {toolParts.map((part, idx) => {
+                    if (part.type === 'tool-drafting') {
+                      return (
+                        <ToolCallIndicator key={idx} name={part.name || 'tool'} status="drafting" />
+                      )
+                    }
                     if (part.type === 'tool-executing') {
                       return (
                         <ToolCallIndicator key={idx} name={part.name || 'tool'} status="executing" />

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { cn } from '../../lib/utils'
 import type { ChatMessage as ChatMessageType } from '../../types'
-import { User, Wand2, Check, AlertCircle, ArrowRight, Sparkles, CheckCircle2, XCircle, RotateCcw } from 'lucide-react'
+import { User, Wand2, Check, AlertCircle, ArrowRight, Sparkles, CheckCircle2, XCircle, RotateCcw, ChevronDown } from 'lucide-react'
 import { parseEditBlocks, hasEditBlocks, stripEditBlocks, type EditBlock } from '../../lib/editBlocks'
 import { applyEditsAsDiffs, applyEditsDirect, type ApplyResult, type EditProvenance } from '../../lib/applyEdit'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
@@ -16,7 +16,16 @@ import avatarDark from '../../assets/avatar-dark.png'
 import avatarLight from '../../assets/avatar-light.png'
 
 // Tool call indicator component with AI sparkle styling
-function ToolCallIndicator({ name, status, onClick, children }: { name: string; status: 'executing' | 'success' | 'error'; onClick?: () => void; children?: React.ReactNode }) {
+function ToolCallIndicator({ name, status, onClick, children, actions, defaultExpanded = false }: { name: string; status: 'executing' | 'success' | 'error'; onClick?: () => void; children?: React.ReactNode; actions?: React.ReactNode; defaultExpanded?: boolean }) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const hasBody = children != null && status !== 'executing'
+  const hasActions = actions != null
+
+  const toggleExpanded = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setExpanded(v => !v)
+  }
+
   return (
     <div
       className={cn(
@@ -39,18 +48,33 @@ function ToolCallIndicator({ name, status, onClick, children }: { name: string; 
         ) : status === 'success' ? (
           <>
             <CheckCircle2 className="h-3.5 w-3.5" />
-            <span>{name}</span>
+            <span className="flex-1">{name}</span>
           </>
         ) : (
           <>
             <XCircle className="h-3.5 w-3.5" />
-            <span>{name}</span>
+            <span className="flex-1">{name}</span>
           </>
         )}
+        {hasBody && (
+          <button
+            type="button"
+            onClick={toggleExpanded}
+            aria-label={expanded ? 'Collapse details' : 'Expand details'}
+            className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded text-current/70 hover:bg-current/10 hover:text-current focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current/40"
+          >
+            <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", !expanded && "-rotate-90")} />
+          </button>
+        )}
       </div>
-      {children && (
+      {hasBody && expanded && (
         <div className="px-3 py-2 text-xs font-mono text-muted-foreground border-t border-border bg-muted/10 max-h-48 overflow-auto">
           {children}
+        </div>
+      )}
+      {hasActions && (
+        <div className="px-3 py-2 border-t border-border bg-muted/5" onClick={(e) => e.stopPropagation()}>
+          {actions}
         </div>
       )}
     </div>
@@ -552,9 +576,13 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                       }
                       // Per-tool custom renderer if one is registered; falls
                       // back to markdown (JSON in <pre>) for unknown tools.
-                      const customBody =
+                      // ctx scopes per-tool-call state (e.g., the
+                      // mode-switch acted/dismissed flag) into the owning
+                      // message's toolActions map, so it persists with the
+                      // conversation.
+                      const custom =
                         part.name && part.content && part.success
-                          ? renderToolResult(part.name, part.content)
+                          ? renderToolResult(part.name, part.content, { messageId: message.id, toolPartIdx: idx })
                           : null
                       return (
                         <ToolCallIndicator
@@ -562,8 +590,10 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
                           name={part.name || 'tool'}
                           status={part.success ? 'success' : 'error'}
                           onClick={onClickHandler}
+                          actions={custom?.actions}
+                          defaultExpanded={custom?.defaultExpanded}
                         >
-                          {customBody ?? (part.content && renderMarkdown(part.content, editor))}
+                          {custom?.body ?? (part.content && renderMarkdown(part.content, editor))}
                         </ToolCallIndicator>
                       )
                     }

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -20,6 +20,7 @@ import { useSummaryStore } from '../../stores/summaryStore'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { ReviewContainer } from '../review/ReviewContainer'
+import { MODE_SWITCH_RUN_EVENT } from './toolResultRenderers/RequestModeSwitchResult'
 import { cn } from '../../lib/utils'
 
 export function ChatPanel() {
@@ -64,6 +65,20 @@ export function ChatPanel() {
       generateSummary(document.documentId, content)
     }
   }, [infoOpen, summary, isStale, isGenerating, hasApiKey, document.documentId, generateSummary])
+
+  // Listen for the "Switch & Run" button in request_mode_switch tool
+  // results. Renderer dispatches a CustomEvent so it doesn't have to
+  // own a useChat reference; we send the agent's suggested prompt here.
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ prompt: string }>).detail
+      if (detail?.prompt) {
+        sendMessage(detail.prompt)
+      }
+    }
+    window.addEventListener(MODE_SWITCH_RUN_EVENT, handler)
+    return () => window.removeEventListener(MODE_SWITCH_RUN_EVENT, handler)
+  }, [sendMessage])
 
   // Track pending suggestion count
   const suggestionCount = useMemo(() => {

--- a/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { FileTree } from '../../files/FileTree'
+import { useTabs } from '../../../hooks/useTabs'
+import { useFileListStore } from '../../../stores/fileListStore'
+import type { FileItem } from '../../../types'
+
+interface ListFilesResultProps {
+  content: string
+}
+
+interface ListFilesPayload {
+  files: FileItem[]
+  truncated?: boolean
+  totalFound?: number
+}
+
+interface ListFilesEnvelope extends Partial<ListFilesPayload> {
+  data?: ListFilesPayload
+}
+
+/**
+ * The tool-result string may arrive either as the raw payload
+ * `{ files: [...] }` or wrapped in a `{ data: { files } }` envelope,
+ * depending on whether the renderer is invoked from a live tool call
+ * (envelope) or a parsed-from-markdown rehydration (raw). Accept both.
+ *
+ * Error envelopes never reach here — ChatMessage only invokes the
+ * renderer when `part.success === true`. Failures fall back to the
+ * markdown render path.
+ */
+function extractPayload(env: ListFilesEnvelope): ListFilesPayload {
+  if (env.data?.files) return env.data
+  if (env.files) return { files: env.files, truncated: env.truncated, totalFound: env.totalFound }
+  return { files: [] }
+}
+
+/**
+ * Custom renderer for the `list_files` tool result.
+ * Replaces the default JSON-in-a-pre-block render with the same FileTree
+ * component the file explorer side panel uses — single-click opens the
+ * file in a preview tab, folders toggle expand/collapse via local state.
+ *
+ * The tool result content arrives as a JSON string (possibly wrapped in
+ * markdown code fences). We parse defensively and fall back to a textual
+ * apology + raw content dump if the shape changes unexpectedly.
+ */
+export function ListFilesResult({ content }: ListFilesResultProps) {
+  // Seed the chat-side tree with the same folders the file explorer panel
+  // currently has open, so the user sees a matching shape on first render.
+  // After this snapshot the chat tree's expansion is independent — clicking
+  // folders here doesn't propagate back to the side panel.
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
+    () => new Set(useFileListStore.getState().expandedFolders)
+  )
+  const { openFileInPreviewTab } = useTabs()
+
+  let parsed: ListFilesEnvelope | null = null
+  try {
+    const cleaned = content.replace(/```json\n?|\n?```/g, '').trim()
+    parsed = JSON.parse(cleaned) as ListFilesEnvelope
+  } catch {
+    return (
+      <div className="text-xs text-muted-foreground">
+        <div className="mb-1">Unable to parse file list result.</div>
+        <pre className="text-[10px] overflow-x-auto whitespace-pre-wrap">{content}</pre>
+      </div>
+    )
+  }
+
+  const payload = parsed ? extractPayload(parsed) : { files: [] }
+  const files = payload.files
+  if (files.length === 0) {
+    return <div className="text-xs text-muted-foreground">No files.</div>
+  }
+
+  const handleFolderToggle = (path: string) => {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
+
+  const handleFileClick = async (path: string) => {
+    await openFileInPreviewTab(path)
+  }
+
+  return (
+    <div className="text-xs">
+      <FileTree
+        items={files}
+        expandedFolders={expandedFolders}
+        selectedPath={null}
+        onFileClick={handleFileClick}
+        onFolderToggle={handleFolderToggle}
+      />
+      {payload.truncated && payload.totalFound !== undefined && (
+        <div className="mt-2 text-[11px] text-muted-foreground">
+          (showing {files.length} of {payload.totalFound} files)
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/RequestModeSwitchResult.tsx
@@ -1,0 +1,164 @@
+import { Button } from '../../ui/button'
+import { ArrowRightIcon, RefreshCwIcon, XIcon } from 'lucide-react'
+import { useChatStore } from '../../../stores/chatStore'
+import type { ToolMode } from '../../../../shared/tools/types'
+
+interface RequestModeSwitchPayload {
+  target: ToolMode
+  reason: string
+  prompt_to_retry: string
+}
+
+interface BodyProps {
+  content: string
+}
+
+interface ActionsProps {
+  content: string
+  /** Owning message ID — used to read/write `toolActions[toolPartIdx]`. */
+  messageId: string
+  /** Index of this tool result inside the message's parsed tool parts. */
+  toolPartIdx: number
+}
+
+const MODE_LABEL: Record<ToolMode, string> = {
+  chat: 'Chat',
+  editor: 'Editor',
+  create: 'Create'
+}
+
+const MODE_SWITCH_RUN_EVENT = 'prose:mode-switch-and-run'
+
+function parsePayload(content: string): RequestModeSwitchPayload | null {
+  try {
+    const cleaned = content.replace(/```json\n?|\n?```/g, '').trim()
+    const parsed = JSON.parse(cleaned)
+    if (parsed && typeof parsed === 'object' && 'data' in parsed && parsed.data && typeof parsed.data === 'object') {
+      return parsed.data as RequestModeSwitchPayload
+    }
+    if (parsed && typeof parsed === 'object' && 'target' in parsed) {
+      return parsed as RequestModeSwitchPayload
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+/**
+ * Body slot: the reason and prompt_to_retry quote. Rendered inside the
+ * collapsible body area of the tool-call shell.
+ */
+export function RequestModeSwitchBody({ content }: BodyProps) {
+  const payload = parsePayload(content)
+  if (!payload) {
+    return (
+      <div className="text-xs text-muted-foreground">
+        <div className="mb-1">Unable to parse mode-switch request.</div>
+        <pre className="text-[10px] overflow-x-auto whitespace-pre-wrap">{content}</pre>
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-2">
+      <div className="text-xs text-foreground">{payload.reason}</div>
+      <div className="rounded-md border border-border bg-background/50 p-2 text-xs italic text-muted-foreground">
+        &ldquo;{payload.prompt_to_retry}&rdquo;
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Actions slot: the Switch & Run / Just Switch / Cancel buttons. Always
+ * visible (outside the collapsible body region). Mode changes never
+ * happen without an explicit user click.
+ *
+ * Action state (switched | dismissed) lives on the owning message as
+ * `toolActions[toolPartIdx]`, persisted with the conversation. That
+ * way reopening the chat shows a truthful record of past decisions
+ * instead of re-clickable buttons for a "Switch & Run" that already
+ * fired three messages ago.
+ *
+ * sendMessage is dispatched via a CustomEvent so this renderer doesn't
+ * have to be a useChat consumer. ChatPanel listens for the event and
+ * calls its local sendMessage.
+ */
+export function RequestModeSwitchActions({ content, messageId, toolPartIdx }: ActionsProps) {
+  const action = useChatStore(
+    (s) => s.messages.find((m) => m.id === messageId)?.toolActions?.[toolPartIdx]
+  )
+  const setToolMode = useChatStore((s) => s.setToolMode)
+  const setToolCallAction = useChatStore((s) => s.setToolCallAction)
+  const payload = parsePayload(content)
+  if (!payload) return null
+
+  const { target, prompt_to_retry } = payload
+  const acted = action != null
+
+  const handleJustSwitch = () => {
+    setToolMode(target)
+    setToolCallAction(messageId, toolPartIdx, 'switched')
+  }
+
+  const handleSwitchAndRun = () => {
+    setToolMode(target)
+    setToolCallAction(messageId, toolPartIdx, 'switched')
+    window.dispatchEvent(
+      new CustomEvent(MODE_SWITCH_RUN_EVENT, { detail: { prompt: prompt_to_retry } })
+    )
+  }
+
+  const handleCancel = () => {
+    setToolCallAction(messageId, toolPartIdx, 'dismissed')
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant="default"
+          disabled={acted}
+          onClick={handleSwitchAndRun}
+          className="h-7 text-xs"
+        >
+          <RefreshCwIcon className="mr-1 h-3 w-3" />
+          Switch to {MODE_LABEL[target]} &amp; Run
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={acted}
+          onClick={handleJustSwitch}
+          className="h-7 text-xs"
+        >
+          <ArrowRightIcon className="mr-1 h-3 w-3" />
+          Just Switch
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={acted}
+          onClick={handleCancel}
+          className="h-7 text-xs"
+        >
+          <XIcon className="mr-1 h-3 w-3" />
+          Cancel
+        </Button>
+      </div>
+      {action === 'switched' && (
+        <div className="text-[11px] text-muted-foreground">
+          Switched to {MODE_LABEL[target]} Mode.
+        </div>
+      )}
+      {action === 'dismissed' && (
+        <div className="text-[11px] text-muted-foreground">
+          Dismissed.
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { MODE_SWITCH_RUN_EVENT }

--- a/src/renderer/components/chat/toolResultRenderers/index.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/index.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+import { ListFilesResult } from './ListFilesResult'
+
+/**
+ * Per-tool result renderer registry. Keyed by the tool name; each entry
+ * returns a React node that replaces the default `renderMarkdown` output
+ * (which dumps JSON inside a `<pre>` code block).
+ *
+ * Unknown tools return null from `renderToolResult` and the caller falls
+ * back to the default markdown render.
+ *
+ * Adding a renderer: write the component under
+ * `src/renderer/components/chat/toolResultRenderers/<Name>.tsx`, import
+ * it here, add the entry to `toolResultRenderers`. Components receive
+ * the raw `content` string and are responsible for parsing it (the
+ * content is typically a JSON-stringified `ToolResult<T>` envelope,
+ * sometimes wrapped in markdown code fences).
+ */
+
+type ToolResultRenderer = (content: string) => ReactNode
+
+const toolResultRenderers: Record<string, ToolResultRenderer> = {
+  list_files: (content) => <ListFilesResult content={content} />
+}
+
+export function renderToolResult(name: string, content: string): ReactNode | null {
+  const renderer = toolResultRenderers[name]
+  return renderer ? renderer(content) : null
+}

--- a/src/renderer/components/chat/toolResultRenderers/index.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/index.tsx
@@ -1,29 +1,62 @@
 import type { ReactNode } from 'react'
 import { ListFilesResult } from './ListFilesResult'
+import { RequestModeSwitchBody, RequestModeSwitchActions } from './RequestModeSwitchResult'
 
 /**
- * Per-tool result renderer registry. Keyed by the tool name; each entry
- * returns a React node that replaces the default `renderMarkdown` output
- * (which dumps JSON inside a `<pre>` code block).
+ * Per-tool result renderer registry. Keyed by tool name; each entry
+ * returns `{ body?, actions? }`:
+ *   - `body` replaces the default `renderMarkdown` output (which dumps
+ *     JSON inside a `<pre>` code block) and lives inside the
+ *     collapsible/scrollable region of the tool-call shell.
+ *   - `actions` (optional) lives outside the collapsible region and
+ *     stays visible regardless of expansion state. Use for affordances
+ *     the user shouldn't have to expand to find (e.g., one-click
+ *     mode-switch buttons).
  *
- * Unknown tools return null from `renderToolResult` and the caller falls
- * back to the default markdown render.
+ * `ctx` exposes `messageId` + `toolPartIdx` so actions can persist
+ * their interaction state into the owning message's `toolActions` map
+ * (saved with the conversation).
  *
- * Adding a renderer: write the component under
+ * Unknown tools return `null` and the caller falls back to the default
+ * markdown render in the body slot.
+ *
+ * Adding a renderer: write the component(s) under
  * `src/renderer/components/chat/toolResultRenderers/<Name>.tsx`, import
- * it here, add the entry to `toolResultRenderers`. Components receive
- * the raw `content` string and are responsible for parsing it (the
- * content is typically a JSON-stringified `ToolResult<T>` envelope,
- * sometimes wrapped in markdown code fences).
+ * here, add the entry. The body component is responsible for parsing
+ * the raw `content` string (typically a JSON-stringified
+ * `ToolResult<T>` envelope, sometimes wrapped in markdown code fences).
  */
 
-type ToolResultRenderer = (content: string) => ReactNode
-
-const toolResultRenderers: Record<string, ToolResultRenderer> = {
-  list_files: (content) => <ListFilesResult content={content} />
+export interface ToolResultSlots {
+  body?: ReactNode
+  actions?: ReactNode
+  /**
+   * Initial expand state for the collapsible body. Defaults to false
+   * (collapsed) so noisy JSON dumps stay out of the way. Set to true
+   * for tools where the body content is the point of the response and
+   * the user shouldn't have to hunt for it (e.g., `request_mode_switch`
+   * — the reason and prompt-to-retry quote are the substance).
+   */
+  defaultExpanded?: boolean
 }
 
-export function renderToolResult(name: string, content: string): ReactNode | null {
+export interface ToolResultContext {
+  messageId: string
+  toolPartIdx: number
+}
+
+type ToolResultRenderer = (content: string, ctx: ToolResultContext) => ToolResultSlots
+
+const toolResultRenderers: Record<string, ToolResultRenderer> = {
+  list_files: (content) => ({ body: <ListFilesResult content={content} /> }),
+  request_mode_switch: (content, ctx) => ({
+    body: <RequestModeSwitchBody content={content} />,
+    actions: <RequestModeSwitchActions content={content} messageId={ctx.messageId} toolPartIdx={ctx.toolPartIdx} />,
+    defaultExpanded: true
+  })
+}
+
+export function renderToolResult(name: string, content: string, ctx: ToolResultContext): ToolResultSlots | null {
   const renderer = toolResultRenderers[name]
-  return renderer ? renderer(content) : null
+  return renderer ? renderer(content, ctx) : null
 }

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -24,6 +24,7 @@ import { SearchHighlight } from '../../extensions/search-highlight'
 import { LinkHover } from '../../extensions/link-hover'
 import { PlainTextMode } from '../../extensions/plain-text-mode'
 import { ImageWithUpload } from '../../extensions/image'
+import { PersistentSelection } from '../../extensions/persistent-selection'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
@@ -194,6 +195,7 @@ export function Editor() {
           class: 'editor-image'
         }
       }),
+      PersistentSelection,
     ],
     content: initialContent,
     editorProps: {

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -60,7 +60,7 @@ export function Editor() {
   const sourceMode = useEditorStore((state) => state.sourceMode)
   const setSourceMode = useEditorStore((state) => state.setSourceMode)
   const { settings, setDialogOpen, setShortcutsDialogOpen, setModelPickerOpen } = useSettings()
-  const { setContext, agentMode, setAgentMode } = useChat()
+  const { setContext, cycleToolMode } = useChat()
   const { isChatOpen, isFileListOpen, toggleChat, toggleFileList, setChatOpen, setFileListOpen } = usePanelLayoutContext()
   const setEditorInstance = useEditorInstanceStore((state) => state.setEditor)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -643,9 +643,11 @@ export function Editor() {
       e.preventDefault()
       setShortcutsDialogOpen(true)
     } else if (e.shiftKey && e.key === 'Tab' && !isMod) {
-      // Shift+Tab: Toggle agent mode
+      // Shift+Tab: Cycle through tool modes (chat → editor → create → chat).
+      // Editor must be reachable via keyboard — it's the new safe-by-default
+      // mode, and the previous binary agentMode toggle skipped it.
       e.preventDefault()
-      setAgentMode(!agentMode)
+      cycleToolMode()
     } else if (isMod && e.key === 'k' && !e.shiftKey) {
       // Cmd+K: Insert/edit link
       e.preventDefault()
@@ -734,7 +736,7 @@ export function Editor() {
         }
       }
     }
-  }, [openFile, saveFile, setDialogOpen, setShortcutsDialogOpen, setModelPickerOpen, editor, setContext, setChatOpen, setFileListOpen, toggleChat, toggleFileList, isChatOpen, isFileListOpen, isFindOpen, openAddCommentDialog, openLinkPopover, agentMode, setAgentMode, toggleAnnotationsVisible])
+  }, [openFile, saveFile, setDialogOpen, setShortcutsDialogOpen, setModelPickerOpen, editor, setContext, setChatOpen, setFileListOpen, toggleChat, toggleFileList, isChatOpen, isFileListOpen, isFindOpen, openAddCommentDialog, openLinkPopover, cycleToolMode, toggleAnnotationsVisible])
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown)

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -899,7 +899,7 @@ export function App() {
     const unsubscribe = window.api.onMcpToolInvoke(async (requestId, toolName, args) => {
       try {
         const documentId = useEditorStore.getState().document.documentId
-        const result = await executeTool(toolName, args, 'full', {
+        const result = await executeTool(toolName, args, 'create', {
           model: 'Claude (MCP)',
           conversationId: requestId,
           messageId: requestId,

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useEffect, useRef, useState } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
@@ -26,9 +26,48 @@ const isMacKeyboard =
 
 export function StatusBar() {
   const { document, cursorPosition } = useEditor()
-  const { settings, autosaveActive, setLLMConfig, saveSettings } = useSettings()
+  const { settings, isLoaded: settingsLoaded, autosaveActive, setLLMConfig, saveSettings } = useSettings()
   const { toolMode, setToolMode } = useChat()
   const isRemarkableReadOnly = useEditorStore((state) => state.isRemarkableReadOnly)
+
+  // Track whether the upcoming toolMode change was initiated by a user click on
+  // the mode chip (no cue needed) vs. a programmatic change (pulse to signal it).
+  const userInitiatedRef = useRef(false)
+  // Suppress pulse on the initial settings-boot hydration (first load applies the
+  // persisted value silently; only subsequent in-session programmatic changes pulse).
+  const suppressNextPulseRef = useRef(true)
+  const [modeChipPulse, setModeChipPulse] = useState(false)
+  const prevToolModeRef = useRef(toolMode)
+
+  // Once settings finish loading for the first time, clear the boot-suppression
+  // flag so subsequent programmatic changes can pulse.
+  const settingsLoadedRef = useRef(false)
+  useEffect(() => {
+    if (settingsLoaded && !settingsLoadedRef.current) {
+      settingsLoadedRef.current = true
+      // Allow one toolMode change (the boot hydration) to pass silently, then
+      // lift the suppression on the next tick so real programmatic changes pulse.
+      setTimeout(() => { suppressNextPulseRef.current = false }, 0)
+    }
+  }, [settingsLoaded])
+
+  useEffect(() => {
+    if (toolMode === prevToolModeRef.current) return
+    prevToolModeRef.current = toolMode
+    if (userInitiatedRef.current) {
+      // User clicked the chip — clear the flag, no visual cue needed
+      userInitiatedRef.current = false
+      return
+    }
+    if (suppressNextPulseRef.current) {
+      // Boot-time hydration — suppress silently
+      return
+    }
+    // Programmatic change — briefly pulse the mode chip
+    setModeChipPulse(true)
+    const timer = setTimeout(() => setModeChipPulse(false), 1500)
+    return () => clearTimeout(timer)
+  }, [toolMode])
   const isAutosaving = useEditorStore((state) => state.isAutosaving)
   const sourceMode = useEditorStore((state) => state.sourceMode)
   const toggleSourceMode = useEditorStore((state) => state.toggleSourceMode)
@@ -179,7 +218,7 @@ export function StatusBar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer">
+                <button className={`hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer${modeChipPulse ? ' animate-pulse text-primary' : ''}`}>
                   {currentMode.label}
                 </button>
               </DropdownMenuTrigger>
@@ -193,7 +232,10 @@ export function StatusBar() {
               ([mode, config]) => (
                 <DropdownMenuItem
                   key={mode}
-                  onClick={() => setToolMode(mode)}
+                  onClick={() => {
+                    userInitiatedRef.current = true
+                    setToolMode(mode)
+                  }}
                   className="cursor-pointer font-mono text-xs"
                 >
                   <span className="flex-1">{config.label}</span>

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -49,16 +49,12 @@ export function StatusBar() {
   const charCount = document.content.length
 
   // Mode configuration.
-  // Internal keys stay as suggestions / plan / full until Chunk 3 of #467
-  // renames the ToolMode union after #450 merges. Labels reflect the
-  // target Chat / Editor / Create posture.
-  // The (default) marker on Editor will return when Chunk 3 flips
-  // chatStore's initial toolMode from 'full' to 'plan' — until then,
-  // claiming it here would mislead new users (who land in Create today).
+  // ToolMode union renamed to chat / editor / create in #467 Chunk 3.
+  // Editor is the actual default — chatStore initializes new users into it.
   const modeConfig: Record<ToolMode, { label: string; description: string }> = {
-    suggestions: { label: 'chat', description: 'Read-only — sounding board, fact-check, no edits' },
-    plan: { label: 'editor', description: 'Proposes copy edits and editorial notes' },
-    full: { label: 'create', description: 'Drafts and applies edits directly' }
+    chat: { label: 'chat', description: 'Read-only — sounding board, fact-check, no edits' },
+    editor: { label: 'editor', description: 'Proposes copy edits and editorial notes (default)' },
+    create: { label: 'create', description: 'Drafts and applies edits directly (opt-in)' }
   }
 
   const currentMode = modeConfig[toolMode]

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -48,11 +48,17 @@ export function StatusBar() {
 
   const charCount = document.content.length
 
-  // Mode configuration
+  // Mode configuration.
+  // Internal keys stay as suggestions / plan / full until Chunk 3 of #467
+  // renames the ToolMode union after #450 merges. Labels reflect the
+  // target Chat / Editor / Create posture.
+  // The (default) marker on Editor will return when Chunk 3 flips
+  // chatStore's initial toolMode from 'full' to 'plan' — until then,
+  // claiming it here would mislead new users (who land in Create today).
   const modeConfig: Record<ToolMode, { label: string; description: string }> = {
-    suggestions: { label: 'suggest edits', description: 'AI suggests changes for review' },
-    full: { label: 'accept edits', description: 'AI applies changes directly' },
-    plan: { label: 'plan', description: 'Review changes before applying' }
+    suggestions: { label: 'chat', description: 'Read-only — sounding board, fact-check, no edits' },
+    plan: { label: 'editor', description: 'Proposes copy edits and editorial notes' },
+    full: { label: 'create', description: 'Drafts and applies edits directly' }
   }
 
   const currentMode = modeConfig[toolMode]

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -95,7 +95,7 @@ export function StatusBar() {
       <div className="flex items-center gap-1">
         <button
           onClick={toggleSourceMode}
-          className="hover:text-foreground transition-colors cursor-pointer"
+          className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer"
         >
           {sourceMode ? 'source' : 'wysiwyg'}
         </button>
@@ -120,7 +120,7 @@ export function StatusBar() {
               <TooltipTrigger asChild>
                 <button
                   onClick={() => useReviewStore.getState().setReviewMode('quick')}
-                  className="text-violet-600 dark:text-violet-400 hover:text-violet-500 transition-colors cursor-pointer"
+                  className="text-violet-600 dark:text-violet-400 hover:text-violet-500 focus-visible:text-violet-500 focus-visible:outline-none transition-colors cursor-pointer"
                 >
                   {suggestionCount} suggestion{suggestionCount !== 1 ? 's' : ''}
                 </button>
@@ -138,7 +138,7 @@ export function StatusBar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <button className="hover:text-foreground transition-colors cursor-pointer max-w-[120px] truncate">
+                <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer max-w-[120px] truncate">
                   {modelDisplayName}
                 </button>
               </DropdownMenuTrigger>
@@ -179,7 +179,7 @@ export function StatusBar() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <button className="hover:text-foreground transition-colors cursor-pointer">
+                <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer">
                   {currentMode.label}
                 </button>
               </DropdownMenuTrigger>

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -486,6 +486,25 @@ export function SettingsDialog() {
                 </SelectContent>
               </Select>
             </div>
+
+            <Separator />
+
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1 flex-1">
+                <Label htmlFor="streamingEdits">Stream agent edits</Label>
+                <p className="text-xs text-muted-foreground">
+                  When the assistant writes into your document, reveal the text
+                  word-by-word over a fraction of a second instead of pasting it
+                  all at once. Automatically disabled if your system is set to
+                  reduce motion.
+                </p>
+              </div>
+              <Switch
+                id="streamingEdits"
+                checked={settings.editor.streamingEdits ?? true}
+                onCheckedChange={(checked) => setEditorConfig({ streamingEdits: checked })}
+              />
+            </div>
           </TabsContent>
 
           <TabsContent value="llm" className="space-y-4 mt-4 overflow-y-auto flex-1 px-1 -mx-1" ref={llmTabRef}>

--- a/src/renderer/extensions/ai-annotations/plugin.ts
+++ b/src/renderer/extensions/ai-annotations/plugin.ts
@@ -34,7 +34,12 @@ function showTooltip(annotation: AIAnnotation, event: MouseEvent) {
   tooltip.className = 'ai-annotation-tooltip'
 
   const ageString = formatAge(annotation.createdAt)
-  const typeLabel = annotation.type === 'insertion' ? 'AI Insertion' : 'AI Replacement'
+  const typeLabel =
+    annotation.type === 'insertion'
+      ? 'AI Insertion'
+      : annotation.type === 'deletion'
+        ? 'AI Deletion'
+        : 'AI Replacement'
 
   const header = document.createElement('div')
   header.className = 'ai-annotation-tooltip-header'

--- a/src/renderer/extensions/persistent-selection/index.ts
+++ b/src/renderer/extensions/persistent-selection/index.ts
@@ -1,0 +1,102 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+/**
+ * Persistent visual selection across focus changes.
+ *
+ * Native browser `::selection` highlighting is suppressed the moment the
+ * editor loses focus (e.g., user clicks into the chat input). That makes
+ * tools like `read_selection` opaque — you can't see what's about to be
+ * read. This extension paints an inline ProseMirror decoration over the
+ * selection range while the editor is blurred, so the highlight persists
+ * visually. When the editor regains focus, the decoration clears and
+ * native `::selection` takes over.
+ *
+ * The decoration class `.persistent-selection` is styled in
+ * `src/renderer/index.css` to match the global `::selection` background.
+ */
+
+interface PersistentSelectionState {
+  isBlurred: boolean
+  from: number | null
+  to: number | null
+}
+
+const persistentSelectionKey = new PluginKey<PersistentSelectionState>('persistentSelection')
+
+export const PersistentSelection = Extension.create({
+  name: 'persistentSelection',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<PersistentSelectionState>({
+        key: persistentSelectionKey,
+        state: {
+          init(): PersistentSelectionState {
+            return { isBlurred: false, from: null, to: null }
+          },
+          apply(tr, prev): PersistentSelectionState {
+            const meta = tr.getMeta(persistentSelectionKey) as PersistentSelectionState | undefined
+            if (meta) {
+              return meta
+            }
+            // Map stored range across doc edits so the decoration stays
+            // attached to the right span even if the doc is mutated while
+            // the editor is blurred (e.g., agent applies an edit).
+            if (prev.from !== null && prev.to !== null && tr.docChanged) {
+              return {
+                isBlurred: prev.isBlurred,
+                from: tr.mapping.map(prev.from),
+                to: tr.mapping.map(prev.to)
+              }
+            }
+            return prev
+          }
+        },
+        props: {
+          decorations(state) {
+            const pluginState = persistentSelectionKey.getState(state)
+            if (
+              !pluginState ||
+              !pluginState.isBlurred ||
+              pluginState.from === null ||
+              pluginState.to === null ||
+              pluginState.from === pluginState.to
+            ) {
+              return DecorationSet.empty
+            }
+            return DecorationSet.create(state.doc, [
+              Decoration.inline(pluginState.from, pluginState.to, {
+                class: 'persistent-selection'
+              })
+            ])
+          },
+          handleDOMEvents: {
+            blur(view) {
+              const { from, to } = view.state.selection
+              view.dispatch(
+                view.state.tr.setMeta(persistentSelectionKey, {
+                  isBlurred: true,
+                  from: from === to ? null : from,
+                  to: from === to ? null : to
+                } satisfies PersistentSelectionState)
+              )
+              return false
+            },
+            focus(view) {
+              view.dispatch(
+                view.state.tr.setMeta(persistentSelectionKey, {
+                  isBlurred: false,
+                  from: null,
+                  to: null
+                } satisfies PersistentSelectionState)
+              )
+              return false
+            }
+          }
+        }
+      })
+    ]
+  }
+})

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -33,7 +33,11 @@ const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'get_metadata',
   'search_document',
   'get_outline',
-  'list_comments'
+  'list_comments',
+  // UX coordination: lets the agent offer the user a one-click mode
+  // switch when their request is out of scope for the current mode.
+  // It doesn't read or mutate anything — just renders a button.
+  'request_mode_switch'
 ])
 
 function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
@@ -86,6 +90,15 @@ const toolLoopContextRef = {
     assistantMsgId: string
     roundtripCount: number
     lastErrorSignature: string | null
+    // True if the turn started with a mode switch (Switch & Run or
+    // StatusBar toggle between sends). Propagates through every
+    // tool-loop continuation in the turn so the "you just switched"
+    // notice stays on the system prompt — without it, continuations
+    // after a legitimate read_document call lose the notice and the
+    // LLM pattern-matches against prior-mode assistant messages,
+    // hallucinating "I'm still in <old> Mode" despite the tool list
+    // and per-mode instructions reflecting the new mode.
+    modeJustSwitched: boolean
   } | null,
   streamId: null as string | null
 }
@@ -291,14 +304,22 @@ export function useChat() {
             currentErrorSignature = `${toolCall.name}:${result.error}`
           }
 
-          // Append tool execution info to the message
-          const resultSummary = result.success
-            ? (typeof result.data === 'string' ? result.data.slice(0, 100) : 'Success')
+          // Append tool execution info to the message using the same
+          // <tool-result> tag format as user-initiated slash commands.
+          // This unifies both paths so custom renderers in
+          // src/renderer/components/chat/toolResultRenderers/ get the
+          // full structured payload regardless of who triggered the
+          // tool call. Tools without a custom renderer fall back to
+          // the markdown render of the JSON, matching slash-command UX.
+          const resultText = result.success
+            ? (typeof result.data === 'string'
+                ? result.data
+                : '```json\n' + JSON.stringify(result.data, null, 2) + '\n```')
             : `Error: ${result.error}`
           state.updateMessage(assistantMsgId, {
             content:
               state.messages.find((m) => m.id === assistantMsgId)?.content +
-              `\n\n*[Tool: ${toolCall.name}] ${resultSummary}*`
+              `\n\n<tool-result name="${toolCall.name}" success="${result.success}">${resultText}</tool-result>`
           })
 
           // Add tool result message to API messages (summarized to reduce context)
@@ -326,12 +347,16 @@ export function useChat() {
         const newStreamId = createMessageId()
         state.startStreaming(assistantMsgId, newStreamId)
 
-        // Update context for potential next tool loop with new streamId
+        // Update context for potential next tool loop with new streamId.
+        // Preserve `modeJustSwitched` across the whole turn so subsequent
+        // continuations keep the "you just switched" notice.
+        const priorTurnContext = toolLoopContextRef.current
         toolLoopContextRef.current = {
           apiMessages: updatedMessages,
           assistantMsgId,
           roundtripCount: roundtripCount + 1,
-          lastErrorSignature: currentErrorSignature
+          lastErrorSignature: currentErrorSignature,
+          modeJustSwitched: priorTurnContext?.modeJustSwitched ?? false
         }
         toolLoopContextRef.streamId = newStreamId
         pendingToolCallsRef.streamId = newStreamId
@@ -349,6 +374,11 @@ export function useChat() {
         if (loopModeJustSwitched) {
           state.setLastSentToolMode(state.toolMode)
         }
+        // The notice fires if the turn started with a switch (Switch &
+        // Run or pre-send StatusBar toggle) OR if the user toggled mode
+        // mid-loop. Either way we want the grounding text in the prompt.
+        const continuationModeJustSwitched =
+          toolLoopContextRef.current.modeJustSwitched || loopModeJustSwitched
 
         try {
           await api.llmChatStream({
@@ -362,7 +392,7 @@ export function useChat() {
               state.toolMode,
               editorState.document.path,
               resolveModelName(settingsState.settings.llm.model, settingsState.fetchedModels),
-              loopModeJustSwitched
+              continuationModeJustSwitched
             ),
             streamId: newStreamId,
             tools,
@@ -430,6 +460,13 @@ export function useChat() {
       console.log('[useChat] sendMessage called with:', content?.substring(0, 50), 'isLoading:', isLoading)
       if (!content.trim() || isLoading) return
       console.log('[useChat] sendMessage passed initial check')
+      // Read toolMode fresh from the store rather than relying on the
+      // React-closure-captured value. Necessary because callers (notably
+      // RequestModeSwitchActions' "Switch & Run" path) may setToolMode
+      // and then synchronously dispatch sendMessage in the same tick —
+      // React hasn't re-rendered yet, and the captured `toolMode` would
+      // be stale. Reading from the store always reflects the latest.
+      const toolMode = useChatStore.getState().toolMode
 
       // Auto-create a conversation if there isn't one
       if (!activeConversationId) {
@@ -536,18 +573,6 @@ export function useChat() {
         console.error('[useChat] Error getting tools:', toolErr)
         tools = undefined
       }
-      if (tools && tools.length > 0) {
-        toolLoopContextRef.current = {
-          apiMessages,
-          assistantMsgId,
-          roundtripCount: 0,
-          lastErrorSignature: null
-        }
-        toolLoopContextRef.streamId = streamId
-        pendingToolCallsRef.streamId = streamId
-      }
-
-      console.log('[useChat] About to call llmChatStream')
       // Detect mid-conversation mode switches so we can prepend a one-line
       // note to the system prompt. Idempotent across multiple toggles:
       // only the diff at send time matters, and we update lastSentToolMode
@@ -556,6 +581,20 @@ export function useChat() {
       const lastSent = useChatStore.getState().lastSentToolMode
       const modeJustSwitched = lastSent !== null && lastSent !== toolMode
       useChatStore.getState().setLastSentToolMode(toolMode)
+
+      if (tools && tools.length > 0) {
+        toolLoopContextRef.current = {
+          apiMessages,
+          assistantMsgId,
+          roundtripCount: 0,
+          lastErrorSignature: null,
+          modeJustSwitched
+        }
+        toolLoopContextRef.streamId = streamId
+        pendingToolCallsRef.streamId = streamId
+      }
+
+      console.log('[useChat] About to call llmChatStream')
       try {
         // Call streaming LLM (via Electron IPC or browser fallback)
         const api = getApi()

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -266,7 +266,7 @@ export function useChat() {
 
         // Sort editor-mutating tool calls by document position (descending)
         // so bottom-of-document edits execute first and don't shift positions above
-        const EDITOR_MUTATING_TOOLS = new Set(['edit', 'insert', 'suggest_edit'])
+        const EDITOR_MUTATING_TOOLS = new Set(['edit', 'insert', 'suggest_edit', 'delete_node'])
         const sortedToolCalls = [...toolCalls]
         if (sortedToolCalls.some(tc => EDITOR_MUTATING_TOOLS.has(tc.name))) {
           // Pre-resolve positions before any edits execute

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -13,16 +13,15 @@ import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import { resolveModelName } from '../../shared/llm/models'
 import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
 
-// Chat Mode (legacy internal key 'suggestions') gets a read-only tool subset
-// rather than zero tools, so the agent can ground itself in the document
-// without proposing edits. We can't filter by `category === 'document'` alone
-// — that category includes the mutating add_comment and resolve_comment tools.
-// Mutating comment tools move behind Editor Mode via `requiresMode` in Chunk 4
-// of #467; until then this explicit allowlist is the gate.
+// Chat Mode gets a read-only tool subset rather than the full read+write
+// surface, so the agent can ground itself in the document without proposing
+// edits. We can't filter by `category === 'document'` alone — that category
+// includes the mutating add_comment and resolve_comment tools. Mutating
+// comment tools move behind Editor Mode via `requiresMode` in Chunk 4 of
+// #467; until then this explicit allowlist is the gate.
 //
-// Audit checkpoint: when #450 (list_tabs / select_tab) merges, decide whether
-// those new tools belong in Chat Mode and extend this set, or defer them to
-// Chunk 3.
+// Audit checkpoint: when new MCP/agent tools land (e.g., list_tabs, select_tab
+// from #450), decide whether they belong in Chat Mode and extend this set.
 const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'read_document',
   'read_selection',
@@ -33,8 +32,8 @@ const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
 ])
 
 function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
-  if (toolMode === 'suggestions') {
-    return getToolsForClaudeAPI('full').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
+  if (toolMode === 'chat') {
+    return getToolsForClaudeAPI('create').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
   }
   return getToolsForClaudeAPI(toolMode)
 }
@@ -111,8 +110,8 @@ export function useChat() {
     togglePanel,
     setPanelOpen,
     setContext,
-    setAgentMode,
     setToolMode,
+    cycleToolMode,
     startStreaming,
     appendStreamChunk,
     completeStreaming
@@ -347,7 +346,7 @@ export function useChat() {
             streamId: newStreamId,
             tools,
             maxToolRoundtrips: 5,
-            maxTokens: state.toolMode === 'suggestions' ? 3072 : 4096
+            maxTokens: state.toolMode === 'chat' ? 3072 : 4096
           })
         } catch (error) {
           console.error('[Chat] Tool loop error:', error)
@@ -547,7 +546,7 @@ export function useChat() {
           streamId,
           tools,
           maxToolRoundtrips: 5,
-          maxTokens: toolMode === 'suggestions' ? 3072 : 4096
+          maxTokens: toolMode === 'chat' ? 3072 : 4096
         })
       } catch (error) {
         console.error('[Chat] Error:', error)
@@ -694,7 +693,7 @@ export function useChat() {
     togglePanel,
     setPanelOpen,
     setContext,
-    setAgentMode,
-    setToolMode
+    setToolMode,
+    cycleToolMode
   }
 }

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -340,6 +340,15 @@ export function useChat() {
         const settingsState = useSettingsStore.getState()
         const editorState = useEditorStore.getState()
         const tools = getToolsForToolMode(state.toolMode)
+        // Mid-stream mode switches are rare (user toggles during tool loop)
+        // but the same idempotency logic applies. lastSentToolMode was set
+        // at the start of this stream, so this fires only on genuine mid-
+        // stream toggles.
+        const loopLastSent = state.lastSentToolMode
+        const loopModeJustSwitched = loopLastSent !== null && loopLastSent !== state.toolMode
+        if (loopModeJustSwitched) {
+          state.setLastSentToolMode(state.toolMode)
+        }
 
         try {
           await api.llmChatStream({
@@ -352,7 +361,8 @@ export function useChat() {
               editorState.document.content,
               state.toolMode,
               editorState.document.path,
-              resolveModelName(settingsState.settings.llm.model, settingsState.fetchedModels)
+              resolveModelName(settingsState.settings.llm.model, settingsState.fetchedModels),
+              loopModeJustSwitched
             ),
             streamId: newStreamId,
             tools,
@@ -538,6 +548,14 @@ export function useChat() {
       }
 
       console.log('[useChat] About to call llmChatStream')
+      // Detect mid-conversation mode switches so we can prepend a one-line
+      // note to the system prompt. Idempotent across multiple toggles:
+      // only the diff at send time matters, and we update lastSentToolMode
+      // immediately so the tool-loop continuation (later in this stream)
+      // doesn't re-fire the marker on every roundtrip.
+      const lastSent = useChatStore.getState().lastSentToolMode
+      const modeJustSwitched = lastSent !== null && lastSent !== toolMode
+      useChatStore.getState().setLastSentToolMode(toolMode)
       try {
         // Call streaming LLM (via Electron IPC or browser fallback)
         const api = getApi()
@@ -552,7 +570,8 @@ export function useChat() {
             useEditorStore.getState().document.content,
             toolMode,
             useEditorStore.getState().document.path,
-            resolveModelName(settings.llm.model, useSettingsStore.getState().fetchedModels)
+            resolveModelName(settings.llm.model, useSettingsStore.getState().fetchedModels),
+            modeJustSwitched
           ),
           streamId,
           tools,

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -15,13 +15,18 @@ import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
 
 // Chat Mode gets a read-only tool subset rather than the full read+write
 // surface, so the agent can ground itself in the document without proposing
-// edits. We can't filter by `category === 'document'` alone — that category
-// includes the mutating add_comment and resolve_comment tools. Mutating
-// comment tools move behind Editor Mode via `requiresMode` in Chunk 4 of
-// #467; until then this explicit allowlist is the gate.
+// edits. Defense-in-depth alongside the registry-level mode gating:
+// `requiresMode` on each ToolConfig excludes mutating tools from Chat Mode at
+// the registry, AND this explicit allowlist ensures Chat Mode only ever
+// receives tools we have specifically vetted as read-only.
 //
-// Audit checkpoint: when new MCP/agent tools land (e.g., list_tabs, select_tab
-// from #450), decide whether they belong in Chat Mode and extend this set.
+// Why both layers: registry gating relies on every new tool author setting
+// `requiresMode` correctly; a tool added with `requiresMode: null` (the
+// default for read-only tools) would silently appear in Chat Mode. The
+// allowlist keeps the failure mode "tool missing" rather than "tool leaks."
+//
+// Audit checkpoint: when new tools land, decide whether they belong in
+// Chat Mode and extend this set.
 const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'read_document',
   'read_selection',
@@ -33,7 +38,13 @@ const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
 
 function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
   if (toolMode === 'chat') {
-    return getToolsForClaudeAPI('create').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
+    // Pass 'chat' to the registry filter first so layer 1 actually fires for
+    // Chat Mode — only tools with `requiresMode <= chat` survive. Then narrow
+    // further to the explicit allowlist. Both layers run in series, so a
+    // regression in either (a missing `requiresMode: 'editor'` on a future
+    // mutating tool, or a missing entry in the allowlist) is caught by the
+    // other.
+    return getToolsForClaudeAPI('chat').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
   }
   return getToolsForClaudeAPI(toolMode)
 }

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { useChatStore, createMessageId } from '../stores/chatStore'
+import { useChatStore, createMessageId, type ToolMode } from '../stores/chatStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useEditorStore } from '../stores/editorStore'
 import { useEditorInstanceStore } from '../stores/editorInstanceStore'
@@ -12,6 +12,32 @@ import { executeTool, resolveToolPosition } from '../lib/tools'
 import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import { resolveModelName } from '../../shared/llm/models'
 import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
+
+// Chat Mode (legacy internal key 'suggestions') gets a read-only tool subset
+// rather than zero tools, so the agent can ground itself in the document
+// without proposing edits. We can't filter by `category === 'document'` alone
+// — that category includes the mutating add_comment and resolve_comment tools.
+// Mutating comment tools move behind Editor Mode via `requiresMode` in Chunk 4
+// of #467; until then this explicit allowlist is the gate.
+//
+// Audit checkpoint: when #450 (list_tabs / select_tab) merges, decide whether
+// those new tools belong in Chat Mode and extend this set, or defer them to
+// Chunk 3.
+const CHAT_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'read_document',
+  'read_selection',
+  'get_metadata',
+  'search_document',
+  'get_outline',
+  'list_comments'
+])
+
+function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForClaudeAPI> {
+  if (toolMode === 'suggestions') {
+    return getToolsForClaudeAPI('full').filter((t) => CHAT_MODE_TOOL_NAMES.has(t.name))
+  }
+  return getToolsForClaudeAPI(toolMode)
+}
 
 // Module-level flag to ensure stream listeners are only registered once globally
 let streamListenersInitialized = false
@@ -303,7 +329,7 @@ export function useChat() {
         // Call LLM again with tool results
         const settingsState = useSettingsStore.getState()
         const editorState = useEditorStore.getState()
-        const tools = state.toolMode !== 'suggestions' ? getToolsForClaudeAPI(state.toolMode) : undefined
+        const tools = getToolsForToolMode(state.toolMode)
 
         try {
           await api.llmChatStream({
@@ -479,9 +505,9 @@ export function useChat() {
 
       // Initialize tool loop context if tools are enabled
       console.log('[useChat] toolMode:', toolMode)
-      let tools
+      let tools: ReturnType<typeof getToolsForToolMode> | undefined
       try {
-        tools = toolMode !== 'suggestions' ? getToolsForClaudeAPI(toolMode) : undefined
+        tools = getToolsForToolMode(toolMode)
         console.log('[useChat] tools:', tools?.length || 0)
         if (tools && tools.length > 0) {
           console.log('[useChat] First tool schema:', JSON.stringify(tools[0], null, 2))
@@ -490,7 +516,7 @@ export function useChat() {
         console.error('[useChat] Error getting tools:', toolErr)
         tools = undefined
       }
-      if (tools) {
+      if (tools && tools.length > 0) {
         toolLoopContextRef.current = {
           apiMessages,
           assistantMsgId,

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -11,7 +11,7 @@ import { getSuggestionsWithFeedback } from '../extensions/ai-suggestions'
 import { executeTool, resolveToolPosition } from '../lib/tools'
 import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import { resolveModelName } from '../../shared/llm/models'
-import type { LLMMessage, LLMStreamToolCall, LLMContentBlock } from '../types'
+import type { LLMMessage, LLMStreamToolCall, LLMStreamToolCallStart, LLMContentBlock } from '../types'
 
 // Chat Mode gets a read-only tool subset rather than the full read+write
 // surface, so the agent can ground itself in the document without proposing
@@ -55,6 +55,31 @@ function getToolsForToolMode(toolMode: ToolMode): ReturnType<typeof getToolsForC
 
 // Module-level flag to ensure stream listeners are only registered once globally
 let streamListenersInitialized = false
+
+// Build a self-closing marker tag that ChatMessage's parseToolTags recognizes
+// as a "drafting" indicator (LLM is composing the tool's input). The matching
+// tag is stripped before the tool result summary is appended.
+function buildDraftingTag(toolCallId: string, toolName: string): string {
+  return `<tool-drafting id="${toolCallId}" name="${toolName}"></tool-drafting>`
+}
+
+// Strip a specific drafting marker once the tool has finished and its
+// result is about to be appended. Match the exact id; only one such tag
+// can exist per tool call.
+function stripDraftingTag(content: string, toolCallId: string): string {
+  const escapedId = toolCallId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return content.replace(
+    new RegExp(`<tool-drafting id="${escapedId}" name="[^"]+"></tool-drafting>`, 'g'),
+    ''
+  )
+}
+
+// Strip every drafting marker regardless of id. Used on terminal paths
+// (stream error, user abort, outer catch) where the per-id strip in the
+// tool-result loop won't run, otherwise the chip persists forever.
+function stripAllDraftingTags(content: string): string {
+  return content.replace(/<tool-drafting[^>]*><\/tool-drafting>/g, '')
+}
 
 // Maximum tool roundtrips before circuit breaker stops the loop
 const MAX_TOOL_ROUNDTRIPS = 5
@@ -186,6 +211,23 @@ export function useChat() {
       }
     })
 
+    // Drafting indicator: fires when the LLM begins a tool_use content block,
+    // before any input_json_delta. For tools whose body the model has to
+    // compose (e.g., `insert`/`edit` with paragraph-length text), this is the
+    // chunk of latency users currently see as silence. We append a self-
+    // closing <tool-drafting> tag to the streaming assistant message so
+    // ChatMessage's parser renders a "Drafting…" chip. The tag is stripped
+    // once the tool result is appended in onLLMStreamComplete below.
+    const unsubToolCallStart = api.onLLMStreamToolCallStart((start: LLMStreamToolCallStart) => {
+      const state = useChatStore.getState()
+      if (start.streamId !== state.currentStreamId || !state.streamingMessageId) return
+      const currentMsg = state.messages.find((m) => m.id === state.streamingMessageId)
+      const existing = currentMsg?.content ?? ''
+      state.updateMessage(state.streamingMessageId, {
+        content: existing + buildDraftingTag(start.toolCallId, start.toolName)
+      })
+    })
+
     const unsubComplete = api.onLLMStreamComplete(async (complete) => {
       console.log('[useChat:complete] Received:', complete.streamId, 'content:', complete.content?.slice(0, 50), 'toolCalls:', complete.toolCalls?.length || 0)
       const state = useChatStore.getState()
@@ -304,21 +346,24 @@ export function useChat() {
             currentErrorSignature = `${toolCall.name}:${result.error}`
           }
 
-          // Append tool execution info to the message using the same
-          // <tool-result> tag format as user-initiated slash commands.
-          // This unifies both paths so custom renderers in
-          // src/renderer/components/chat/toolResultRenderers/ get the
-          // full structured payload regardless of who triggered the
-          // tool call. Tools without a custom renderer fall back to
-          // the markdown render of the JSON, matching slash-command UX.
+          // Append tool execution info using the same <tool-result> tag
+          // format as user-initiated slash commands so custom renderers in
+          // src/renderer/components/chat/toolResultRenderers/ get the full
+          // structured payload regardless of who triggered the tool call.
+          // Strip the matching drafting marker for this tool call first so
+          // we don't render the "Drafting…" chip alongside the result chip.
+          // Read latest state so prior-tool appends in this same loop
+          // iteration are preserved.
           const resultText = result.success
             ? (typeof result.data === 'string'
                 ? result.data
                 : '```json\n' + JSON.stringify(result.data, null, 2) + '\n```')
             : `Error: ${result.error}`
-          state.updateMessage(assistantMsgId, {
+          const latest = useChatStore.getState()
+          const previous = latest.messages.find((m) => m.id === assistantMsgId)?.content ?? ''
+          latest.updateMessage(assistantMsgId, {
             content:
-              state.messages.find((m) => m.id === assistantMsgId)?.content +
+              stripDraftingTag(previous, toolCall.id) +
               `\n\n<tool-result name="${toolCall.name}" success="${result.success}">${resultText}</tool-result>`
           })
 
@@ -432,8 +477,12 @@ export function useChat() {
           } else if (lowerError.includes('connect') || lowerError.includes('network') || lowerError.includes('timeout')) {
             guidance = ' Check your internet connection.'
           }
+          // Strip any orphan <tool-drafting> tags. They're normally cleared in
+          // onLLMStreamComplete's tool-result loop, but a stream error between
+          // content_block_start and that loop would leave them dangling.
+          const cleaned = stripAllDraftingTags(currentMsg?.content || '')
           state.updateMessage(state.streamingMessageId, {
-            content: (currentMsg?.content || '') + `\n\nError: ${error.error}${guidance}`,
+            content: cleaned + `\n\nError: ${error.error}${guidance}`,
             isError: true
           })
         }
@@ -449,6 +498,7 @@ export function useChat() {
       console.log('[useChat:listeners] CLEANUP - unsubscribing all listeners')
       unsubChunk()
       unsubToolCall()
+      unsubToolCallStart()
       unsubComplete()
       unsubError()
       streamListenersInitialized = false
@@ -669,6 +719,18 @@ export function useChat() {
     if (state.currentStreamId) {
       const api = getApi()
       api.llmAbortStream(state.currentStreamId)
+    }
+    // Strip orphan drafting tags before tearing down the stream — aborting
+    // mid-tool-input composition would otherwise leave a perpetual chip.
+    // Must run before completeStreaming() clears streamingMessageId.
+    if (state.streamingMessageId) {
+      const currentMsg = state.messages.find((m) => m.id === state.streamingMessageId)
+      if (currentMsg?.content) {
+        const cleaned = stripAllDraftingTags(currentMsg.content)
+        if (cleaned !== currentMsg.content) {
+          state.updateMessage(state.streamingMessageId, { content: cleaned })
+        }
+      }
     }
     // Clear stream refs before completing to prevent race conditions
     clearStreamRefs()

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1012,15 +1012,27 @@
   border-radius: 0.125em;
 }
 
-/* Insertion type - violet text color (for imported/manual AI annotations) */
+/* Insertion type - unified with replacement: violet background highlight with
+ * legible text. (Previously violet text + transparent bg, whose hover used
+ * background-clip:text + transparent text-fill, making the text invisible on
+ * hover. #548 routes inserts through the same annotation path, so the visual
+ * register must match edits/suggest_edit-accepts.) */
 .prose-editor .ai-annotation-insertion {
-  color: hsl(262 83% 45% / calc(var(--annotation-opacity) * 0.9 + 0.1));
-  background: transparent;
-  border-bottom: none;
+  background: linear-gradient(
+    135deg,
+    hsl(262 83% 58% / calc(var(--annotation-opacity) * 0.25)) 0%,
+    hsl(270 70% 50% / calc(var(--annotation-opacity) * 0.15)) 100%
+  );
+  border-bottom: 2px solid hsl(262 83% 58% / calc(var(--annotation-opacity) * 0.5));
 }
 
 .dark .prose-editor .ai-annotation-insertion {
-  color: hsl(262 70% 70% / calc(var(--annotation-opacity) * 0.85 + 0.15));
+  background: linear-gradient(
+    135deg,
+    hsl(262 70% 50% / calc(var(--annotation-opacity) * 0.3)) 0%,
+    hsl(270 60% 45% / calc(var(--annotation-opacity) * 0.18)) 100%
+  );
+  border-bottom-color: hsl(262 70% 60% / calc(var(--annotation-opacity) * 0.6));
 }
 
 /* Replacement type - violet gradient (for AI chat suggestions) */
@@ -1048,47 +1060,37 @@
 }
 
 /* Shimmer animation keyframes */
-@keyframes shimmer-text {
-  0% { background-position: -200% center; }
-  100% { background-position: 200% center; }
-}
-
 @keyframes shimmer-bg {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
 
-/* Insertion hover - shimmer across text */
+/* Insertion hover - shimmer across background (unified with replacement; keeps
+ * text legible instead of clipping the gradient to transparent text). */
 .prose-editor .ai-annotation-insertion:hover {
   background: linear-gradient(
     90deg,
-    hsl(262 83% 45%) 0%,
-    hsl(262 83% 45%) 40%,
-    hsl(262 90% 65%) 50%,
-    hsl(262 83% 45%) 60%,
-    hsl(262 83% 45%) 100%
+    hsl(262 83% 58% / 0.2) 0%,
+    hsl(262 83% 58% / 0.2) 40%,
+    hsl(262 90% 70% / 0.4) 50%,
+    hsl(262 83% 58% / 0.2) 60%,
+    hsl(262 83% 58% / 0.2) 100%
   );
   background-size: 200% 100%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: shimmer-text 2s ease-in-out infinite;
+  animation: shimmer-bg 2s ease-in-out infinite;
 }
 
 .dark .prose-editor .ai-annotation-insertion:hover {
   background: linear-gradient(
     90deg,
-    hsl(262 70% 70%) 0%,
-    hsl(262 70% 70%) 40%,
-    hsl(262 85% 85%) 50%,
-    hsl(262 70% 70%) 60%,
-    hsl(262 70% 70%) 100%
+    hsl(262 70% 50% / 0.25) 0%,
+    hsl(262 70% 50% / 0.25) 40%,
+    hsl(262 80% 65% / 0.45) 50%,
+    hsl(262 70% 50% / 0.25) 60%,
+    hsl(262 70% 50% / 0.25) 100%
   );
   background-size: 200% 100%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: shimmer-text 2s ease-in-out infinite;
+  animation: shimmer-bg 2s ease-in-out infinite;
 }
 
 /* Replacement hover - shimmer across background */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -415,6 +415,24 @@
   background: hsl(var(--primary) / 0.2);
 }
 
+/* Persistent visual selection while the editor is blurred.
+ * Painted by src/renderer/extensions/persistent-selection/ so users can
+ * still see what e.g. read_selection will operate against after focus
+ * moves to the chat input.
+ *
+ * Two-layer visual: a primary-tinted background for the common case,
+ * plus an inset outline that survives even when the inner content has
+ * its own background-image (e.g., .ai-annotation-replacement's
+ * linear-gradient). The outline paints on top of inner backgrounds, so
+ * users always see a selection boundary regardless of what mark or
+ * decoration wraps the range. */
+.prose-editor .persistent-selection {
+  background: hsl(var(--primary) / 0.2);
+  outline: 1.5px solid hsl(var(--primary) / 0.7);
+  outline-offset: -1.5px;
+  border-radius: 2px;
+}
+
 /* Diff Suggestions */
 .prose-editor .diff-suggestion {
   display: inline-flex;

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -13,6 +13,7 @@ import type {
   LLMStreamRequest,
   LLMStreamChunk,
   LLMStreamToolCall,
+  LLMStreamToolCallStart,
   LLMStreamComplete,
   LLMStreamError,
   ElectronAPI
@@ -380,6 +381,12 @@ export const browserApi: ElectronAPI = {
     const handler = (e: Event) => callback((e as CustomEvent).detail)
     window.addEventListener('llm:stream:tool-call', handler)
     return () => window.removeEventListener('llm:stream:tool-call', handler)
+  },
+
+  onLLMStreamToolCallStart: (callback: (start: LLMStreamToolCallStart) => void) => {
+    const handler = (e: Event) => callback((e as CustomEvent).detail)
+    window.addEventListener('llm:stream:tool-call:start', handler)
+    return () => window.removeEventListener('llm:stream:tool-call:start', handler)
   },
 
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => {

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -20,14 +20,22 @@ function stripCommentMarkup(content: string): string {
 
 const BASE_PROMPT = `You are Prose, a writing assistant embedded in a markdown editor.
 
-You help writers edit, revise, and improve their documents. You are concise, direct, and opinionated when asked for feedback. You do not hedge or pad your responses with pleasantries.
+## Posture
 
-## How you work
+You are an editor in the original sense. You edit, you question, you scaffold. **By default, you do not write prose for the user.** Authorship stays with the writer; you make their existing words sharper.
 
-- When asked to **edit text**, use tools to make changes. Read the document first if you haven't already.
-- When asked for **feedback or critique**, respond in 2-3 sentences. Be specific. Point to exact phrases or passages.
-- When asked to **write or draft** new content, output markdown directly in your response.
-- When **discussing ideas**, keep responses short. One paragraph is usually enough.
+## Authorship test
+
+*Would a reader see words I wrote?* If yes, that is authorship. Apply the test to the document body — not to edit-comment captions in the diff UI, escape-hatch prompts written to working files, or transient chat messages.
+
+If a request would have you draft prose into the document, stop and ask whether the user wants you to leave the drafting to them. The exception is Create Mode, where the user has explicitly opted in to LLM-authored prose.
+
+## Heuristics (all modes)
+
+- **Hold interpretations loosely. Push once, then defer.** When you think a user's claim or framing is off, state the case with evidence and listen. Strong opinions weakly held. Don't dig in — especially on territory where you have structural conflict of interest (e.g., a writer questioning AI-vendor research).
+- **Surface the user's own crisp lines.** When the user articulates something well in conversation, flag it as worth using deliberately. Do not quote it back as if generated — that's a quiet form of authorship users will eventually notice.
+- **Reflect words accurately.** Never let reflected phrasing shade into generated phrasing.
+- **Structural diagnosis before scaffolding.** Identify competing intentions in a draft before proposing reorganization. Don't reorder without understanding intent first.
 
 ## Rules
 
@@ -35,46 +43,98 @@ You help writers edit, revise, and improve their documents. You are concise, dir
 - Never restate what the user just said back to them.
 - Never explain what you're about to do before doing it. Just do it.
 - When making edits, don't narrate each change. The diff UI shows the user what changed.
-- If you need to explain *why* you made a change, put it in the edit's \`comment\` field, not in the chat.
-- Prefer multiple small, targeted edits over one large replacement.
+- If you need to explain *why* you made a change, put it in the edit's \`comment\` field, not in the chat. Keep edit comments under 20 words — they appear in the diff UI.
+- Prefer multiple small, targeted edits over one large replacement. One logical concern per suggestion.
 - If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes.
+- Edit the actual document being reviewed, not a parallel review doc.
 
 ## Tone
 
-You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice.`
+You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice — it is the thing you exist to protect.`
 
+// Chat Mode posture. Tools are not yet wired in this mode — Chunk 2 of
+// the #467 umbrella adds read-only tool wiring. For now, this is a
+// sounding-board / fact-check posture with no document mutations.
 const SUGGESTIONS_MODE_INSTRUCTIONS = `
 
-You do not have editing tools in this mode. Provide writing feedback, analysis, and suggestions in your response text. When suggesting changes, quote the original text and show the proposed revision.`
+## Chat Mode
 
+Sounding board, fact-check, pushback, brainstorm. You do not have editing tools in this mode — provide feedback in your response text. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
+
+If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.`
+
+// Editor Mode posture. Proposes concrete copy edits via suggest_edit and
+// leaves editorial notes via add_comment. Never authors prose into the
+// document — that requires Create Mode. Will become the default in Chunk 3
+// of #467 (chatStore initialization flip); today's actual default is
+// Create Mode (legacy 'full'), so this PR doesn't claim the (default) tag.
 const PLAN_MODE_INSTRUCTIONS = `
 
+## Editor Mode
+
+You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user. If the user asks you to write a paragraph, decline or ask them to draft it for you to edit.
+
 ## Tools
 
 - \`read_document\` — Returns document nodes with unique IDs
-- \`suggest_edit\` — Creates an inline diff the user can accept or reject
+- \`get_outline\` — Headings-only structural skim
+- \`list_comments\` — Existing comments in the document
+- \`suggest_edit\` — Inline diff for a copy edit the user can accept or reject
+- \`add_comment\` — Editorial note attached to a range; the user decides the replacement
+- \`resolve_comment\` — Remove a comment by ID
 
-### Workflow
-1. **Always** call \`read_document\` first — node IDs change between sessions and cannot be guessed
-2. Call \`suggest_edit\` with the target node ID, new content, and a brief comment (under 20 words)
-3. **Always include \`search\`** with the node's original text content — this ensures edits succeed even if node IDs have changed
+## \`suggest_edit\` vs \`add_comment\`
 
-The user sees a highlighted diff and decides whether to accept. You have a budget of 5 tool roundtrips per response.`
+- **\`suggest_edit\`** — user-sanctioned copy edits where there's a clear right answer (typos, formatting, link insertion, mechanical fixes). Propose the exact replacement; the user reviews and accepts or rejects via the diff overlay.
+- **\`add_comment\`** — editorial notes where the user, not you, should decide the resolution ("tighten this paragraph", "competing thesis with paragraph 2", "needs a transition"). Flag the issue without proposing the replacement prose. Proposing prose for a judgment-bearing concern crosses into authorship.
 
+## Workflow
+
+1. Always call \`read_document\` first — node IDs change between sessions and cannot be guessed
+2. Match the tool to the concern: clear right answer → \`suggest_edit\`; judgment-bearing → \`add_comment\`
+3. Always include \`search\` on \`suggest_edit\` calls — original text content ensures edits succeed even if node IDs have changed
+
+## Escape hatch
+
+When in-tool affordances hit a wall (schema lock, tool contract limitation, autosave conflict), pivot to producing a self-contained handoff prompt the user can run in a different context. Deliver as a markdown file via \`create_and_open_file\`, not as an inline chat code block.
+
+You have a budget of 5 tool roundtrips per response.`
+
+// Create Mode posture. Opt-in. The no-authorship rule is lifted; the user
+// has explicitly asked for LLM-authored prose. Persona constraints around
+// accuracy, structural diagnosis, and concision still apply.
 const FULL_MODE_INSTRUCTIONS = `
 
+## Create Mode
+
+The user has opted in to LLM-authored prose. The no-authorship rule is lifted — you may draft prose into the document. Accuracy, structural diagnosis, and concision still apply.
+
 ## Tools
 
 - \`read_document\` — Returns document nodes with unique IDs
-- \`suggest_edit\` — Creates an inline diff the user can accept or reject (use when the user should review)
-- \`edit\` — Directly replaces a node's content (use for unambiguous fixes: typos, formatting)
+- \`get_outline\` — Headings-only structural skim
+- \`list_comments\` / \`add_comment\` / \`resolve_comment\` — Editorial notes
+- \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
+- \`edit\` — Directly replaces a node's content (unambiguous fixes; or drafted content the user has asked for)
+- \`insert\` — Insert new content at a position
 
-### Workflow
-1. **Always** call \`read_document\` first — node IDs change between sessions and cannot be guessed
-2. Use \`suggest_edit\` when judgment is involved, \`edit\` for obvious fixes
-3. **Always include \`search\`** with the node's original text content — this ensures edits succeed even if node IDs have changed
+## When to use what
 
-Keep edit comments under 20 words. You have a budget of 5 tool roundtrips per response.`
+- **Prefer \`suggest_edit\`** over direct \`edit\` / \`insert\` for changes to existing authored content. Provenance matters even in Create Mode.
+- **\`edit\` and \`insert\`** are appropriate when the user has explicitly asked you to draft prose, or for unambiguous fixes (typos, formatting) where review is redundant.
+- **\`add_comment\`** is still the right tool for judgment-bearing editorial notes when the writer should decide.
+
+## Workflow
+
+1. Always call \`read_document\` first
+2. Match the tool to intent: drafting → \`edit\` / \`insert\`; copy edits → \`suggest_edit\`; editorial direction → \`add_comment\`
+3. Always include \`search\` on \`suggest_edit\` calls
+
+## Escape hatch
+
+When in-tool affordances hit a wall (schema lock, tool contract limitation, autosave conflict), pivot to producing a self-contained handoff prompt the user can run in a different context. Deliver as a markdown file via \`create_and_open_file\`, not as an inline chat code block.
+
+You have a budget of 5 tool roundtrips per response.`
 
 export function buildSystemPrompt(
   documentContent?: string,

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -160,6 +160,7 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 2. Match the tool to intent: drafting → \`edit\` / \`insert\`; copy edits → \`suggest_edit\`; editorial direction → \`add_comment\`
 3. Anchor \`insert\` on a section heading's \`nodeId\` (\`position=after_node\`) when adding content to a specific section — don't rely on cursor placement
 4. Always include \`search\` on \`suggest_edit\` and anchored \`insert\` calls
+5. Include a one-line \`comment\` on \`edit\` and \`insert\` calls when there's a non-obvious reason for the change (e.g., "Tightened for rhythm" or "Added missing transition"). Keep under 20 words. Omit when the user's request is the full rationale.
 
 ## Escape hatch
 

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -28,7 +28,7 @@ You are an editor in the original sense. You edit, you question, you scaffold. *
 
 *Would a reader see words I wrote?* If yes, that is authorship. Apply the test to the document body — not to edit-comment captions in the diff UI, escape-hatch prompts written to working files, or transient chat messages.
 
-If a request would have you draft prose into the document, stop and ask whether the user wants you to leave the drafting to them. The exception is Create Mode, where the user has explicitly opted in to LLM-authored prose.
+If a request would have you draft prose into the document, the right move depends on mode. In Editor or Chat Mode, call \`request_mode_switch\` with \`target: 'create'\` and a prompt the user can run after switching — don't lecture about modes in prose. In Create Mode, drafting is on the table; proceed.
 
 ## Heuristics (all modes)
 
@@ -69,8 +69,16 @@ Sounding board, fact-check, pushback, brainstorm. You have read-only tools to gr
 - \`search_document\` — Locate text or regex matches
 - \`get_metadata\` — Document path, word count, frontmatter, dirty state
 - \`list_comments\` — Existing comments in the document
+- \`request_mode_switch\` — Offer the user a one-click switch to a different mode
 
-If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.
+## When a request needs a different mode
+
+Don't lecture about modes in prose. Call \`request_mode_switch\` with:
+- \`target\`: the minimum mode that enables the request (\`editor\` for edits / comments, \`create\` for drafting)
+- \`reason\`: one short sentence about what the switch enables (under 20 words)
+- \`prompt_to_retry\`: the exact prompt to run after switching, phrased as the user would write it
+
+The user sees a small inline button: "Switch & Run" (mode-switch + auto-send the retry prompt) or "Just Switch" (mode-switch only). Use this for typo fixes, comments, drafting requests, file writes — anything Chat Mode can't do.
 
 You have a budget of 5 tool roundtrips per response.`
 
@@ -81,7 +89,9 @@ const EDITOR_MODE_INSTRUCTIONS = `
 
 ## Editor Mode
 
-You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user. If the user asks you to write a paragraph, decline or ask them to draft it for you to edit.
+You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user.
+
+If the user asks for drafting, don't lecture: call \`request_mode_switch\` with \`target: 'create'\` and the prompt they'd run after switching. The user gets a one-click button to switch and run, or just switch.
 
 ## Tools
 
@@ -91,6 +101,7 @@ You propose concrete copy edits and leave editorial notes. You do not draft pros
 - \`suggest_edit\` — Inline diff for a copy edit the user can accept or reject
 - \`add_comment\` — Editorial note attached to a range; the user decides the replacement
 - \`resolve_comment\` — Remove a comment by ID
+- \`request_mode_switch\` — Offer the user a one-click switch to Create Mode for drafting requests
 
 ## \`suggest_edit\` vs \`add_comment\`
 
@@ -170,7 +181,7 @@ export function buildSystemPrompt(
   if (modeJustSwitched) {
     const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
     prompt =
-      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Earlier turns may have been in a different mode with different capabilities. Adopt the current mode's posture immediately.\n\n` +
+      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Their next message likely reflects a request you should now be able to fulfill directly with this mode's tools. **Do NOT call \`request_mode_switch\` in this turn** — they've already switched. Use the tools available in ${modeLabel} Mode to act on their request.\n\n` +
       prompt
   }
   if (resolvedMode === 'chat') {

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -52,16 +52,27 @@ If a request would have you draft prose into the document, stop and ask whether 
 
 You write the way a good editor marks up a manuscript: precise, economical, occasionally witty. You have strong opinions about clarity and concision. You cut ruthlessly and suggest boldly, but you respect the writer's voice — it is the thing you exist to protect.`
 
-// Chat Mode posture. Tools are not yet wired in this mode — Chunk 2 of
-// the #467 umbrella adds read-only tool wiring. For now, this is a
-// sounding-board / fact-check posture with no document mutations.
+// Chat Mode posture. Read-only tool surface — the agent can read the
+// document to ground its responses but cannot propose edits, comment, or
+// mutate anything.
 const SUGGESTIONS_MODE_INSTRUCTIONS = `
 
 ## Chat Mode
 
-Sounding board, fact-check, pushback, brainstorm. You do not have editing tools in this mode — provide feedback in your response text. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
+Sounding board, fact-check, pushback, brainstorm. You have read-only tools to ground yourself in the document, but you cannot propose edits or leave comments. When suggesting changes, quote the original text and show the proposed revision so the user can apply it themselves.
 
-If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.`
+## Tools
+
+- \`read_document\` — Returns document nodes with unique IDs
+- \`read_selection\` — Returns the currently selected text and position
+- \`get_outline\` — Headings-only structural skim
+- \`search_document\` — Locate text or regex matches
+- \`get_metadata\` — Document path, word count, frontmatter, dirty state
+- \`list_comments\` — Existing comments in the document
+
+If a request would require an edit, an annotation, or a file write, tell the user to switch to Editor Mode (StatusBar → editor) and re-ask.
+
+You have a budget of 5 tool roundtrips per response.`
 
 // Editor Mode posture. Proposes concrete copy edits via suggest_edit and
 // leaves editorial notes via add_comment. Never authors prose into the
@@ -163,7 +174,8 @@ export function buildSystemPrompt(
     prompt += `\n\nThe user is currently working on the following document:\n\n---\n${cleanContent}\n---`
 
     if (!toolMode || toolMode === 'suggestions') {
-      // Line references only when no tools available
+      // Chat Mode: agent references doc content in plain chat replies; line
+      // refs render as clickable jump-to-line links in the UI.
       prompt += `\n\n## Referencing Line Numbers\nFormat: [Line N](line:N) — these render as clickable links that navigate to that line.`
     } else {
       prompt += `\n\nCall \`read_document\` for node IDs needed by editing tools.`

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -136,7 +136,7 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 - \`list_comments\` / \`add_comment\` / \`resolve_comment\` — Editorial notes
 - \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
 - \`edit\` — Directly replaces a node's content (unambiguous fixes; or drafted content the user has asked for)
-- \`insert\` — Insert new content at a position
+- \`insert\` — Insert new content at a position. Default to \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when the user asks to add content to a specific section. Reserve \`position=cursor\` for cases where the user explicitly said "here" — the cursor may be parked anywhere.
 
 ## When to use what
 
@@ -148,7 +148,8 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 
 1. Always call \`read_document\` first
 2. Match the tool to intent: drafting → \`edit\` / \`insert\`; copy edits → \`suggest_edit\`; editorial direction → \`add_comment\`
-3. Always include \`search\` on \`suggest_edit\` calls
+3. Anchor \`insert\` on a section heading's \`nodeId\` (\`position=after_node\`) when adding content to a specific section — don't rely on cursor placement
+4. Always include \`search\` on \`suggest_edit\` and anchored \`insert\` calls
 
 ## Escape hatch
 

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -45,8 +45,15 @@ If a request would have you draft prose into the document, the right move depend
 - When making edits, don't narrate each change. The diff UI shows the user what changed.
 - If you need to explain *why* you made a change, put it in the edit's \`comment\` field, not in the chat. Keep edit comments under 20 words — they appear in the diff UI.
 - Prefer multiple small, targeted edits over one large replacement. One logical concern per suggestion.
-- If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes.
+- If the user's request is ambiguous, make your best interpretation and act. Don't ask clarifying questions unless the ambiguity would lead to meaningfully different outcomes. When asked to draft something with the topic unspecified ("write something", "surprise me"), propose — the user can redirect.
 - Edit the actual document being reviewed, not a parallel review doc.
+
+## Tool selection (all modes)
+
+Your mode determines your default tool family. The per-mode sections below spell out what each mode's defaults are. Two cross-mode rules also apply:
+
+- **Tool-name verbs are direct instructions.** When the user uses "suggest", "comment", "insert", "edit", "rewrite", "draft", follow the verb. If the named tool isn't available in your current mode, call \`request_mode_switch\` with \`prompt_to_retry\` set to the user's request — don't substitute a near-tool (e.g., \`suggest_edit\` is not a substitute for \`edit\`) and don't lecture about modes.
+- **Judgment language routes to \`add_comment\`.** When the user describes a *concern* without prescribing a *fix* — words like "weak", "off", "off-tone", "doesn't land", "doesn't earn", "feels off", "competes with", "needs work" — that's an editorial flag, not a draft request. Use \`add_comment\`. Resist the impulse to propose replacement prose; the writer decides.
 
 ## Tone
 
@@ -91,7 +98,7 @@ const EDITOR_MODE_INSTRUCTIONS = `
 
 You propose concrete copy edits and leave editorial notes. You do not draft prose into the document — authorship stays with the user.
 
-If the user asks for drafting, don't lecture: call \`request_mode_switch\` with \`target: 'create'\` and the prompt they'd run after switching. The user gets a one-click button to switch and run, or just switch.
+If the user asks for direct drafting — verbs like "rewrite", "write", "draft", or asks for content you'd have to author — don't lecture and don't substitute a near-tool (\`suggest_edit\` is not a substitute for the \`edit\` tool). Call \`request_mode_switch\` with \`target: 'create'\` and the prompt they'd run after switching. The user gets a one-click button to switch and run, or just switch. ("Edit X" is *not* on this list — in Editor Mode, "edit this sentence to be clearer" is the canonical \`suggest_edit\` request, not a draft.)
 
 ## Tools
 
@@ -136,16 +143,16 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 - \`get_outline\` — Headings-only structural skim
 - \`list_comments\` / \`add_comment\` / \`resolve_comment\` — Editorial notes
 - \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
-- \`edit\` — Directly replaces a node's content (unambiguous fixes; or drafted content the user has asked for)
-- \`insert\` — Insert new content at a position. Default to \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when the user asks to add content to a specific section. Reserve \`position=cursor\` for cases where the user explicitly said "here" — the cursor may be parked anywhere.
+- \`edit\` — Directly replaces a node's content (the default tool for "edit X to be Y", "rewrite this paragraph", or other in-place rewrites the user has requested)
+- \`insert\` — Insert text at a position. Use \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when adding to a specific section. Use \`position=cursor\` when the user said "here" — OR when the user has a non-empty selection and asks to replace it: \`position=cursor\` over a selection deletes the selection and inserts the new text in its place. (\`insert\` is the correct tool for "use insert to replace this with X" — don't redirect to \`edit\`.)
 - \`delete_node\` — Remove a node by ID (e.g., to undo an inserted paragraph)
 - \`move_cursor\` — Park the user's cursor at a node before \`insert\` with \`position: 'cursor'\`
 
 ## When to use what
 
-- **Prefer \`suggest_edit\`** over direct \`edit\` / \`insert\` for changes to existing authored content. Provenance matters even in Create Mode.
-- **\`edit\` and \`insert\`** are appropriate when the user has explicitly asked you to draft prose, or for unambiguous fixes (typos, formatting) where review is redundant.
-- **\`add_comment\`** is still the right tool for judgment-bearing editorial notes when the writer should decide.
+- **Default to direct \`edit\` / \`insert\`** for changes the user has requested. The user opted into Create Mode precisely to skip the review gate — direct edits still record provenance via the AI-annotation system, so \`suggest_edit\` is the *review-gated* path, not the default-with-history path.
+- **Use \`suggest_edit\`** only when (a) you're proposing an unprompted change the user didn't directly ask for, or (b) the change is mechanical and worth a quick eye over (e.g., a typo sweep across multiple instances, a formatting normalization).
+- **Use \`add_comment\`** for judgment-bearing concerns where the writer should decide the resolution — flag the issue without proposing replacement prose. (See the all-modes "Tool selection" rule above for the language cues.)
 
 ## Workflow
 

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -176,16 +176,25 @@ export function buildSystemPrompt(
   // Mode-specific tool instructions. Defaults to Editor when no mode supplied
   // (matches the chatStore initial value).
   const resolvedMode: ToolMode = toolMode ?? 'editor'
+  const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
 
-  // Mid-conversation mode switch notice — surface a one-line note BEFORE
-  // the base persona so the agent sees the mode change first. Caller
-  // computes the boolean by comparing chatStore.lastSentToolMode with
-  // the current toolMode; this is idempotent across multiple toggles
-  // between sends.
+  // Top-of-prompt mode anchor. Always present, so the LLM has an
+  // authoritative signal that overrides any prior assistant turn in
+  // conversation history that may have claimed a different mode (the
+  // failure mode tracked in #551: the agent pattern-matches on its own
+  // prior "I'm in Editor Mode" reply and refuses to act in the new mode).
+  prompt =
+    `**CURRENT MODE: ${modeLabel}.** Your available tools and posture are defined by ${modeLabel} Mode (see "## ${modeLabel} Mode" section below). If any prior assistant turn in this conversation claimed a different mode, that claim is stale — disregard it and act according to ${modeLabel} Mode now.\n\n` +
+    prompt
+
+  // Mid-conversation mode switch notice — fires the turn after a switch.
+  // Reinforces the mode anchor with explicit "do not re-fire the switch
+  // tool" guidance. Caller computes the boolean by comparing
+  // chatStore.lastSentToolMode with the current toolMode; this is
+  // idempotent across multiple toggles between sends.
   if (modeJustSwitched) {
-    const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
     prompt =
-      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Their next message likely reflects a request you should now be able to fulfill directly with this mode's tools. **Do NOT call \`request_mode_switch\` in this turn** — they've already switched. Use the tools available in ${modeLabel} Mode to act on their request.\n\n` +
+      `**MODE CHANGED.** The user just switched to ${modeLabel} Mode mid-conversation. Their next message reflects a request you should fulfill directly with ${modeLabel} Mode's tools. Do NOT call \`request_mode_switch\` in this turn — they've already switched.\n\n` +
       prompt
   }
   if (resolvedMode === 'chat') {

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -55,7 +55,7 @@ You write the way a good editor marks up a manuscript: precise, economical, occa
 // Chat Mode posture. Read-only tool surface — the agent can read the
 // document to ground its responses but cannot propose edits, comment, or
 // mutate anything.
-const SUGGESTIONS_MODE_INSTRUCTIONS = `
+const CHAT_MODE_INSTRUCTIONS = `
 
 ## Chat Mode
 
@@ -74,12 +74,10 @@ If a request would require an edit, an annotation, or a file write, tell the use
 
 You have a budget of 5 tool roundtrips per response.`
 
-// Editor Mode posture. Proposes concrete copy edits via suggest_edit and
-// leaves editorial notes via add_comment. Never authors prose into the
-// document — that requires Create Mode. Will become the default in Chunk 3
-// of #467 (chatStore initialization flip); today's actual default is
-// Create Mode (legacy 'full'), so this PR doesn't claim the (default) tag.
-const PLAN_MODE_INSTRUCTIONS = `
+// Editor Mode posture. Default for new users. Proposes concrete copy edits
+// via suggest_edit and leaves editorial notes via add_comment. Never
+// authors prose into the document — that requires Create Mode.
+const EDITOR_MODE_INSTRUCTIONS = `
 
 ## Editor Mode
 
@@ -114,7 +112,7 @@ You have a budget of 5 tool roundtrips per response.`
 // Create Mode posture. Opt-in. The no-authorship rule is lifted; the user
 // has explicitly asked for LLM-authored prose. Persona constraints around
 // accuracy, structural diagnosis, and concision still apply.
-const FULL_MODE_INSTRUCTIONS = `
+const CREATE_MODE_INSTRUCTIONS = `
 
 ## Create Mode
 
@@ -159,13 +157,15 @@ export function buildSystemPrompt(
     prompt = `You are ${modelName}.\n\n` + prompt
   }
 
-  // Mode-specific tool instructions
-  if (!toolMode || toolMode === 'suggestions') {
-    prompt += SUGGESTIONS_MODE_INSTRUCTIONS
-  } else if (toolMode === 'plan') {
-    prompt += PLAN_MODE_INSTRUCTIONS
-  } else if (toolMode === 'full') {
-    prompt += FULL_MODE_INSTRUCTIONS
+  // Mode-specific tool instructions. Defaults to Editor when no mode supplied
+  // (matches the chatStore initial value).
+  const resolvedMode: ToolMode = toolMode ?? 'editor'
+  if (resolvedMode === 'chat') {
+    prompt += CHAT_MODE_INSTRUCTIONS
+  } else if (resolvedMode === 'editor') {
+    prompt += EDITOR_MODE_INSTRUCTIONS
+  } else if (resolvedMode === 'create') {
+    prompt += CREATE_MODE_INSTRUCTIONS
   }
 
   // Document context — always include full document regardless of tool mode
@@ -173,7 +173,7 @@ export function buildSystemPrompt(
     const cleanContent = stripCommentMarkup(documentContent)
     prompt += `\n\nThe user is currently working on the following document:\n\n---\n${cleanContent}\n---`
 
-    if (!toolMode || toolMode === 'suggestions') {
+    if (resolvedMode === 'chat') {
       // Chat Mode: agent references doc content in plain chat replies; line
       // refs render as clickable jump-to-line links in the UI.
       prompt += `\n\n## Referencing Line Numbers\nFormat: [Line N](line:N) — these render as clickable links that navigate to that line.`

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -149,7 +149,8 @@ export function buildSystemPrompt(
   documentContent?: string,
   toolMode?: ToolMode,
   documentPath?: string | null,
-  modelName?: string
+  modelName?: string,
+  modeJustSwitched?: boolean
 ): string {
   let prompt = BASE_PROMPT
 
@@ -160,6 +161,18 @@ export function buildSystemPrompt(
   // Mode-specific tool instructions. Defaults to Editor when no mode supplied
   // (matches the chatStore initial value).
   const resolvedMode: ToolMode = toolMode ?? 'editor'
+
+  // Mid-conversation mode switch notice — surface a one-line note BEFORE
+  // the base persona so the agent sees the mode change first. Caller
+  // computes the boolean by comparing chatStore.lastSentToolMode with
+  // the current toolMode; this is idempotent across multiple toggles
+  // between sends.
+  if (modeJustSwitched) {
+    const modeLabel = resolvedMode.charAt(0).toUpperCase() + resolvedMode.slice(1)
+    prompt =
+      `Note: the user just switched to ${modeLabel} Mode mid-conversation. Earlier turns may have been in a different mode with different capabilities. Adopt the current mode's posture immediately.\n\n` +
+      prompt
+  }
   if (resolvedMode === 'chat') {
     prompt += CHAT_MODE_INSTRUCTIONS
   } else if (resolvedMode === 'editor') {

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -101,6 +101,7 @@ If the user asks for drafting, don't lecture: call \`request_mode_switch\` with 
 - \`suggest_edit\` — Inline diff for a copy edit the user can accept or reject
 - \`add_comment\` — Editorial note attached to a range; the user decides the replacement
 - \`resolve_comment\` — Remove a comment by ID
+- \`move_cursor\` — Park the user's cursor at a specific node (no content change)
 - \`request_mode_switch\` — Offer the user a one-click switch to Create Mode for drafting requests
 
 ## \`suggest_edit\` vs \`add_comment\`
@@ -137,6 +138,8 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 - \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
 - \`edit\` — Directly replaces a node's content (unambiguous fixes; or drafted content the user has asked for)
 - \`insert\` — Insert new content at a position. Default to \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when the user asks to add content to a specific section. Reserve \`position=cursor\` for cases where the user explicitly said "here" — the cursor may be parked anywhere.
+- \`delete_node\` — Remove a node by ID (e.g., to undo an inserted paragraph)
+- \`move_cursor\` — Park the user's cursor at a node before \`insert\` with \`position: 'cursor'\`
 
 ## When to use what
 

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -7,6 +7,7 @@ import type { ToolResult } from '../../../../shared/tools/types'
 import { toolSuccess, toolError } from '../../../../shared/tools/types'
 import { useEditorStore } from '../../../stores/editorStore'
 import { useEditorInstanceStore } from '../../../stores/editorInstanceStore'
+import { useSettingsStore } from '../../../stores/settingsStore'
 import { useAnnotationStore } from '../../../extensions/ai-annotations'
 import { createWordDiffAnnotations } from '../../diffUtils'
 import { findNodeById, findNodeByContent, getNodesWithIds, flattenNodes } from '../../../extensions/node-ids'
@@ -14,6 +15,113 @@ import { generateId } from '../../persistence'
 import { getAISuggestions } from '../../../extensions/ai-suggestions'
 import { parseMarkdown, FRONTMATTER_REGEX } from '../../markdown'
 import { load as parseYaml } from 'js-yaml'
+
+/**
+ * Target visible duration for a chunked streaming insertion. The number of
+ * chunks is capped so total wall time stays under ~400ms even for long
+ * paragraphs — long enough to perceive motion, short enough that the user
+ * isn't waiting on the agent.
+ */
+const STREAM_TARGET_FRAME_COUNT = 24
+
+/**
+ * Decide whether the next agent insertion should stream chunk-by-chunk.
+ * Falls back to instant apply when the user has disabled the setting or
+ * has `prefers-reduced-motion: reduce` set at the OS level.
+ */
+function shouldStreamInsertion(): boolean {
+  const enabled = useSettingsStore.getState().settings.editor.streamingEdits
+  if (enabled === false) return false
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Split text into word-level chunks (word + trailing whitespace per chunk),
+ * then group into at most STREAM_TARGET_FRAME_COUNT chunks so total wall time
+ * stays bounded for long paragraphs.
+ */
+function buildStreamChunks(text: string): string[] {
+  // Token alternation: [word, space, word, space, ...]; either side may be empty.
+  const tokens = text.split(/(\s+)/)
+  const words: string[] = []
+  for (let i = 0; i < tokens.length; i += 2) {
+    const word = tokens[i] || ''
+    const space = tokens[i + 1] || ''
+    if (word || space) words.push(word + space)
+  }
+  if (words.length <= STREAM_TARGET_FRAME_COUNT) return words
+  const groupSize = Math.ceil(words.length / STREAM_TARGET_FRAME_COUNT)
+  const groups: string[] = []
+  for (let i = 0; i < words.length; i += groupSize) {
+    groups.push(words.slice(i, i + groupSize).join(''))
+  }
+  return groups
+}
+
+/** Yield to the browser so paint can happen between chunks. */
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve())
+    } else {
+      setTimeout(resolve, 16)
+    }
+  })
+}
+
+/**
+ * Insert `text` at `from`, or replace the range `[from, to]` when `to` is
+ * supplied, either instantly or in word-level chunks across animation frames.
+ * Chunked transactions land within ~400ms total — inside the ProseMirror
+ * history plugin's default newGroupDelay (500ms) — so the whole insertion
+ * collapses into a single undo step.
+ *
+ * When `to` is supplied, the range delete and the first chunk insert run in
+ * the same chain (a single transaction), so range replacement is atomic and
+ * shares undo state with the first chunk.
+ *
+ * Subsequent chunks track the running insertion endpoint explicitly via the
+ * doc-size delta, so user clicks or keystrokes mid-stream can't redirect
+ * later chunks into the user's cursor position.
+ */
+async function applyInsertion(
+  editor: Editor,
+  text: string,
+  from: number,
+  to?: number
+): Promise<void> {
+  const hasRange = to !== undefined && to !== from
+  const selection = hasRange ? { from, to: to! } : from
+
+  if (!shouldStreamInsertion()) {
+    editor.chain().focus().setTextSelection(selection).insertContent(text).run()
+    return
+  }
+  const chunks = buildStreamChunks(text)
+  if (chunks.length <= 1) {
+    editor.chain().focus().setTextSelection(selection).insertContent(text).run()
+    return
+  }
+  const rangeSize = hasRange ? to! - from : 0
+  const sizeBefore = editor.state.doc.content.size
+  editor.chain().focus().setTextSelection(selection).insertContent(chunks[0]).run()
+  // End of inserted content = from + (size of inserted chunk in PM coords).
+  // Inserted size = doc delta + chars removed by any range replace.
+  let pos = from + (editor.state.doc.content.size - sizeBefore) + rangeSize
+  for (let i = 1; i < chunks.length; i++) {
+    await nextFrame()
+    const prev = editor.state.doc.content.size
+    editor.chain().setTextSelection(pos).insertContent(chunks[i]).run()
+    pos += editor.state.doc.content.size - prev
+  }
+}
 
 /**
  * Get the TipTap editor instance.
@@ -134,14 +242,14 @@ export function resolveToolPosition(toolName: string, args: Record<string, unkno
  * edit - Replace the content of a node by its ID.
  * Falls back to content matching if the nodeId is stale.
  */
-export function executeEdit(
+export async function executeEdit(
   args: {
     nodeId: string
     content: string
     search?: string
   },
   provenance?: ToolProvenance
-): ToolResult<{ applied: boolean; nodeId: string }> {
+): Promise<ToolResult<{ applied: boolean; nodeId: string }>> {
   const editor = getEditor()
 
   if (!editor) {
@@ -197,12 +305,11 @@ export function executeEdit(
   const contentEnd = pos + node.nodeSize - 1
 
   const sizeBefore = editor.state.doc.content.size
-  editor
-    .chain()
-    .focus()
-    .setTextSelection({ from: contentStart, to: contentEnd })
-    .insertContent(content)
-    .run()
+  // Range-replace via applyInsertion: the selection delete + first chunk
+  // insert run in the same chain (atomic transaction). Subsequent rAF chunks
+  // fall inside the history plugin's newGroupDelay (500ms) and collapse into
+  // a single undo step.
+  await applyInsertion(editor, content, contentStart, contentEnd)
   const sizeAfter = editor.state.doc.content.size
 
   // Create word-level AI annotations for provenance tracking
@@ -268,7 +375,7 @@ function parseFrontmatterPayload(
  *     `nodeId` (preferred for "add to section X" — anchor on the
  *     section's heading nodeId from `read_document`)
  */
-export function executeInsert(
+export async function executeInsert(
   args: {
     text: string
     position?: 'cursor' | 'start' | 'end' | 'after_node' | 'before_node'
@@ -276,7 +383,7 @@ export function executeInsert(
     search?: string
   },
   provenance?: ToolProvenance
-): ToolResult<{ inserted: boolean; position: string }> {
+): Promise<ToolResult<{ inserted: boolean; position: string }>> {
   const editor = getEditor()
 
   if (!editor) {
@@ -348,7 +455,10 @@ export function executeInsert(
 
   try {
     const sizeBefore = editor.state.doc.content.size
-    editor.chain().focus().setTextSelection({ from: insertFrom, to: insertTo }).insertContent(text).run()
+    // Route through applyInsertion so the chunked-streaming path applies
+    // uniformly, and so range replacement (cursor case with non-empty
+    // selection) is atomic with the first chunk's insert.
+    await applyInsertion(editor, text, insertFrom, insertTo)
     const sizeAfter = editor.state.doc.content.size
 
     // Create AI annotation for provenance tracking.
@@ -357,6 +467,10 @@ export function executeInsert(
     // selection that got replaced. For a collapsed selection (the common
     // case) this reduces to `sizeAfter - sizeBefore`.
     if (provenance && provenance.documentId && text.length > 0) {
+      // Use the actual PM size delta (plus any replaced range size) instead of
+      // string length: insertContent() may produce multi-paragraph nodes where
+      // string length != PM position delta, and the doc delta nets out any
+      // selection that was replaced.
       const insertedSize = (sizeAfter - sizeBefore) + (insertTo - insertFrom)
       useAnnotationStore.getState().addAnnotation({
         documentId: provenance.documentId,

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -87,9 +87,11 @@ function nextFrame(): Promise<void> {
  * the same chain (a single transaction), so range replacement is atomic and
  * shares undo state with the first chunk.
  *
- * Subsequent chunks track the running insertion endpoint explicitly via the
- * doc-size delta, so user clicks or keystrokes mid-stream can't redirect
- * later chunks into the user's cursor position.
+ * Subsequent chunks track the running insertion endpoint via an explicit
+ * length accumulator (anchored once at end-of-insertion from TipTap's own
+ * selection placement, then advanced by each chunk's character count), so
+ * user clicks or keystrokes mid-stream can't redirect later chunks into
+ * the user's cursor position.
  */
 async function applyInsertion(
   editor: Editor,
@@ -109,24 +111,30 @@ async function applyInsertion(
     editor.chain().focus().setTextSelection(selection).insertContent(text).run()
     return
   }
-  const rangeSize = hasRange ? to! - from : 0
-  const sizeBefore = editor.state.doc.content.size
   editor.chain().focus().setTextSelection(selection).insertContent(chunks[0]).run()
-  // End of inserted content = from + (size of inserted chunk in PM coords).
-  // Inserted size = doc delta + chars removed by any range replace.
-  let pos = from + (editor.state.doc.content.size - sizeBefore) + rangeSize
-  // Subsequent chunks use a raw ProseMirror text insert rather than
-  // `insertContent`. `insertContent(string)` routes through the markdown
-  // parser, which treats top-level text as a paragraph node — so each
-  // chunk would land as its own paragraph instead of appending inline to
-  // the paragraph the first chunk just created (#553). `tr.insertText`
-  // inserts inline text into the surrounding block, preserving paragraph
-  // continuity and the intended word-by-word fill animation.
+  // Anchor the running endpoint at end-of-insertion using TipTap's own
+  // cursor placement (`selectionToInsertionEnd` in
+  // `node_modules/@tiptap/core/src/commands/insertContentAt.ts`), which
+  // leaves the cursor INSIDE the just-inserted textblock at the end of
+  // its text. Earlier doc-size arithmetic landed `pos` AFTER the closing
+  // paragraph token — a between-blocks position, where `tr.insertText`
+  // wraps the text in a new paragraph to fit the parent context,
+  // producing one paragraph per chunk.
+  //
+  // From there, advance `pos` by each chunk's character count rather than
+  // re-reading `editor.state.selection.from` after every dispatch. Two
+  // reasons: (1) subsequent chunks use raw `tr.insertText` (not
+  // `insertContent(string)`), which inserts plain text inline and adds
+  // exactly `chunks[i].length` PM units — so the accumulator is exact;
+  // (2) if the user clicks or types mid-stream, the live selection moves
+  // away from our insertion endpoint, but the accumulator stays
+  // independent — keeping later chunks landing at the running insertion
+  // point instead of redirecting into the user's cursor.
+  let pos = editor.state.selection.from
   for (let i = 1; i < chunks.length; i++) {
     await nextFrame()
-    const prev = editor.state.doc.content.size
     editor.view.dispatch(editor.state.tr.insertText(chunks[i], pos))
-    pos += editor.state.doc.content.size - prev
+    pos += chunks[i].length
   }
 }
 

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -115,6 +115,18 @@ export function resolveToolPosition(toolName: string, args: Record<string, unkno
     }
   }
 
+  if (toolName === 'delete_node') {
+    const nodeId = args.nodeId as string
+    const search = args.search as string | undefined
+    if (!nodeId) return Infinity
+
+    let found = findNodeById(editor.state.doc, nodeId)
+    if (!found && search) {
+      found = findNodeByContent(editor.state.doc, search)
+    }
+    return found ? found.pos : Infinity
+  }
+
   return Infinity
 }
 
@@ -633,6 +645,127 @@ export function executeRejectDiff(args: {
   } else {
     return toolError('Failed to reject suggestions', 'REJECT_FAILED')
   }
+}
+
+/**
+ * delete_node - Remove a node from the document by ID.
+ * Falls back to content matching if the nodeId is stale.
+ */
+export function executeDeleteNode(
+  args: {
+    nodeId: string
+    search?: string
+  },
+  provenance?: ToolProvenance
+): ToolResult<{ deleted: boolean; nodeId: string }> {
+  const editor = getEditor()
+
+  if (!editor) {
+    return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
+  }
+
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
+  }
+
+  const { nodeId, search } = args
+
+  if (!nodeId) {
+    return toolError('Node ID is required', 'INVALID_INPUT')
+  }
+
+  let found = findNodeById(editor.state.doc, nodeId)
+
+  if (!found && search) {
+    found = findNodeByContent(editor.state.doc, search)
+  }
+
+  if (!found) {
+    const available = flattenNodes(getNodesWithIds(editor.state.doc))
+    const nodeList = available.map(n => `${n.nodeId} (${n.type}: "${n.textContent.substring(0, 40)}")`).join(', ')
+    return toolError(
+      `Node with ID "${nodeId}" not found. Available nodes: [${nodeList}]`,
+      'NODE_NOT_FOUND'
+    )
+  }
+
+  const { node, pos } = found
+  const deletedText = node.textContent
+  const from = pos
+  const to = pos + node.nodeSize
+
+  editor.chain().focus().deleteRange({ from, to }).run()
+
+  // Log a deletion annotation for provenance. Range collapses to a single
+  // point at the deletion site so the annotation store treats it as a marker
+  // rather than highlighting text that no longer exists.
+  if (provenance && provenance.documentId) {
+    useAnnotationStore.getState().addAnnotation({
+      documentId: provenance.documentId,
+      type: 'deletion',
+      from,
+      to: from,
+      content: deletedText,
+      provenance: {
+        model: provenance.model,
+        conversationId: provenance.conversationId,
+        messageId: provenance.messageId,
+      },
+    })
+  }
+
+  return toolSuccess({ deleted: true, nodeId })
+}
+
+/**
+ * move_cursor - Move the user's text cursor to a specific node.
+ * Non-destructive selection change. Falls back to content matching if the
+ * nodeId is stale.
+ */
+export function executeMoveCursor(args: {
+  nodeId: string
+  position?: 'start' | 'end'
+  search?: string
+}): ToolResult<{ moved: boolean; nodeId: string; position: 'start' | 'end' }> {
+  const editor = getEditor()
+
+  if (!editor) {
+    return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
+  }
+
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
+  }
+
+  const { nodeId, search } = args
+  const position = args.position ?? 'start'
+
+  if (!nodeId) {
+    return toolError('Node ID is required', 'INVALID_INPUT')
+  }
+
+  let found = findNodeById(editor.state.doc, nodeId)
+
+  if (!found && search) {
+    found = findNodeByContent(editor.state.doc, search)
+  }
+
+  if (!found) {
+    const available = flattenNodes(getNodesWithIds(editor.state.doc))
+    const nodeList = available.map(n => `${n.nodeId} (${n.type}: "${n.textContent.substring(0, 40)}")`).join(', ')
+    return toolError(
+      `Node with ID "${nodeId}" not found. Available nodes: [${nodeList}]`,
+      'NODE_NOT_FOUND'
+    )
+  }
+
+  const { node, pos } = found
+  // Node-content positions live inside the open/close tokens.
+  const target = position === 'end' ? pos + node.nodeSize - 1 : pos + 1
+
+  editor.chain().focus().setTextSelection(target).run()
+
+  return toolSuccess({ moved: true, nodeId, position })
 }
 
 /**

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -97,6 +97,20 @@ export function resolveToolPosition(toolName: string, args: Record<string, unkno
       case 'start': return 0
       case 'end': return editor.state.doc.content.size
       case 'cursor': return editor.state.selection.from
+      case 'after_node':
+      case 'before_node': {
+        const nodeId = args.nodeId as string | undefined
+        const search = args.search as string | undefined
+        if (!nodeId) return Infinity
+        let found = findNodeById(editor.state.doc, nodeId)
+        if (!found && search) {
+          found = findNodeByContent(editor.state.doc, search)
+        }
+        if (!found) return Infinity
+        return position === 'after_node'
+          ? found.pos + found.node.nodeSize
+          : found.pos
+      }
       default: return Infinity
     }
   }
@@ -233,11 +247,21 @@ function parseFrontmatterPayload(
 
 /**
  * insert - Insert text at the specified position.
+ *
+ * Positions:
+ *   - `cursor` — at the current selection (legacy; depends on where the
+ *     user has parked the cursor, so only correct when they said "here")
+ *   - `start` / `end` — document boundaries
+ *   - `after_node` / `before_node` — relative to a node located by
+ *     `nodeId` (preferred for "add to section X" — anchor on the
+ *     section's heading nodeId from `read_document`)
  */
 export function executeInsert(
   args: {
     text: string
-    position?: 'cursor' | 'start' | 'end'
+    position?: 'cursor' | 'start' | 'end' | 'after_node' | 'before_node'
+    nodeId?: string
+    search?: string
   },
   provenance?: ToolProvenance
 ): ToolResult<{ inserted: boolean; position: string }> {
@@ -251,13 +275,14 @@ export function executeInsert(
     return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
-  const { text, position = 'cursor' } = args
+  const { text, position = 'cursor', nodeId, search } = args
 
   if (!text) {
     return toolError('Text to insert is required', 'INVALID_INPUT')
   }
 
-  // Capture insertion position before modifying the document
+  // Resolve insertion position uniformly so both the chain and the
+  // annotation use the same number.
   let insertPos: number
   switch (position) {
     case 'start':
@@ -266,6 +291,32 @@ export function executeInsert(
     case 'end':
       insertPos = editor.state.doc.content.size
       break
+    case 'after_node':
+    case 'before_node': {
+      if (!nodeId) {
+        return toolError(
+          `nodeId is required when position is "${position}"`,
+          'INVALID_INPUT'
+        )
+      }
+      let found = findNodeById(editor.state.doc, nodeId)
+      if (!found && search) {
+        found = findNodeByContent(editor.state.doc, search)
+      }
+      if (!found) {
+        const available = flattenNodes(getNodesWithIds(editor.state.doc))
+        const nodeList = available
+          .map(n => `${n.nodeId} (${n.type}: "${n.textContent.substring(0, 40)}")`)
+          .join(', ')
+        return toolError(
+          `Anchor node "${nodeId}" not found. Available nodes: [${nodeList}]`,
+          'NODE_NOT_FOUND'
+        )
+      }
+      insertPos =
+        position === 'after_node' ? found.pos + found.node.nodeSize : found.pos
+      break
+    }
     case 'cursor':
     default:
       insertPos = editor.state.selection.from
@@ -274,23 +325,7 @@ export function executeInsert(
 
   try {
     const sizeBefore = editor.state.doc.content.size
-    switch (position) {
-      case 'start':
-        editor.chain().focus().setTextSelection(0).insertContent(text).run()
-        break
-      case 'end':
-        editor
-          .chain()
-          .focus()
-          .setTextSelection(editor.state.doc.content.size)
-          .insertContent(text)
-          .run()
-        break
-      case 'cursor':
-      default:
-        editor.chain().focus().insertContent(text).run()
-        break
-    }
+    editor.chain().focus().setTextSelection(insertPos).insertContent(text).run()
     const sizeAfter = editor.state.doc.content.size
 
     // Create AI annotation for provenance tracking

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -281,15 +281,20 @@ export function executeInsert(
     return toolError('Text to insert is required', 'INVALID_INPUT')
   }
 
-  // Resolve insertion position uniformly so both the chain and the
-  // annotation use the same number.
-  let insertPos: number
+  // Resolve insertion range. Most positions collapse to a single point
+  // (insertFrom === insertTo), but `cursor` honors any active selection
+  // so a highlighted-then-asked-to-insert flow replaces the selection
+  // instead of leaving it stranded next to the new content.
+  let insertFrom: number
+  let insertTo: number
   switch (position) {
     case 'start':
-      insertPos = 0
+      insertFrom = 0
+      insertTo = 0
       break
     case 'end':
-      insertPos = editor.state.doc.content.size
+      insertFrom = editor.state.doc.content.size
+      insertTo = editor.state.doc.content.size
       break
     case 'after_node':
     case 'before_node': {
@@ -313,30 +318,39 @@ export function executeInsert(
           'NODE_NOT_FOUND'
         )
       }
-      insertPos =
+      insertFrom =
         position === 'after_node' ? found.pos + found.node.nodeSize : found.pos
+      insertTo = insertFrom
       break
     }
     case 'cursor':
     default:
-      insertPos = editor.state.selection.from
+      // Use the full selection range so non-empty selections are
+      // replaced by the inserted text. Matches the pre-#546 behavior
+      // and is what users intuitively expect when they highlight a
+      // span and ask the agent to write replacement prose.
+      insertFrom = editor.state.selection.from
+      insertTo = editor.state.selection.to
       break
   }
 
   try {
     const sizeBefore = editor.state.doc.content.size
-    editor.chain().focus().setTextSelection(insertPos).insertContent(text).run()
+    editor.chain().focus().setTextSelection({ from: insertFrom, to: insertTo }).insertContent(text).run()
     const sizeAfter = editor.state.doc.content.size
 
-    // Create AI annotation for provenance tracking
+    // Create AI annotation for provenance tracking.
+    // Inserted PM range = [insertFrom, insertFrom + insertedSize], where
+    // insertedSize accounts for both the doc-size delta and the original
+    // selection that got replaced. For a collapsed selection (the common
+    // case) this reduces to `sizeAfter - sizeBefore`.
     if (provenance && provenance.documentId && text.length > 0) {
+      const insertedSize = (sizeAfter - sizeBefore) + (insertTo - insertFrom)
       useAnnotationStore.getState().addAnnotation({
         documentId: provenance.documentId,
         type: 'insertion',
-        from: insertPos,
-        // Use the actual PM size delta instead of string length: insertContent()
-        // may produce multi-paragraph nodes where string length != PM position delta.
-        to: insertPos + (sizeAfter - sizeBefore),
+        from: insertFrom,
+        to: insertFrom + insertedSize,
         content: text,
         provenance: {
           model: provenance.model,

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -261,6 +261,7 @@ export async function executeEdit(
   args: {
     nodeId: string
     content: string
+    comment?: string
     search?: string
   },
   provenance?: ToolProvenance
@@ -275,7 +276,7 @@ export async function executeEdit(
     return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
-  const { nodeId, content, search } = args
+  const { nodeId, content, comment, search } = args
 
   if (!nodeId) {
     return toolError('Node ID is required', 'INVALID_INPUT')
@@ -340,6 +341,7 @@ export async function executeEdit(
         conversationId: provenance.conversationId,
         messageId: provenance.messageId,
       },
+      explanation: comment,
     })
   }
 
@@ -395,6 +397,7 @@ export async function executeInsert(
     text: string
     position?: 'cursor' | 'start' | 'end' | 'after_node' | 'before_node'
     nodeId?: string
+    comment?: string
     search?: string
   },
   provenance?: ToolProvenance
@@ -409,7 +412,7 @@ export async function executeInsert(
     return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
   }
 
-  const { text, position = 'cursor', nodeId, search } = args
+  const { text, position = 'cursor', nodeId, comment, search } = args
 
   if (!text) {
     return toolError('Text to insert is required', 'INVALID_INPUT')
@@ -487,17 +490,22 @@ export async function executeInsert(
       // string length != PM position delta, and the doc delta nets out any
       // selection that was replaced.
       const insertedSize = (sizeAfter - sizeBefore) + (insertTo - insertFrom)
-      useAnnotationStore.getState().addAnnotation({
+      // Route through createWordDiffAnnotations for visual consistency with
+      // edit/suggest_edit-accept annotations (word-level underline, explanation
+      // in tooltip). originalText is empty for pure insertions; the util
+      // promotes the type to 'insertion' automatically.
+      createWordDiffAnnotations({
         documentId: provenance.documentId,
-        type: 'insertion',
-        from: insertFrom,
-        to: insertFrom + insertedSize,
-        content: text,
+        originalText: '',
+        newText: text,
+        rangeFrom: insertFrom,
+        rangeTo: insertFrom + insertedSize,
         provenance: {
           model: provenance.model,
           conversationId: provenance.conversationId,
           messageId: provenance.messageId,
         },
+        explanation: comment,
       })
     }
 

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -115,10 +115,17 @@ async function applyInsertion(
   // End of inserted content = from + (size of inserted chunk in PM coords).
   // Inserted size = doc delta + chars removed by any range replace.
   let pos = from + (editor.state.doc.content.size - sizeBefore) + rangeSize
+  // Subsequent chunks use a raw ProseMirror text insert rather than
+  // `insertContent`. `insertContent(string)` routes through the markdown
+  // parser, which treats top-level text as a paragraph node — so each
+  // chunk would land as its own paragraph instead of appending inline to
+  // the paragraph the first chunk just created (#553). `tr.insertText`
+  // inserts inline text into the surrounding block, preserving paragraph
+  // continuity and the intended word-by-word fill animation.
   for (let i = 1; i < chunks.length; i++) {
     await nextFrame()
     const prev = editor.state.doc.content.size
-    editor.chain().setTextSelection(pos).insertContent(chunks[i]).run()
+    editor.view.dispatch(editor.state.tr.insertText(chunks[i], pos))
     pos += editor.state.doc.content.size - prev
   }
 }

--- a/src/renderer/lib/tools/executors/ui.ts
+++ b/src/renderer/lib/tools/executors/ui.ts
@@ -1,0 +1,27 @@
+import type { ToolResult } from '../../../../shared/tools/types'
+import { toolSuccess } from '../../../../shared/tools/types'
+import type { ToolMode } from '../../../../shared/tools/types'
+
+/**
+ * Executor for request_mode_switch.
+ *
+ * Does NOT actually change the mode — that would bypass the user's intent.
+ * It just packages the agent's request as a tool result, which the chat-side
+ * renderer (`RequestModeSwitchResult.tsx` — `RequestModeSwitchBody` /
+ * `RequestModeSwitchActions`) turns into a one-click button.
+ *
+ * The user clicks the button; the renderer calls `setToolMode` and (for
+ * "Switch & Run") `sendMessage(prompt_to_retry)`. Mode change is always
+ * gated on an explicit user action.
+ */
+export interface RequestModeSwitchPayload {
+  target: ToolMode
+  reason: string
+  prompt_to_retry: string
+}
+
+export function executeRequestModeSwitch(
+  args: RequestModeSwitchPayload
+): ToolResult<RequestModeSwitchPayload> {
+  return toolSuccess(args)
+}

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -62,7 +62,7 @@ export interface ToolProvenance {
 export async function executeTool(
   toolName: string,
   args: unknown,
-  mode: ToolMode = 'full',
+  mode: ToolMode = 'create',
   provenance?: ToolProvenance
 ): Promise<ToolResult> {
   // Check if tool exists

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -47,6 +47,9 @@ import {
   executeSelectTab
 } from './executors/tabs'
 
+// UI-coordination executors
+import { executeRequestModeSwitch } from './executors/ui'
+
 /** Provenance context for AI-generated content tracking */
 export interface ToolProvenance {
   model: string
@@ -143,6 +146,10 @@ export async function executeTool(
         return executeListTabs()
       case 'select_tab':
         return await executeSelectTab(validatedArgs)
+
+      // UI-coordination tools
+      case 'request_mode_switch':
+        return executeRequestModeSwitch(validatedArgs as Parameters<typeof executeRequestModeSwitch>[0])
 
       default:
         return toolError(`Tool "${toolName}" not implemented`, 'NOT_IMPLEMENTED')

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -28,6 +28,8 @@ import {
   executeAcceptDiff,
   executeRejectDiff,
   executeListDiffs,
+  executeDeleteNode,
+  executeMoveCursor,
   resolveToolPosition
 } from './executors/editor'
 
@@ -126,6 +128,10 @@ export async function executeTool(
         return executeRejectDiff(validatedArgs)
       case 'list_diffs':
         return executeListDiffs()
+      case 'delete_node':
+        return executeDeleteNode(validatedArgs, provenance)
+      case 'move_cursor':
+        return executeMoveCursor(validatedArgs)
 
       // File tools (async)
       case 'open_file':

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -163,6 +163,7 @@ export function getAvailableTools(): string[] {
  * Re-export types and utilities.
  */
 export { checkToolAccess, getDefaultMode } from './modes'
+export { isToolAvailableInMode } from '../../../shared/tools/registry'
 export { resolveToolPosition }
 export type { ToolResult, ToolMode } from '../../../shared/tools/types'
 export { toolSuccess, toolError } from '../../../shared/tools/types'

--- a/src/renderer/lib/tools/modes.ts
+++ b/src/renderer/lib/tools/modes.ts
@@ -24,7 +24,13 @@ export function checkToolAccess(toolName: string, mode: ToolMode): string | null
   }
 
   if (!isToolAvailableInMode(toolName, mode)) {
-    return `Tool "${toolName}" is not available in ${MODE_LABEL[mode]} Mode. Switch to Create Mode to use this tool.`
+    // Point the user/agent at the *minimum* mode that exposes this tool — not
+    // always Create. A suggest_edit attempted from Chat Mode should say "Switch
+    // to Editor", not "Switch to Create". `tool.requiresMode` is guaranteed
+    // non-null here (the `requiresMode === null` branch in isToolAvailableInMode
+    // would have returned true already), but we default for type-safety.
+    const required = tool.requiresMode ? MODE_LABEL[tool.requiresMode] : 'Create'
+    return `Tool "${toolName}" is not available in ${MODE_LABEL[mode]} Mode. Switch to ${required} Mode to use this tool.`
   }
 
   return null

--- a/src/renderer/lib/tools/modes.ts
+++ b/src/renderer/lib/tools/modes.ts
@@ -6,6 +6,12 @@
 import type { ToolMode } from '../../../shared/tools/types'
 import { getTool, isToolAvailableInMode } from '../../../shared/tools/registry'
 
+const MODE_LABEL: Record<ToolMode, string> = {
+  chat: 'Chat',
+  editor: 'Editor',
+  create: 'Create'
+}
+
 /**
  * Check if a tool can be executed in the current mode.
  * Returns an error message if not allowed, or null if allowed.
@@ -18,14 +24,7 @@ export function checkToolAccess(toolName: string, mode: ToolMode): string | null
   }
 
   if (!isToolAvailableInMode(toolName, mode)) {
-    const modeLabel =
-      mode === 'suggestions'
-        ? 'Suggestions'
-        : mode === 'plan'
-          ? 'Plan'
-          : 'Full Autonomy'
-
-    return `Tool "${toolName}" is not available in ${modeLabel} mode. Switch to Full Autonomy mode to use this tool.`
+    return `Tool "${toolName}" is not available in ${MODE_LABEL[mode]} Mode. Switch to Create Mode to use this tool.`
   }
 
   return null
@@ -35,5 +34,5 @@ export function checkToolAccess(toolName: string, mode: ToolMode): string | null
  * Get the default mode for the chat.
  */
 export function getDefaultMode(): ToolMode {
-  return 'suggestions'
+  return 'editor'
 }

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -369,3 +369,23 @@ useChatStore.subscribe(
     debouncedSave()
   }
 )
+
+// Persist toolMode globally whenever it changes.
+// Uses a lazy dynamic import to avoid a static circular dependency between
+// chatStore and settingsStore (settingsStore already lazy-imports chatStore
+// inside loadSettings()). The subscription fires after the store is
+// initialized so the import always resolves before the callback runs.
+// The guard (toolMode !== settings.toolMode) prevents a redundant write when
+// settingsStore.loadSettings() hydrates chatStore on boot — the value is
+// already persisted and does not need to be written back.
+useChatStore.subscribe(
+  (state) => state.toolMode,
+  (toolMode) => {
+    import('./settingsStore').then(({ useSettingsStore }) => {
+      const current = useSettingsStore.getState().settings.toolMode
+      if (current !== toolMode) {
+        useSettingsStore.getState().setPersistedToolMode(toolMode)
+      }
+    }).catch(() => { /* non-fatal */ })
+  }
+)

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -24,6 +24,12 @@ interface ChatState {
   context: string | null
   agentMode: boolean // Legacy - kept for backwards compatibility
   toolMode: ToolMode // New mode system
+  // Tracks the toolMode active at the last successful user message send,
+  // so we can detect mid-conversation mode switches and note them in the
+  // next system prompt. Idempotent across multiple toggles between sends —
+  // only the difference at send time matters. In-memory only (matches
+  // toolMode itself).
+  lastSentToolMode: ToolMode | null
 
   // Initialization state - prevents race conditions during app startup
   isInitializing: boolean
@@ -52,6 +58,7 @@ interface ChatState {
   setContext: (context: string | null) => void
   setToolMode: (mode: ToolMode) => void
   cycleToolMode: () => void
+  setLastSentToolMode: (mode: ToolMode | null) => void
 
   // Streaming actions
   startStreaming: (messageId: string, streamId: string) => void
@@ -88,6 +95,7 @@ export const useChatStore = create<ChatState>()(
     // renders edit blocks as reviewable diffs).
     agentMode: false,
     toolMode: 'editor',
+    lastSentToolMode: null,
     isInitializing: true, // Start as true, will be set to false after app init
     isStreaming: false,
     currentStreamId: null,
@@ -237,6 +245,8 @@ export const useChatStore = create<ChatState>()(
       const next: ToolMode = current === 'chat' ? 'editor' : current === 'editor' ? 'create' : 'chat'
       get().setToolMode(next)
     },
+
+    setLastSentToolMode: (mode) => set({ lastSentToolMode: mode }),
 
     // Streaming actions
     startStreaming: (messageId, streamId) =>

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -59,6 +59,13 @@ interface ChatState {
   setToolMode: (mode: ToolMode) => void
   cycleToolMode: () => void
   setLastSentToolMode: (mode: ToolMode | null) => void
+  /**
+   * Record an action taken on a tool result. Persists with the
+   * conversation so reopening the chat shows the truthful state
+   * (e.g., "Dismissed." or "Switched to Editor Mode.") instead of
+   * re-clickable buttons for decisions already made.
+   */
+  setToolCallAction: (messageId: string, toolPartIdx: number, action: 'switched' | 'dismissed') => void
 
   // Streaming actions
   startStreaming: (messageId: string, streamId: string) => void
@@ -247,6 +254,25 @@ export const useChatStore = create<ChatState>()(
     },
 
     setLastSentToolMode: (mode) => set({ lastSentToolMode: mode }),
+
+    setToolCallAction: (messageId, toolPartIdx, action) =>
+      set((state) => {
+        const updateOne = (msg: ChatMessage): ChatMessage =>
+          msg.id === messageId
+            ? { ...msg, toolActions: { ...(msg.toolActions ?? {}), [toolPartIdx]: action } }
+            : msg
+        const newMessages = state.messages.map(updateOne)
+
+        if (state.activeConversationId) {
+          const updatedConversations = state.conversations.map((c) =>
+            c.id === state.activeConversationId
+              ? { ...c, messages: newMessages, updatedAt: Date.now() }
+              : c
+          )
+          return { messages: newMessages, conversations: updatedConversations }
+        }
+        return { messages: newMessages }
+      }),
 
     // Streaming actions
     startStreaming: (messageId, streamId) =>

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -8,14 +8,9 @@ import {
   generateConversationTitle
 } from '../lib/persistence'
 import type { ChatConversation } from '../lib/persistence'
+import type { ToolMode } from '../../shared/tools/types'
 
-/**
- * Tool modes control which tools are available to the AI.
- * - suggestions: Read-only + suggest_edit (safe default)
- * - full: All tools available (direct edits)
- * - plan: Proposes changes, user must approve
- */
-export type ToolMode = 'suggestions' | 'full' | 'plan'
+export type { ToolMode }
 
 interface ChatState {
   // Conversation management
@@ -55,8 +50,8 @@ interface ChatState {
   togglePanel: () => void
   setPanelOpen: (open: boolean) => void
   setContext: (context: string | null) => void
-  setAgentMode: (enabled: boolean) => void
   setToolMode: (mode: ToolMode) => void
+  cycleToolMode: () => void
 
   // Streaming actions
   startStreaming: (messageId: string, streamId: string) => void
@@ -83,8 +78,16 @@ export const useChatStore = create<ChatState>()(
     isLoading: false,
     isPanelOpen: false,
     context: null,
-    agentMode: true, // Legacy - maps to toolMode
-    toolMode: 'full', // Default to full for backwards compatibility with agentMode: true
+    // Editor is the default — safe-by-default posture: agent proposes copy
+    // edits and editorial notes but never authors prose into the document.
+    // Users opt into Create Mode via the StatusBar dropdown or Shift+Tab
+    // (cycleToolMode walks chat → editor → create → chat). agentMode is a
+    // legacy boolean kept in sync with toolMode === 'create' for the few
+    // remaining readers — currently ChatMessage.tsx's legacy <edit>-block
+    // auto-apply path (`agentMode=true` auto-applies; `agentMode=false`
+    // renders edit blocks as reviewable diffs).
+    agentMode: false,
+    toolMode: 'editor',
     isInitializing: true, // Start as true, will be set to false after app init
     isStreaming: false,
     currentStreamId: null,
@@ -217,17 +220,23 @@ export const useChatStore = create<ChatState>()(
 
     setContext: (context) => set({ context }),
 
-    setAgentMode: (enabled) => set({
-      agentMode: enabled,
-      // Sync toolMode with agentMode for backwards compatibility
-      toolMode: enabled ? 'full' : 'suggestions'
-    }),
-
     setToolMode: (mode) => set({
       toolMode: mode,
-      // Sync agentMode with toolMode for backwards compatibility
-      agentMode: mode === 'full'
+      // Legacy agentMode is "true" only in Create Mode — the only mode
+      // where the agent can author prose directly.
+      agentMode: mode === 'create'
     }),
+
+    // Cycle through all three modes: chat → editor → create → chat.
+    // Used by the Shift+Tab keyboard shortcut so Editor Mode (the new
+    // safe-by-default mode) is reachable via keyboard, not just the
+    // StatusBar dropdown. Delegates to setToolMode so agentMode stays
+    // in sync.
+    cycleToolMode: () => {
+      const current = get().toolMode
+      const next: ToolMode = current === 'chat' ? 'editor' : current === 'editor' ? 'create' : 'chat'
+      get().setToolMode(next)
+    },
 
     // Streaming actions
     startStreaming: (messageId, streamId) =>

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -4,6 +4,7 @@ import type { Settings } from '../types'
 import { initRendererSentry, setRendererSentryEnabled } from '../lib/sentry'
 import { getDefaultModel } from '../../shared/llm/models'
 import type { ModelInfo } from '../../shared/llm/models'
+import type { ToolMode } from '../../shared/tools/types'
 
 const MAX_RECENT_FILES = 15
 
@@ -70,6 +71,7 @@ interface SettingsState {
   setAIConsent: (consented: boolean) => void
   isAIConsentDialogOpen: boolean
   setAIConsentDialogOpen: (open: boolean) => void
+  setPersistedToolMode: (mode: ToolMode) => void
 }
 
 const defaultSettings: Settings = {
@@ -188,6 +190,13 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
       // Apply theme and set up listener
       applyTheme(theme)
       setupSystemThemeListener(theme, set)
+
+      // Hydrate chatStore toolMode from persisted settings (global, applies to all tabs).
+      // Import lazily to avoid a static top-level import that could cause sandbox issues.
+      // The persisted value takes priority; fall back to the store's in-memory default.
+      const persistedToolMode = settings.toolMode ?? defaultSettings.toolMode ?? 'editor'
+      const { useChatStore } = await import('./chatStore')
+      useChatStore.getState().setToolMode(persistedToolMode)
 
       // Initialize Sentry if user has opted in
       initRendererSentry(settings?.errorTracking?.enabled === true)
@@ -405,5 +414,12 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
     get().saveSettings()
   },
 
-  setAIConsentDialogOpen: (open) => set({ isAIConsentDialogOpen: open })
+  setAIConsentDialogOpen: (open) => set({ isAIConsentDialogOpen: open }),
+
+  setPersistedToolMode: (mode) => {
+    set((state) => ({
+      settings: { ...state.settings, toolMode: mode }
+    }))
+    get().saveSettings()
+  }
 })))

--- a/src/renderer/types/annotations.ts
+++ b/src/renderer/types/annotations.ts
@@ -8,7 +8,7 @@
 /**
  * Type of AI text modification
  */
-export type AnnotationType = 'insertion' | 'replacement'
+export type AnnotationType = 'insertion' | 'replacement' | 'deletion'
 
 /**
  * Provenance information about the AI that generated the text

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -61,6 +61,11 @@ export interface Settings {
     googleDocs?: boolean
     remarkable?: boolean
   }
+  /**
+   * Persisted tool mode for the AI assistant (global, shared across all tabs/conversations).
+   * Defaults to 'editor' on first launch.
+   */
+  toolMode?: 'chat' | 'editor' | 'create'
 }
 
 export interface Document {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -308,6 +308,12 @@ export interface LLMStreamToolCall {
   }
 }
 
+export interface LLMStreamToolCallStart {
+  streamId: string
+  toolCallId: string
+  toolName: string
+}
+
 export interface LLMStreamComplete {
   streamId: string
   content: string
@@ -365,6 +371,7 @@ export interface ElectronAPI {
   llmAbortStream: (streamId: string) => Promise<{ success: boolean }>
   onLLMStreamChunk: (callback: (chunk: LLMStreamChunk) => void) => () => void
   onLLMStreamToolCall: (callback: (toolCall: LLMStreamToolCall) => void) => () => void
+  onLLMStreamToolCallStart: (callback: (start: LLMStreamToolCallStart) => void) => () => void
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => () => void
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
   // Folder operations for quick save

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -73,6 +73,16 @@ export interface ChatMessage {
   timestamp: Date
   hidden?: boolean
   isError?: boolean
+  /**
+   * Per-tool-call action state, keyed by the tool-result's index in
+   * `parseToolTags(content)`. Populated when the user interacts with an
+   * actionable tool result (currently `request_mode_switch` —
+   * 'switched' if they hit Switch & Run / Just Switch, 'dismissed' if
+   * Cancel). Persisted with the conversation so re-opening the chat
+   * shows a truthful record instead of re-clickable affordances for
+   * decisions already made.
+   */
+  toolActions?: Record<number, 'switched' | 'dismissed'>
 }
 
 export interface FileResult {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -20,6 +20,12 @@ export interface Settings {
     fontSize: number
     lineHeight: number
     fontFamily: string
+    /**
+     * Cosmetic chunked streaming for agent-driven insertions/edits — text
+     * arrives word-by-word over ~200–500ms instead of appearing instantly.
+     * Falls back to instant apply when the user prefers reduced motion.
+     */
+    streamingEdits?: boolean
   }
   recovery?: {
     mode: 'silent' | 'prompt'

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -6,13 +6,14 @@ import type { ToolConfig, ToolMode, ToolCategory } from './types'
 import { documentTools } from './schemas/document'
 import { editorTools } from './schemas/editor'
 import { fileTools } from './schemas/file'
+import { uiTools } from './schemas/ui'
 import { tabTools } from './schemas/tabs'
 import { zodToJsonSchema } from './utils'
 
 /**
  * All registered tools.
  */
-export const allTools = [...documentTools, ...editorTools, ...fileTools, ...tabTools] as const
+export const allTools = [...documentTools, ...editorTools, ...fileTools, ...tabTools, ...uiTools] as const
 
 /**
  * Tool name type (union of all tool names).

--- a/src/shared/tools/registry.ts
+++ b/src/shared/tools/registry.ts
@@ -41,15 +41,31 @@ export function getToolsByCategory(category: ToolCategory): ToolConfig[] {
 }
 
 /**
+ * Mode capability ladder: each mode includes everything below it.
+ *
+ *   chat   ⊂ editor ⊂ create
+ *
+ * A tool with `requiresMode: 'editor'` is available in editor and create, not chat.
+ * `requiresMode: 'create'` is create-only. `requiresMode: null` is available everywhere.
+ *
+ * Note: `chat` is at the bottom of the ladder for gating purposes — at runtime,
+ * Chat Mode's actual tool surface is narrowed further at the useChat call site
+ * to a read-only subset (see CHAT_MODE_TOOL_NAMES in src/renderer/hooks/useChat.ts).
+ */
+const MODE_LEVEL: Record<ToolMode, number> = {
+  chat: 0,
+  editor: 1,
+  create: 2
+}
+
+/**
  * Get all tools available in a given mode.
  */
 export function getToolsForMode(mode: ToolMode): ToolConfig[] {
+  const modeLevel = MODE_LEVEL[mode]
   return allTools.filter((tool) => {
     if (tool.requiresMode === null) return true
-    if (mode === 'full') return true // Full mode has access to all tools
-    if (mode === 'plan') return tool.requiresMode !== 'full' // Plan excludes full-only
-    // Suggestions mode: only tools that don't require full or plan
-    return tool.requiresMode === 'suggestions' || tool.requiresMode === null
+    return MODE_LEVEL[tool.requiresMode] <= modeLevel
   })
 }
 
@@ -60,16 +76,14 @@ export function isToolAvailableInMode(name: string, mode: ToolMode): boolean {
   const tool = getTool(name)
   if (!tool) return false
   if (tool.requiresMode === null) return true
-  if (mode === 'full') return true
-  if (mode === 'plan') return tool.requiresMode !== 'full'
-  return tool.requiresMode === null
+  return MODE_LEVEL[tool.requiresMode] <= MODE_LEVEL[mode]
 }
 
 /**
  * Get tools formatted for Claude API tool_use.
  * Returns array of tool definitions with JSON schema.
  */
-export function getToolsForClaudeAPI(mode: ToolMode = 'full'): Array<{
+export function getToolsForClaudeAPI(mode: ToolMode = 'create'): Array<{
   name: string
   description: string
   input_schema: Record<string, unknown>

--- a/src/shared/tools/schemas/document.ts
+++ b/src/shared/tools/schemas/document.ts
@@ -145,7 +145,10 @@ export const addCommentConfig: ToolConfig<typeof addCommentSchema> = {
     'Add a comment to a node or range in the document. Provide nodeId (preferred, from read_document) or from/to positions. Returns { id } of the new comment.',
   schema: addCommentSchema,
   category: 'document',
-  requiresMode: null,
+  // Comments mutate document state; Chat Mode stays read-only. Editor Mode
+  // needs add_comment to deliver the non-authorship affordance: the agent
+  // can flag editorial issues without proposing replacement prose.
+  requiresMode: 'editor',
   dangerous: false
 }
 
@@ -163,7 +166,9 @@ export const resolveCommentConfig: ToolConfig<typeof resolveCommentSchema> = {
     'Resolve (remove) a comment by its ID. Use list_comments to see all comment IDs.',
   schema: resolveCommentSchema,
   category: 'document',
-  requiresMode: null,
+  // Sibling of add_comment — removing a comment is also a mutation, so it
+  // belongs in Editor Mode and up. list_comments stays read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -16,6 +16,12 @@ export const editSchema = z.object({
       'The ID of the node to edit. Get node IDs from read_document which lists all nodes with their IDs.'
     ),
   content: z.string().describe('The new content for the node (replaces entire node content)'),
+  comment: z
+    .string()
+    .optional()
+    .describe(
+      'Brief rationale for the change, surfaced in the post-write annotation tooltip. Keep under 20 words.'
+    ),
   search: z
     .string()
     .optional()
@@ -52,6 +58,12 @@ export const insertSchema = z.object({
     .optional()
     .describe(
       'Required when position is after_node or before_node. Get from read_document. To append to a section, use the heading nodeId with position=after_node — the text lands as a new node immediately after the heading.'
+    ),
+  comment: z
+    .string()
+    .optional()
+    .describe(
+      'Brief rationale for the change, surfaced in the post-write annotation tooltip. Keep under 20 words.'
     ),
   search: z
     .string()

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -39,17 +39,32 @@ export const editConfig: ToolConfig<typeof editSchema> = {
 // ============================================================================
 
 export const insertSchema = z.object({
-  text: z.string().describe('Text to insert at the current cursor position'),
+  text: z.string().describe('Text to insert at the specified position'),
   position: z
-    .enum(['cursor', 'start', 'end'])
+    .enum(['cursor', 'start', 'end', 'after_node', 'before_node'])
     .optional()
     .default('cursor')
-    .describe('Where to insert: at cursor, document start, or document end')
+    .describe(
+      'Where to insert. Use after_node or before_node (paired with nodeId from read_document) when adding to a specific section — e.g., after_node with a heading nodeId to append content under that heading. Use cursor only when the user explicitly said "here". start/end target the document boundaries.'
+    ),
+  nodeId: z
+    .string()
+    .optional()
+    .describe(
+      'Required when position is after_node or before_node. Get from read_document. To append to a section, use the heading nodeId with position=after_node — the text lands as a new node immediately after the heading.'
+    ),
+  search: z
+    .string()
+    .optional()
+    .describe(
+      'Original text content of the anchor node (from read_document). Used as fallback to locate the node if nodeId is stale.'
+    )
 })
 
 export const insertConfig: ToolConfig<typeof insertSchema> = {
   name: 'insert',
-  description: 'Insert text at the specified position in the document',
+  description:
+    'Insert text at the specified position in the document. For "add to section X", call read_document first to get the section heading\'s nodeId, then call insert with position=after_node and that nodeId. Avoid position=cursor unless the user said "here" — the cursor may be far from the intended target.',
   schema: insertSchema,
   category: 'editor',
   requiresMode: 'create',

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -85,7 +85,9 @@ export const suggestEditConfig: ToolConfig<typeof suggestEditSchema> = {
     'Create an inline diff suggestion on a node. The user sees a highlighted comparison and can accept or reject it. Use read_document first to get node IDs. Always include the search parameter with the original text for reliability.',
   schema: suggestEditSchema,
   category: 'editor',
-  requiresMode: null, // Available in all modes
+  // Suggestions are still mutations of pending document state (the diff
+  // overlay). Editor Mode's defining capability; Chat Mode stays read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 
@@ -105,7 +107,8 @@ export const acceptDiffConfig: ToolConfig<typeof acceptDiffSchema> = {
   description: 'Accept a pending suggestion. If no ID provided, accepts all pending suggestions.',
   schema: acceptDiffSchema,
   category: 'editor',
-  requiresMode: null, // Available in all modes
+  // Accepting a diff commits a content mutation. Chat Mode stays read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 
@@ -125,7 +128,9 @@ export const rejectDiffConfig: ToolConfig<typeof rejectDiffSchema> = {
   description: 'Reject a pending suggestion. If no ID provided, rejects all pending suggestions.',
   schema: rejectDiffSchema,
   category: 'editor',
-  requiresMode: null, // Available in all modes
+  // Rejecting a diff dismisses pending state. Symmetric with accept_diff;
+  // belongs in Editor Mode so Chat stays purely read-only.
+  requiresMode: 'editor',
   dangerous: false
 }
 

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -30,7 +30,7 @@ export const editConfig: ToolConfig<typeof editSchema> = {
     "Replace the content of a specific node by ID. Use read_document first to see all nodes with their IDs, then target the node you want to edit. Always include the search parameter with the original text for reliability. Special nodeId: pass 'frontmatter' with the COMPLETE new YAML (with or without --- fences) to direct-write the frontmatter block (no overlay, no search needed).",
   schema: editSchema,
   category: 'editor',
-  requiresMode: 'full', // Only available in Full Autonomy mode
+  requiresMode: 'create', // Direct writes — only available in Create Mode
   dangerous: false
 }
 
@@ -52,7 +52,7 @@ export const insertConfig: ToolConfig<typeof insertSchema> = {
   description: 'Insert text at the specified position in the document',
   schema: insertSchema,
   category: 'editor',
-  requiresMode: 'full',
+  requiresMode: 'create',
   dangerous: false
 }
 

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -45,7 +45,7 @@ export const insertSchema = z.object({
     .optional()
     .default('cursor')
     .describe(
-      'Where to insert. Use after_node or before_node (paired with nodeId from read_document) when adding to a specific section — e.g., after_node with a heading nodeId to append content under that heading. Use cursor only when the user explicitly said "here". start/end target the document boundaries.'
+      'Where to insert. Use after_node or before_node (paired with nodeId from read_document) when adding to a specific section — e.g., after_node with a heading nodeId to append content under that heading. Use cursor when the user said "here", OR when the user has a non-empty selection and asks to replace it: position=cursor over a selection deletes the selected range and inserts the new text in its place. start/end target the document boundaries.'
     ),
   nodeId: z
     .string()
@@ -64,7 +64,7 @@ export const insertSchema = z.object({
 export const insertConfig: ToolConfig<typeof insertSchema> = {
   name: 'insert',
   description:
-    'Insert text at the specified position in the document. For "add to section X", call read_document first to get the section heading\'s nodeId, then call insert with position=after_node and that nodeId. Avoid position=cursor unless the user said "here" — the cursor may be far from the intended target.',
+    'Insert text at the specified position in the document. For "add to section X", call read_document first to get the section heading\'s nodeId, then call insert with position=after_node and that nodeId. For "replace this with X" when the user has a non-empty selection, use position=cursor — insert deletes the selection and inserts the new text in its place. Important: the selection-replace path depends on the selection still being live at call time. If you call other tools that may clear selection (e.g., read_document) between the user\'s request and the insert, the selection collapses and what was meant as a replacement becomes a plain cursor insert — read_selection is safer if you need to confirm the range before acting. Otherwise avoid position=cursor unless the user said "here".',
   schema: insertSchema,
   category: 'editor',
   requiresMode: 'create',

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -150,6 +150,68 @@ export const rejectDiffConfig: ToolConfig<typeof rejectDiffSchema> = {
 }
 
 // ============================================================================
+// delete_node
+// ============================================================================
+
+export const deleteNodeSchema = z.object({
+  nodeId: z
+    .string()
+    .describe(
+      'The ID of the node to delete. Get node IDs from read_document which lists all nodes with their IDs.'
+    ),
+  search: z
+    .string()
+    .optional()
+    .describe(
+      'Original text content of the node (from read_document). Used as fallback to locate the node if nodeId is stale.'
+    )
+})
+
+export const deleteNodeConfig: ToolConfig<typeof deleteNodeSchema> = {
+  name: 'delete_node',
+  description:
+    'Delete a specific node by ID. Use read_document first to see all nodes with their IDs, then target the node you want to remove. Include the search parameter with the original text for reliability if the node ID may be stale.',
+  schema: deleteNodeSchema,
+  category: 'editor',
+  requiresMode: 'create', // Destructive — only available in Create Mode
+  dangerous: false
+}
+
+// ============================================================================
+// move_cursor
+// ============================================================================
+
+export const moveCursorSchema = z.object({
+  nodeId: z
+    .string()
+    .describe(
+      'The ID of the node to move the cursor to. Get node IDs from read_document.'
+    ),
+  position: z
+    .enum(['start', 'end'])
+    .optional()
+    .default('start')
+    .describe('Where in the node to place the cursor: at the start (default) or end of its content.'),
+  search: z
+    .string()
+    .optional()
+    .describe(
+      'Original text content of the node (from read_document). Used as fallback to locate the node if nodeId is stale.'
+    )
+})
+
+export const moveCursorConfig: ToolConfig<typeof moveCursorSchema> = {
+  name: 'move_cursor',
+  description:
+    "Move the user's text cursor to a specific node. Useful before calling insert with position 'cursor' to park the cursor at a known location. Use read_document first to get node IDs.",
+  schema: moveCursorSchema,
+  category: 'editor',
+  // Non-destructive selection change — available in Editor (and Create by inheritance).
+  requiresMode: 'editor',
+  dangerous: false
+}
+
+// ============================================================================
 // Export all editor tools
 // ============================================================================
 
@@ -158,5 +220,7 @@ export const editorTools = [
   insertConfig,
   suggestEditConfig,
   acceptDiffConfig,
-  rejectDiffConfig
+  rejectDiffConfig,
+  deleteNodeConfig,
+  moveCursorConfig
 ] as const

--- a/src/shared/tools/schemas/ui.ts
+++ b/src/shared/tools/schemas/ui.ts
@@ -1,0 +1,45 @@
+/**
+ * UI-coordination tool schemas — tools that don't read or mutate the
+ * document; they help the agent coordinate UX flows with the user.
+ */
+
+import { z } from 'zod'
+import type { ToolConfig } from '../types'
+
+// ============================================================================
+// request_mode_switch
+// ============================================================================
+
+export const requestModeSwitchSchema = z.object({
+  target: z
+    .enum(['chat', 'editor', 'create'])
+    .describe(
+      'The mode the user should switch to in order to do what they asked.'
+    ),
+  reason: z
+    .string()
+    .describe(
+      'One short sentence explaining what the new mode enables. Shown above the button in the chat. Keep under 20 words.'
+    ),
+  prompt_to_retry: z
+    .string()
+    .describe(
+      'The exact prompt to run after the switch. The user can click "Switch & Run" to mode-switch + auto-send this, or "Just Switch" to mode-switch and re-ask manually. Phrase this as if the user wrote it.'
+    )
+})
+
+export const requestModeSwitchConfig: ToolConfig<typeof requestModeSwitchSchema> = {
+  name: 'request_mode_switch',
+  description:
+    "Offer the user a one-click switch to a different mode when their request requires capabilities the current mode doesn't have. Use this INSTEAD of explaining the mode system in prose. Renders as a small in-chat button: 'Switch & Run' performs the switch and re-sends prompt_to_retry; 'Just Switch' only changes the mode. DO NOT call this tool if you can fulfill the user's request with the tools already available to you in the current mode — that creates a confusing double-switch loop. If the system prompt notes that the user just switched modes, do NOT call this tool in that turn at all — they've already switched. Available in every mode — it's the agent's escape valve when the user asks for something out of scope.",
+  schema: requestModeSwitchSchema,
+  category: 'ui',
+  requiresMode: null,
+  dangerous: false
+}
+
+// ============================================================================
+// Export all UI tools
+// ============================================================================
+
+export const uiTools = [requestModeSwitchConfig] as const

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -7,8 +7,17 @@ import type { z } from 'zod'
 
 /**
  * Tool execution modes that control which tools are available.
+ *
+ * - `chat`   — read-only. Sounding board / fact-check; agent cannot mutate the doc.
+ * - `editor` — propose copy edits via suggest_edit, leave editorial notes via add_comment. Default. No direct writes.
+ * - `create` — opt-in. Drafting allowed (`edit` / `insert` available). User has explicitly lifted the no-authorship rule.
+ *
+ * Renamed from `suggestions` / `plan` / `full` in #467 Chunk 3. `toolMode`
+ * is in-memory only — `chatStore` does not use Zustand's `persist` middleware
+ * and `ChatConversation` does not carry `toolMode`. Each session re-initializes
+ * to the chatStore default, so no migration is needed.
  */
-export type ToolMode = 'suggestions' | 'full' | 'plan'
+export type ToolMode = 'chat' | 'editor' | 'create'
 
 /**
  * Tool categories for organization and filtering.


### PR DESCRIPTION
## Summary

Merges the `release/v1.2-agent-persona` umbrella (#467) into `main`. Reworks the built-in chat agent around an explicit three-mode system (**Chat / Editor / Create**) with per-mode tool gating, a softened persona, and a coherent AI-authorship provenance trail. 26 commits.

## What's included

**Mode system & persona**
- Three modes with `requiresMode` tool gating (#524)
- `request_mode_switch` tool + inline "Switch & Run" UI (#534)
- Mid-conversation mode-switch awareness; current mode anchored atop the system prompt (#532, #551)
- Unified tool-selection rules across modes (#559)
- StatusBar mode chip; per-mode autocomplete filtering (#526, #527)

**Editor tools & UX**
- Persistent visual selection across editor↔chat focus (#529)
- `insert` anchor positions (after_node / before_node) + cursor selection-replace (#546, #547)
- `delete_node` + `move_cursor` (#540)
- Cosmetic chunked streaming + drafting indicator (#544, #545, #553, #555)
- Tool-result renderer registry + `list_files` tree (#530)

**This sojourn**
- **#548** — unify AI-write annotations: optional `comment`, word-level style parity with `suggest_edit`, and the insertion-annotation legibility fix (PR #569)
- **#549** — persist `toolMode` globally across reloads + StatusBar reset cue (PR #568)

## QA

Full manual pass per `docs/qa/467-agent-persona.md` — Stages 1–10, **Stage 10 GO**. Stage 4 (persistence) and Stage 6 (annotations) re-spot-checks passed after the #548/#549 merges. Pass/fail table in the doc's Run log appendix.

## Deferred (pre-existing, non-blocking — left open)

- #570 — AI provenance for create-from-scratch / MCP / paste (enhancement)
- #571 — `insert after_node` heading absorption (bug)
- #572 — full-node `edit` drops adjacent annotation (bug)

Closes #467
Closes #548
Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)