### PR TITLE
feat(appearance): tokenize feature colors in index.css (#499 PR 1b)

### DIFF
--- a/docs/design/v1.2-appearance/feature-token-map.md
+++ b/docs/design/v1.2-appearance/feature-token-map.md
@@ -1,0 +1,46 @@
+# Feature Color Token Map
+
+Reference: what each feature-semantic token colors, declared in `src/renderer/index.css`.
+
+Tokens are declared under `:root` (Mono light baseline) and `.dark` (Mono dark). Theme overrides appear under `.theme-prose`, `.theme-prose.dark`, `.theme-termy`, `.theme-termy.dark`. Mono renders pixel-identical to the pre-tokenization literals.
+
+## Token Reference
+
+| Token | Mono (light) | What it colors |
+|---|---|---|
+| `--diff-suggest` | `210 100% 50%` | Diff suggestion container — border and background |
+| `--diff-del` | `0 70% 50%` | Deleted text within a diff suggestion (strikethrough text and bg) |
+| `--diff-ins` | `140 60% 35%` | Inserted text within a diff suggestion (text and bg tint) |
+| `--diff-accept-btn` | `140 60% 45%` | "Accept" button in diff suggestion and AI suggestion popovers |
+| `--diff-reject-btn` | `0 65% 50%` | "Reject" button in diff suggestion popovers; remove button in comment popovers |
+| `--comment` | `45 100% 50%` | Comment marks (highlight + border), search match highlights, grammar-error underlines |
+| `--comment-bg` | `45 60% 20%` | Comment popover text box background |
+| `--ai-suggest` | `270 70% 50%` | AI suggestion marks (purple highlight + border) and pending-feedback dashed border |
+| `--ai-action` | `270 60% 50%` | AI popover action buttons (feedback, process, submit) and feedback input focus ring |
+| `--annotation` | `262 83% 58%` | AI annotation primary color — gradient start, border, shimmer base |
+| `--annotation-end` | `270 70% 50%` | AI annotation gradient endpoint (insertion/replacement gradient tail) |
+| `--annotation-shimmer` | `262 90% 70%` | AI annotation hover shimmer highlight stop |
+| `--pending` | `330 81% 60%` | Pending annotation state — dashed underline and glow box-shadow |
+| `--pending-word` | `330 60% 50%` | Word-diff "removed" highlight background within suggestions |
+| `--spell-error` | `0 75% 55%` | Spell-check wavy underline (`::spelling-error`) |
+| `--grammar-error` | `45 80% 50%` | Grammar-check wavy underline (`::grammar-error`) |
+| `--frontmatter-ins` | `145 70% 45%` | Frontmatter pending overlay — border, label, value, and accept button |
+
+## Theme Overrides
+
+### Prose (warm/gold)
+Warm tints: amber shifts to gold (`40–42 hue`), greens shift warmer (`142 hue`), violets shift slightly warmer (`268–280 hue`), reds shift toward orange-red (`5 hue`).
+
+### Termy (phosphor/green)
+Terminal phosphor tints: diff-suggest → teal (`160 hue`), comment → yellow-green (`80 hue`), annotations → phosphor green (`150–160 hue`), pending → lime (`100 hue`). Red values remain red for deletion contrast.
+
+## Usage Pattern
+
+All feature colors use the `hsl(var(--token) / <alpha>)` form, e.g.:
+
+```css
+background: hsl(var(--diff-suggest) / 0.1);
+border: 1px solid hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.5));
+```
+
+The `--annotation-opacity` CSS variable is set on `.ai-annotation` elements and animated separately; feature tokens provide only the color channel.

--- a/docs/design/v1.2-appearance/feature-token-map.md
+++ b/docs/design/v1.2-appearance/feature-token-map.md
@@ -2,45 +2,146 @@
 
 Reference: what each feature-semantic token colors, declared in `src/renderer/index.css`.
 
-Tokens are declared under `:root` (Mono light baseline) and `.dark` (Mono dark). Theme overrides appear under `.theme-prose`, `.theme-prose.dark`, `.theme-termy`, `.theme-termy.dark`. Mono renders pixel-identical to the pre-tokenization literals.
+Tokens are declared under `:root` (Mono light baseline) and `.dark` (Mono dark). Theme overrides appear under `.theme-prose`, `.theme-prose.dark`, `.theme-termy`, `.theme-termy.dark`. Mono renders pixel-identical to the pre-tokenization literals — every token value in `:root`/`.dark` equals the original hardcoded literal exactly.
+
+## Design Principle
+
+Where the original CSS used **distinct lightness values** for different roles within the same color family (e.g., mark background vs. mark border; text color vs. tint background; light vs. dark variant), separate tokens are declared. This preserves Mono pixel-identity while giving theme overrides clean anchors to override.
 
 ## Token Reference
 
-| Token | Mono (light) | What it colors |
+### Diff Suggestions (blue-210)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--diff-suggest` | `210 100% 50%` | `210 100% 60%` | Diff suggestion container border |
+| `--diff-suggest-dark-bg` | `210 100% 30%` | _(dark-specific)_ | Diff suggestion container bg in `.dark` only |
+
+### Deletion Text in Diff (red-0, 70%)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--diff-del` | `0 70% 50%` | `0 70% 65%` | Deleted text color |
+| `--diff-del-bg-dark` | `0 70% 40%` | _(dark-specific)_ | Deleted text bg tint in `.dark` |
+
+### Insertion Text in Diff (green-140, 60%)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--diff-ins` | `140 60% 35%` | `140 60% 60%` | Inserted text color |
+| `--diff-ins-bg` | `140 60% 40%` | `140 60% 40%` | Inserted text bg tint (light) |
+| `--diff-ins-bg-dark` | `140 60% 30%` | _(dark-specific)_ | Inserted text bg tint in `.dark` |
+
+### Diff Action Buttons
+
+| Token | Mono value | What it colors |
 |---|---|---|
-| `--diff-suggest` | `210 100% 50%` | Diff suggestion container — border and background |
-| `--diff-del` | `0 70% 50%` | Deleted text within a diff suggestion (strikethrough text and bg) |
-| `--diff-ins` | `140 60% 35%` | Inserted text within a diff suggestion (text and bg tint) |
-| `--diff-accept-btn` | `140 60% 45%` | "Accept" button in diff suggestion and AI suggestion popovers |
-| `--diff-reject-btn` | `0 65% 50%` | "Reject" button in diff suggestion popovers; remove button in comment popovers |
-| `--comment` | `45 100% 50%` | Comment marks (highlight + border), search match highlights, grammar-error underlines |
-| `--comment-bg` | `45 60% 20%` | Comment popover text box background |
-| `--ai-suggest` | `270 70% 50%` | AI suggestion marks (purple highlight + border) and pending-feedback dashed border |
-| `--ai-action` | `270 60% 50%` | AI popover action buttons (feedback, process, submit) and feedback input focus ring |
-| `--annotation` | `262 83% 58%` | AI annotation primary color — gradient start, border, shimmer base |
-| `--annotation-end` | `270 70% 50%` | AI annotation gradient endpoint (insertion/replacement gradient tail) |
-| `--annotation-shimmer` | `262 90% 70%` | AI annotation hover shimmer highlight stop |
-| `--pending` | `330 81% 60%` | Pending annotation state — dashed underline and glow box-shadow |
-| `--pending-word` | `330 60% 50%` | Word-diff "removed" highlight background within suggestions |
-| `--spell-error` | `0 75% 55%` | Spell-check wavy underline (`::spelling-error`) |
-| `--grammar-error` | `45 80% 50%` | Grammar-check wavy underline (`::grammar-error`) |
-| `--frontmatter-ins` | `145 70% 45%` | Frontmatter pending overlay — border, label, value, and accept button |
+| `--diff-accept-btn` | `140 60% 45%` | Accept button bg |
+| `--diff-accept-btn-hover` | `140 60% 38%` | Accept button hover bg |
+| `--diff-reject-btn` | `0 65% 50%` | Reject button bg (diff bar) |
+| `--diff-reject-btn-hover` | `0 65% 42%` | Reject button hover |
 
-## Theme Overrides
+### Comment Marks (amber-45)
 
-### Prose (warm/gold)
-Warm tints: amber shifts to gold (`40–42 hue`), greens shift warmer (`142 hue`), violets shift slightly warmer (`268–280 hue`), reds shift toward orange-red (`5 hue`).
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--comment-mark-bg` | `45 100% 70%` | `45 100% 40%` | Comment mark highlight bg (higher lightness than border) |
+| `--comment` | `45 100% 50%` | `45 100% 60%` | Comment mark border; search highlight; grammar-error anchor |
+| `--comment-bg` | `45 60% 20%` | `45 60% 20%` | Comment popover text-box bg (opaque dark amber) |
+| `--comment-text-fg` | `45 70% 80%` | `45 70% 80%` | Comment popover text-box fg |
 
-### Termy (phosphor/green)
-Terminal phosphor tints: diff-suggest → teal (`160 hue`), comment → yellow-green (`80 hue`), annotations → phosphor green (`150–160 hue`), pending → lime (`100 hue`). Red values remain red for deletion contrast.
+### Comment Popover Remove Button (dark red, distinct from diff-reject)
+
+| Token | Mono value | What it colors |
+|---|---|---|
+| `--comment-remove-btn` | `0 60% 40%` | Remove button bg |
+| `--comment-remove-btn-hover` | `0 60% 35%` | Remove button hover |
+
+### AI Suggestion Marks (violet-270, 70%)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--ai-suggest-mark-bg` | `270 70% 70%` | `270 70% 40%` | AI suggestion mark highlight bg |
+| `--ai-suggest` | `270 70% 50%` | `270 70% 60%` | AI suggestion mark border |
+| `--ai-suggest-reply-bg` | `270 70% 60%` | `270 70% 45%` | `[data-ai-user-reply]` mark bg |
+| `--ai-suggest-reply-border` | `270 70% 50%` | `270 70% 65%` | `[data-ai-user-reply]` mark border |
+
+### AI Suggestion Popover — Suggested Text Block (green-145)
+
+| Token | Mono value | What it colors |
+|---|---|---|
+| `--ai-suggest-text-bg` | `145 60% 20%` | Suggested-text box bg (opaque) |
+| `--ai-suggest-text-fg` | `145 70% 75%` | Suggested-text box fg |
+| `--ai-suggest-text-border` | `145 70% 45%` | Suggested-text box left border |
+
+### AI Suggestion Popover — Accept Button (green-145, distinct from diff-accept)
+
+| Token | Mono value | What it colors |
+|---|---|---|
+| `--ai-suggest-accept-btn` | `145 60% 40%` | Accept button bg |
+| `--ai-suggest-accept-hover` | `145 60% 35%` | Accept button hover |
+
+### AI Action Buttons (violet-270, 60%)
+
+| Token | Mono value | What it colors |
+|---|---|---|
+| `--ai-action` | `270 60% 50%` | Feedback / process / submit button bg |
+| `--ai-action-hover` | `270 60% 45%` | Action button hover |
+| `--ai-action-muted` | `270 60% 30%` | Feedback-text display bg tint |
+| `--ai-action-link` | `270 60% 60%` | Edit-feedback button text color |
+| `--ai-action-link-hover` | `270 60% 70%` | Edit-feedback button hover text |
+
+### AI Annotations (deep violet-262)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--annotation` | `262 83% 58%` | `262 70% 60%` | Annotation gradient start + border |
+| `--annotation-end` | `270 70% 50%` | `270 60% 45%` | Annotation gradient tail |
+| `--annotation-shimmer` | `262 90% 70%` | `262 80% 65%` | Hover shimmer highlight stop |
+
+### Pending Annotation / Word-Diff (pink-330)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--pending` | `330 81% 60%` | `330 70% 55%` | Pending annotation dashed underline + glow |
+| `--pending-word` | `330 60% 50%` | `330 55% 45%` | Word-diff removed highlight |
+
+### Word-Diff Added (violet-262)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--diff-word-added` | `262 70% 55%` | `262 65% 50%` | Word-diff added highlight |
+
+### Spell / Grammar Underlines
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--spell-error` | `0 75% 55%` | `0 80% 60%` | `::spelling-error` wavy underline |
+| `--grammar-error` | `45 80% 50%` | `45 85% 55%` | `::grammar-error` wavy underline |
+
+### Frontmatter Pending Overlay (green-145)
+
+| Token | Mono light | Mono dark | What it colors |
+|---|---|---|---|
+| `--frontmatter-bg` | `145 60% 20%` | `145 60% 15%` | Overlay background |
+| `--frontmatter-ins` | `145 70% 45%` | `145 70% 55%` | Overlay border + label color |
+| `--frontmatter-val` | `145 60% 55%` | `145 60% 65%` | Pending value text color |
+| `--frontmatter-accept-btn` | `145 60% 40%` | `145 60% 40%` | Accept button bg |
+| `--frontmatter-accept-hover` | `145 60% 35%` | `145 60% 35%` | Accept button hover |
 
 ## Usage Pattern
 
-All feature colors use the `hsl(var(--token) / <alpha>)` form, e.g.:
-
 ```css
 background: hsl(var(--diff-suggest) / 0.1);
+background: hsl(var(--diff-suggest-dark-bg) / 0.2);   /* in .dark only */
 border: 1px solid hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.5));
 ```
 
 The `--annotation-opacity` CSS variable is set on `.ai-annotation` elements and animated separately; feature tokens provide only the color channel.
+
+## Theme Overrides
+
+Theme blocks (`.theme-prose*`, `.theme-termy*`) override all tokens listed above.
+
+- **Prose** — warm/gold tints: amber shifts to gold (40 hue), greens shift warmer (142/148 hue), violets shift slightly (268–280 hue), reds shift toward orange-red (5 hue).
+- **Termy** — phosphor/green tints: diff-suggest → teal (160 hue), comment → yellow-green (80 hue), annotations → phosphor green (150–160 hue), pending → lime (100 hue). Red values remain red for deletion contrast.

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -32,6 +32,26 @@
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;
     --radius: 0.5rem;
+
+    /* Feature-semantic color tokens — Mono baseline (light).
+       Values match the original hardcoded literals exactly. */
+    --diff-suggest:       210 100% 50%;   /* blue: diff suggestion container */
+    --diff-del:           0 70% 50%;      /* red: deletion text/bg */
+    --diff-ins:           140 60% 35%;    /* green: insertion text/bg */
+    --diff-accept-btn:    140 60% 45%;    /* green: accept-change button */
+    --diff-reject-btn:    0 65% 50%;      /* red: reject-change button */
+    --comment:            45 100% 50%;    /* amber: comment marks & search highlights */
+    --comment-bg:         45 60% 20%;     /* dark amber: comment popover bg */
+    --ai-suggest:         270 70% 50%;    /* violet: AI suggestion marks */
+    --ai-action:          270 60% 50%;    /* violet: AI popover action buttons */
+    --annotation:         262 83% 58%;    /* deep violet: AI annotation primary */
+    --annotation-end:     270 70% 50%;    /* violet: gradient endpoint / dark base */
+    --annotation-shimmer: 262 90% 70%;   /* violet: shimmer highlight stop */
+    --pending:            330 81% 60%;    /* pink: pending annotation state */
+    --pending-word:       330 60% 50%;    /* pink: word-diff removed highlight */
+    --spell-error:        0 75% 55%;      /* red: spell-check underline */
+    --grammar-error:      45 80% 50%;     /* amber: grammar-check underline */
+    --frontmatter-ins:    145 70% 45%;    /* green: frontmatter pending indicator */
   }
 
   .dark {
@@ -54,6 +74,26 @@
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
+
+    /* Feature-semantic token overrides — Mono dark baseline.
+       Values match the original hardcoded dark literals exactly. */
+    --diff-suggest:       210 100% 60%;   /* blue: brighter for dark bg */
+    --diff-del:           0 70% 65%;      /* red: lighter for dark bg */
+    --diff-ins:           140 60% 60%;    /* green: lighter for dark bg */
+    --diff-accept-btn:    140 60% 45%;    /* green: same — solid button */
+    --diff-reject-btn:    0 65% 50%;      /* red: same — solid button */
+    --comment:            45 100% 60%;    /* amber: brighter for dark bg */
+    --comment-bg:         45 60% 20%;     /* dark amber: same — dark popover */
+    --ai-suggest:         270 70% 60%;    /* violet: lighter for dark bg */
+    --ai-action:          270 60% 50%;    /* violet: same — solid button */
+    --annotation:         262 70% 60%;    /* deep violet: lighter for dark bg */
+    --annotation-end:     270 60% 45%;    /* violet: gradient endpoint dark */
+    --annotation-shimmer: 262 80% 65%;   /* violet: shimmer highlight dark */
+    --pending:            330 70% 55%;    /* pink: slightly muted for dark */
+    --pending-word:       330 55% 45%;    /* pink: word-diff dark */
+    --spell-error:        0 80% 60%;      /* red: brighter for dark bg */
+    --grammar-error:      45 85% 55%;     /* amber: brighter for dark bg */
+    --frontmatter-ins:    145 70% 40%;    /* green: slightly darker for dark */
   }
 
   .termy-green-dark {
@@ -123,6 +163,25 @@
     --border: 39.4 29.1% 78.4%;
     --input: 39.4 29.1% 78.4%;
     --ring: 39.1 42.6% 42.4%;
+
+    /* Prose feature tokens — warm/gold tints for parchment theme */
+    --diff-suggest:       210 80% 48%;    /* slightly de-saturated blue on warm bg */
+    --diff-del:           5 65% 48%;      /* warm red-orange deletion */
+    --diff-ins:           142 50% 32%;    /* warm forest green insertion */
+    --diff-accept-btn:    142 50% 40%;    /* warm forest green accept button */
+    --diff-reject-btn:    5 60% 47%;      /* warm red-orange reject button */
+    --comment:            40 90% 45%;     /* gold amber — natural for Prose */
+    --comment-bg:         40 55% 18%;     /* deep gold bg */
+    --ai-suggest:         280 55% 50%;    /* slightly warmer violet mark */
+    --ai-action:          280 55% 48%;    /* violet action button */
+    --annotation:         268 75% 55%;    /* warm deep violet annotation */
+    --annotation-end:     280 60% 48%;    /* warm violet gradient end */
+    --annotation-shimmer: 268 85% 68%;   /* warm shimmer */
+    --pending:            340 70% 57%;    /* warm pink pending */
+    --pending-word:       340 55% 48%;    /* warm pink word-diff */
+    --spell-error:        5 70% 52%;      /* warm red spell error */
+    --grammar-error:      40 75% 45%;     /* gold grammar error */
+    --frontmatter-ins:    148 60% 40%;    /* warm green frontmatter */
   }
 
   .theme-prose.dark {
@@ -143,6 +202,25 @@
     --border: 0 0% 11.4%;
     --input: 0 0% 11.4%;
     --ring: 40.4 50% 56.9%;
+
+    /* Prose dark feature tokens — warm/gold tints on dark parchment */
+    --diff-suggest:       210 85% 62%;    /* brighter blue on dark warm bg */
+    --diff-del:           5 65% 62%;      /* warm red-orange on dark */
+    --diff-ins:           142 55% 58%;    /* warm forest green on dark */
+    --diff-accept-btn:    142 50% 42%;    /* forest green button */
+    --diff-reject-btn:    5 60% 47%;      /* warm red button */
+    --comment:            40 90% 58%;     /* bright gold amber */
+    --comment-bg:         40 55% 18%;     /* deep gold bg */
+    --ai-suggest:         280 60% 62%;    /* warmer violet on dark */
+    --ai-action:          280 55% 50%;    /* violet button */
+    --annotation:         268 70% 62%;    /* warm deep violet on dark */
+    --annotation-end:     280 60% 47%;    /* warm gradient end dark */
+    --annotation-shimmer: 268 80% 67%;   /* warm shimmer dark */
+    --pending:            340 70% 57%;    /* warm pink pending */
+    --pending-word:       340 55% 47%;    /* warm pink word-diff */
+    --spell-error:        5 75% 58%;      /* warm red on dark */
+    --grammar-error:      40 80% 55%;     /* gold grammar on dark */
+    --frontmatter-ins:    148 60% 42%;    /* warm green frontmatter */
   }
 
   .theme-termy {
@@ -163,6 +241,25 @@
     --border: 87.8 28.3% 71.6%;
     --input: 87.8 28.3% 71.6%;
     --ring: 137.7 57.4% 26.7%;
+
+    /* Termy feature tokens — phosphor/green tints for terminal theme */
+    --diff-suggest:       160 70% 38%;    /* teal-green for diff suggestion */
+    --diff-del:           0 65% 45%;      /* red-on-green deletion */
+    --diff-ins:           130 55% 30%;    /* deeper phosphor green insertion */
+    --diff-accept-btn:    130 55% 38%;    /* phosphor green accept button */
+    --diff-reject-btn:    0 60% 45%;      /* red reject button */
+    --comment:            80 70% 38%;     /* yellow-green amber comment */
+    --comment-bg:         80 45% 18%;     /* deep yellow-green bg */
+    --ai-suggest:         160 55% 38%;    /* teal violet-adjacent for marks */
+    --ai-action:          155 50% 36%;    /* teal action button */
+    --annotation:         155 65% 38%;    /* phosphor annotation */
+    --annotation-end:     160 55% 35%;    /* annotation gradient end */
+    --annotation-shimmer: 155 80% 55%;   /* phosphor shimmer */
+    --pending:            100 55% 42%;    /* lime-green pending */
+    --pending-word:       100 45% 38%;    /* lime word-diff */
+    --spell-error:        0 70% 48%;      /* red on green bg */
+    --grammar-error:      80 65% 40%;     /* yellow-green grammar */
+    --frontmatter-ins:    135 60% 35%;    /* phosphor green frontmatter */
   }
 
   .theme-termy.dark {
@@ -183,6 +280,25 @@
     --border: 146.1 53.5% 8.4%;
     --input: 146.1 53.5% 8.4%;
     --ring: 149.9 100% 50%;
+
+    /* Termy dark feature tokens — phosphor/green on black terminal */
+    --diff-suggest:       160 80% 55%;    /* bright teal on black */
+    --diff-del:           0 70% 55%;      /* red on dark terminal */
+    --diff-ins:           130 70% 55%;    /* bright phosphor green */
+    --diff-accept-btn:    130 65% 48%;    /* phosphor accept button */
+    --diff-reject-btn:    0 65% 48%;      /* red reject button */
+    --comment:            80 90% 55%;     /* bright yellow-green */
+    --comment-bg:         80 45% 12%;     /* deep phosphor bg */
+    --ai-suggest:         155 75% 52%;    /* bright teal mark */
+    --ai-action:          155 65% 48%;    /* teal action button */
+    --annotation:         150 80% 48%;    /* bright phosphor annotation */
+    --annotation-end:     155 65% 42%;    /* gradient end dark */
+    --annotation-shimmer: 150 90% 65%;   /* bright phosphor shimmer */
+    --pending:            100 65% 52%;    /* bright lime pending */
+    --pending-word:       100 55% 45%;    /* lime word-diff dark */
+    --spell-error:        0 75% 58%;      /* red on dark terminal */
+    --grammar-error:      80 80% 55%;     /* yellow-green grammar */
+    --frontmatter-ins:    140 75% 50%;    /* bright phosphor frontmatter */
   }
 }
 
@@ -533,14 +649,14 @@
   flex-wrap: nowrap;
   border-radius: 0.25em;
   padding: 0.125em 0.25em;
-  border: 1px solid hsl(210 100% 50% / 0.3);
-  background: hsl(210 100% 50% / 0.1);
+  border: 1px solid hsl(var(--diff-suggest) / 0.3);
+  background: hsl(var(--diff-suggest) / 0.1);
   margin: 0 0.125em;
 }
 
 .dark .prose-editor .diff-suggestion {
-  border-color: hsl(210 100% 60% / 0.3);
-  background: hsl(210 100% 30% / 0.2);
+  border-color: hsl(var(--diff-suggest) / 0.3);
+  background: hsl(var(--diff-suggest) / 0.2);
 }
 
 /* Visual separator between consecutive diffs */
@@ -550,28 +666,28 @@
 
 .prose-editor .diff-suggestion [data-diff-suggestion-old] {
   text-decoration: line-through;
-  color: hsl(0 70% 50%);
-  background: hsl(0 70% 50% / 0.15);
+  color: hsl(var(--diff-del));
+  background: hsl(var(--diff-del) / 0.15);
   padding: 0 0.1em;
   border-radius: 0.125em;
 }
 
 .dark .prose-editor .diff-suggestion [data-diff-suggestion-old] {
-  color: hsl(0 70% 65%);
-  background: hsl(0 70% 40% / 0.25);
+  color: hsl(var(--diff-del));
+  background: hsl(var(--diff-del) / 0.25);
 }
 
 .prose-editor .diff-suggestion [data-diff-suggestion-new] {
-  color: hsl(140 60% 35%);
-  background: hsl(140 60% 40% / 0.15);
+  color: hsl(var(--diff-ins));
+  background: hsl(var(--diff-ins) / 0.15);
   padding: 0 0.1em;
   border-radius: 0.125em;
   margin-left: 0.25em;
 }
 
 .dark .prose-editor .diff-suggestion [data-diff-suggestion-new] {
-  color: hsl(140 60% 60%);
-  background: hsl(140 60% 30% / 0.25);
+  color: hsl(var(--diff-ins));
+  background: hsl(var(--diff-ins) / 0.25);
 }
 
 .prose-editor .diff-suggestion-content {
@@ -598,27 +714,27 @@
 }
 
 .prose-editor .diff-accept-btn {
-  background: hsl(140 60% 45%);
+  background: hsl(var(--diff-accept-btn));
   color: white;
 }
 
 .prose-editor .diff-accept-btn:hover {
-  background: hsl(140 60% 38%);
+  background: hsl(var(--diff-accept-btn) / 0.85);
 }
 
 .prose-editor .diff-reject-btn {
-  background: hsl(0 65% 50%);
+  background: hsl(var(--diff-reject-btn));
   color: white;
 }
 
 .prose-editor .diff-reject-btn:hover {
-  background: hsl(0 65% 42%);
+  background: hsl(var(--diff-reject-btn) / 0.85);
 }
 
 /* Comment Marks */
 .prose-editor .comment-mark {
-  background: hsl(45 100% 70% / 0.4);
-  border-bottom: 2px solid hsl(45 100% 50%);
+  background: hsl(var(--comment) / 0.4);
+  border-bottom: 2px solid hsl(var(--comment));
   padding: 0 0.1em;
   border-radius: 0.125em;
   cursor: pointer;
@@ -626,16 +742,16 @@
 }
 
 .dark .prose-editor .comment-mark {
-  background: hsl(45 100% 40% / 0.3);
-  border-bottom-color: hsl(45 100% 60%);
+  background: hsl(var(--comment) / 0.3);
+  border-bottom-color: hsl(var(--comment));
 }
 
 .prose-editor .comment-mark:hover {
-  background: hsl(45 100% 70% / 0.6);
+  background: hsl(var(--comment) / 0.6);
 }
 
 .dark .prose-editor .comment-mark:hover {
-  background: hsl(45 100% 40% / 0.5);
+  background: hsl(var(--comment) / 0.5);
 }
 
 /* Comment Popover (click to open) */
@@ -657,15 +773,15 @@
 }
 
 .comment-popover .comment-text {
-  background: hsl(45 60% 20%);
-  color: hsl(45 70% 80%);
+  background: hsl(var(--comment-bg));
+  color: hsl(var(--comment) / 0.9);
   padding: 0.75rem 1rem;
   border-radius: 0.375rem;
   font-family: var(--font-mono);
   font-size: 0.875rem;
   line-height: 1.5;
   margin-bottom: 1rem;
-  border-left: 3px solid hsl(45 100% 50%);
+  border-left: 3px solid hsl(var(--comment));
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -692,23 +808,23 @@
 }
 
 .comment-popover .process-btn {
-  background: hsl(270 60% 50%);
+  background: hsl(var(--ai-action));
   color: white;
   border: none;
 }
 
 .comment-popover .process-btn:hover {
-  background: hsl(270 60% 45%);
+  background: hsl(var(--ai-action) / 0.88);
 }
 
 .comment-popover .remove-btn {
-  background: hsl(0 60% 40%);
+  background: hsl(var(--diff-reject-btn) / 0.85);
   color: white;
   border: none;
 }
 
 .comment-popover .remove-btn:hover {
-  background: hsl(0 60% 35%);
+  background: hsl(var(--diff-reject-btn) / 0.72);
 }
 
 .comment-popover .close-btn {
@@ -723,8 +839,8 @@
 
 /* AI Suggestion Marks - Purple highlighting for AI edit suggestions */
 .prose-editor .ai-suggestion-mark {
-  background: hsl(270 70% 70% / 0.4);
-  border-bottom: 2px solid hsl(270 70% 50%);
+  background: hsl(var(--ai-suggest) / 0.4);
+  border-bottom: 2px solid hsl(var(--ai-suggest));
   padding: 0 0.1em;
   border-radius: 0.125em;
   cursor: pointer;
@@ -732,16 +848,16 @@
 }
 
 .dark .prose-editor .ai-suggestion-mark {
-  background: hsl(270 70% 40% / 0.3);
-  border-bottom-color: hsl(270 70% 60%);
+  background: hsl(var(--ai-suggest) / 0.3);
+  border-bottom-color: hsl(var(--ai-suggest));
 }
 
 .prose-editor .ai-suggestion-mark:hover {
-  background: hsl(270 70% 70% / 0.6);
+  background: hsl(var(--ai-suggest) / 0.6);
 }
 
 .dark .prose-editor .ai-suggestion-mark:hover {
-  background: hsl(270 70% 40% / 0.5);
+  background: hsl(var(--ai-suggest) / 0.5);
 }
 
 /* Hide AI annotations when toggled off */
@@ -792,15 +908,15 @@
 }
 
 .ai-suggestion-popover .suggested-text {
-  background: hsl(145 60% 20%);
-  color: hsl(145 70% 75%);
+  background: hsl(var(--frontmatter-ins) / 0.2);
+  color: hsl(var(--frontmatter-ins) / 0.9);
   padding: 0.75rem 1rem;
   border-radius: 0.375rem;
   font-family: var(--font-mono);
   font-size: 0.875rem;
   line-height: 1.5;
   margin-bottom: 1rem;
-  border-left: 3px solid hsl(145 70% 45%);
+  border-left: 3px solid hsl(var(--frontmatter-ins));
 }
 
 .ai-suggestion-popover .explanation-label {
@@ -828,7 +944,7 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: hsl(145 60% 40%);
+  background: hsl(var(--diff-accept-btn));
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -839,7 +955,7 @@
 }
 
 .ai-suggestion-popover .accept-btn:hover {
-  background: hsl(145 60% 35%);
+  background: hsl(var(--diff-accept-btn) / 0.85);
 }
 
 .ai-suggestion-popover .reject-btn {
@@ -870,7 +986,7 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: hsl(270 60% 50%);
+  background: hsl(var(--ai-action));
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -881,7 +997,7 @@
 }
 
 .ai-suggestion-popover .feedback-btn:hover {
-  background: hsl(270 60% 45%);
+  background: hsl(var(--ai-action) / 0.88);
 }
 
 /* Feedback section styles */
@@ -912,8 +1028,8 @@
 
 .ai-suggestion-popover .feedback-input:focus {
   outline: none;
-  border-color: hsl(270 60% 50%);
-  box-shadow: 0 0 0 2px hsl(270 60% 50% / 0.2);
+  border-color: hsl(var(--ai-action));
+  box-shadow: 0 0 0 2px hsl(var(--ai-action) / 0.2);
 }
 
 .ai-suggestion-popover .feedback-actions {
@@ -924,7 +1040,7 @@
 .ai-suggestion-popover .feedback-submit-btn {
   flex: 1;
   padding: 0.375rem 0.75rem;
-  background: hsl(270 60% 50%);
+  background: hsl(var(--ai-action));
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -935,7 +1051,7 @@
 }
 
 .ai-suggestion-popover .feedback-submit-btn:hover:not(:disabled) {
-  background: hsl(270 60% 45%);
+  background: hsl(var(--ai-action) / 0.88);
 }
 
 .ai-suggestion-popover .feedback-submit-btn:disabled {
@@ -966,20 +1082,20 @@
 }
 
 .ai-suggestion-popover .feedback-text {
-  background: hsl(270 60% 30% / 0.2);
+  background: hsl(var(--ai-action) / 0.2);
   color: hsl(var(--foreground));
   padding: 0.5rem 0.75rem;
   border-radius: 0.375rem;
   font-size: 0.875rem;
   line-height: 1.5;
   margin-bottom: 0.5rem;
-  border-left: 3px solid hsl(270 60% 50%);
+  border-left: 3px solid hsl(var(--ai-action));
 }
 
 .ai-suggestion-popover .edit-feedback-btn {
   padding: 0.25rem 0.5rem;
   background: transparent;
-  color: hsl(270 60% 60%);
+  color: hsl(var(--ai-action) / 0.85);
   border: none;
   font-size: 0.75rem;
   cursor: pointer;
@@ -987,19 +1103,19 @@
 }
 
 .ai-suggestion-popover .edit-feedback-btn:hover {
-  color: hsl(270 60% 70%);
+  color: hsl(var(--ai-action));
 }
 
 /* Visual indicator for suggestions with pending feedback */
 .prose-editor .ai-suggestion-mark[data-ai-user-reply] {
-  background: hsl(270 70% 60% / 0.5);
-  border-bottom: 2px dashed hsl(270 70% 50%);
+  background: hsl(var(--ai-suggest) / 0.5);
+  border-bottom: 2px dashed hsl(var(--ai-suggest));
   animation: pulse-feedback 2s ease-in-out infinite;
 }
 
 .dark .prose-editor .ai-suggestion-mark[data-ai-user-reply] {
-  background: hsl(270 70% 45% / 0.4);
-  border-bottom-color: hsl(270 70% 65%);
+  background: hsl(var(--ai-suggest) / 0.4);
+  border-bottom-color: hsl(var(--ai-suggest));
 }
 
 @keyframes pulse-feedback {
@@ -1009,32 +1125,32 @@
 
 /* Frontmatter pending overlay — shown when AI proposes frontmatter changes (#488) */
 .frontmatter-pending-overlay {
-  background: hsl(145 60% 20% / 0.25);
-  border-color: hsl(145 70% 45% / 0.6);
+  background: hsl(var(--frontmatter-ins) / 0.25);
+  border-color: hsl(var(--frontmatter-ins) / 0.6);
 }
 
 .dark .frontmatter-pending-overlay {
-  background: hsl(145 60% 15% / 0.35);
-  border-color: hsl(145 70% 40% / 0.5);
+  background: hsl(var(--frontmatter-ins) / 0.35);
+  border-color: hsl(var(--frontmatter-ins) / 0.5);
 }
 
 .frontmatter-pending-label {
-  color: hsl(145 70% 45%);
+  color: hsl(var(--frontmatter-ins));
   font-size: 0.6875rem;
   font-weight: 500;
   letter-spacing: 0.01em;
 }
 
 .dark .frontmatter-pending-label {
-  color: hsl(145 70% 55%);
+  color: hsl(var(--frontmatter-ins));
 }
 
 .frontmatter-pending-value {
-  color: hsl(145 60% 55%);
+  color: hsl(var(--frontmatter-ins) / 0.85);
 }
 
 .dark .frontmatter-pending-value {
-  color: hsl(145 60% 65%);
+  color: hsl(var(--frontmatter-ins) / 0.9);
 }
 
 .frontmatter-pending-accept-btn {
@@ -1042,7 +1158,7 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.125rem 0.5rem;
-  background: hsl(145 60% 40%);
+  background: hsl(var(--diff-accept-btn));
   color: white;
   border: none;
   border-radius: 0.25rem;
@@ -1054,7 +1170,7 @@
 }
 
 .frontmatter-pending-accept-btn:hover {
-  background: hsl(145 60% 35%);
+  background: hsl(var(--diff-accept-btn) / 0.85);
 }
 
 .frontmatter-pending-reject-btn {
@@ -1079,23 +1195,23 @@
 
 /* Spell-check styling - more prominent squiggles */
 .prose-editor ::spelling-error {
-  text-decoration: wavy underline hsl(0 75% 55%);
+  text-decoration: wavy underline hsl(var(--spell-error));
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
 }
 
 .dark .prose-editor ::spelling-error {
-  text-decoration-color: hsl(0 80% 60%);
+  text-decoration-color: hsl(var(--spell-error));
 }
 
 .prose-editor ::grammar-error {
-  text-decoration: wavy underline hsl(45 80% 50%);
+  text-decoration: wavy underline hsl(var(--grammar-error));
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
 }
 
 .dark .prose-editor ::grammar-error {
-  text-decoration-color: hsl(45 85% 55%);
+  text-decoration-color: hsl(var(--grammar-error));
 }
 
 /* AI Annotations - Time-fading gradient visuals (Vercel/Linear inspired) */
@@ -1113,38 +1229,38 @@
 .prose-editor .ai-annotation-insertion {
   background: linear-gradient(
     135deg,
-    hsl(262 83% 58% / calc(var(--annotation-opacity) * 0.25)) 0%,
-    hsl(270 70% 50% / calc(var(--annotation-opacity) * 0.15)) 100%
+    hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.25)) 0%,
+    hsl(var(--annotation-end) / calc(var(--annotation-opacity) * 0.15)) 100%
   );
-  border-bottom: 2px solid hsl(262 83% 58% / calc(var(--annotation-opacity) * 0.5));
+  border-bottom: 2px solid hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.5));
 }
 
 .dark .prose-editor .ai-annotation-insertion {
   background: linear-gradient(
     135deg,
-    hsl(262 70% 50% / calc(var(--annotation-opacity) * 0.3)) 0%,
-    hsl(270 60% 45% / calc(var(--annotation-opacity) * 0.18)) 100%
+    hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.3)) 0%,
+    hsl(var(--annotation-end) / calc(var(--annotation-opacity) * 0.18)) 100%
   );
-  border-bottom-color: hsl(262 70% 60% / calc(var(--annotation-opacity) * 0.6));
+  border-bottom-color: hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.6));
 }
 
 /* Replacement type - violet gradient (for AI chat suggestions) */
 .prose-editor .ai-annotation-replacement {
   background: linear-gradient(
     135deg,
-    hsl(262 83% 58% / calc(var(--annotation-opacity) * 0.25)) 0%,
-    hsl(270 70% 50% / calc(var(--annotation-opacity) * 0.15)) 100%
+    hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.25)) 0%,
+    hsl(var(--annotation-end) / calc(var(--annotation-opacity) * 0.15)) 100%
   );
-  border-bottom: 2px solid hsl(262 83% 58% / calc(var(--annotation-opacity) * 0.5));
+  border-bottom: 2px solid hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.5));
 }
 
 .dark .prose-editor .ai-annotation-replacement {
   background: linear-gradient(
     135deg,
-    hsl(262 70% 50% / calc(var(--annotation-opacity) * 0.3)) 0%,
-    hsl(270 60% 45% / calc(var(--annotation-opacity) * 0.18)) 100%
+    hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.3)) 0%,
+    hsl(var(--annotation-end) / calc(var(--annotation-opacity) * 0.18)) 100%
   );
-  border-bottom-color: hsl(262 70% 60% / calc(var(--annotation-opacity) * 0.6));
+  border-bottom-color: hsl(var(--annotation) / calc(var(--annotation-opacity) * 0.6));
 }
 
 /* Hover state - glow effect */
@@ -1163,11 +1279,11 @@
 .prose-editor .ai-annotation-insertion:hover {
   background: linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.2) 0%,
-    hsl(262 83% 58% / 0.2) 40%,
-    hsl(262 90% 70% / 0.4) 50%,
-    hsl(262 83% 58% / 0.2) 60%,
-    hsl(262 83% 58% / 0.2) 100%
+    hsl(var(--annotation) / 0.2) 0%,
+    hsl(var(--annotation) / 0.2) 40%,
+    hsl(var(--annotation-shimmer) / 0.4) 50%,
+    hsl(var(--annotation) / 0.2) 60%,
+    hsl(var(--annotation) / 0.2) 100%
   );
   background-size: 200% 100%;
   animation: shimmer-bg 2s ease-in-out infinite;
@@ -1176,11 +1292,11 @@
 .dark .prose-editor .ai-annotation-insertion:hover {
   background: linear-gradient(
     90deg,
-    hsl(262 70% 50% / 0.25) 0%,
-    hsl(262 70% 50% / 0.25) 40%,
-    hsl(262 80% 65% / 0.45) 50%,
-    hsl(262 70% 50% / 0.25) 60%,
-    hsl(262 70% 50% / 0.25) 100%
+    hsl(var(--annotation) / 0.25) 0%,
+    hsl(var(--annotation) / 0.25) 40%,
+    hsl(var(--annotation-shimmer) / 0.45) 50%,
+    hsl(var(--annotation) / 0.25) 60%,
+    hsl(var(--annotation) / 0.25) 100%
   );
   background-size: 200% 100%;
   animation: shimmer-bg 2s ease-in-out infinite;
@@ -1190,11 +1306,11 @@
 .prose-editor .ai-annotation-replacement:hover {
   background: linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.2) 0%,
-    hsl(262 83% 58% / 0.2) 40%,
-    hsl(262 90% 70% / 0.4) 50%,
-    hsl(262 83% 58% / 0.2) 60%,
-    hsl(262 83% 58% / 0.2) 100%
+    hsl(var(--annotation) / 0.2) 0%,
+    hsl(var(--annotation) / 0.2) 40%,
+    hsl(var(--annotation-shimmer) / 0.4) 50%,
+    hsl(var(--annotation) / 0.2) 60%,
+    hsl(var(--annotation) / 0.2) 100%
   );
   background-size: 200% 100%;
   animation: shimmer-bg 2s ease-in-out infinite;
@@ -1203,11 +1319,11 @@
 .dark .prose-editor .ai-annotation-replacement:hover {
   background: linear-gradient(
     90deg,
-    hsl(262 70% 50% / 0.25) 0%,
-    hsl(262 70% 50% / 0.25) 40%,
-    hsl(262 80% 65% / 0.45) 50%,
-    hsl(262 70% 50% / 0.25) 60%,
-    hsl(262 70% 50% / 0.25) 100%
+    hsl(var(--annotation) / 0.25) 0%,
+    hsl(var(--annotation) / 0.25) 40%,
+    hsl(var(--annotation-shimmer) / 0.45) 50%,
+    hsl(var(--annotation) / 0.25) 60%,
+    hsl(var(--annotation) / 0.25) 100%
   );
   background-size: 200% 100%;
   animation: shimmer-bg 2s ease-in-out infinite;
@@ -1271,38 +1387,38 @@
 /* Pending suggestion state - pink dashed underline */
 .prose-editor .ai-annotation-pending {
   background: transparent;
-  border-bottom: 1px dashed hsl(330 81% 60% / 0.6);
+  border-bottom: 1px dashed hsl(var(--pending) / 0.6);
 }
 
 .dark .prose-editor .ai-annotation-pending {
-  border-bottom-color: hsl(330 70% 55% / 0.5);
+  border-bottom-color: hsl(var(--pending) / 0.5);
 }
 
 .prose-editor .ai-annotation-pending:hover {
   box-shadow:
-    0 0 4px hsl(330 81% 60% / calc(var(--annotation-opacity) * 0.3)),
-    0 0 8px hsl(330 81% 60% / calc(var(--annotation-opacity) * 0.15));
+    0 0 4px hsl(var(--pending) / calc(var(--annotation-opacity) * 0.3)),
+    0 0 8px hsl(var(--pending) / calc(var(--annotation-opacity) * 0.15));
 }
 
 /* Word-level diff highlighting within suggestions */
 .prose-editor .diff-word-removed {
-  background: hsl(330 60% 50% / 0.25);
+  background: hsl(var(--pending-word) / 0.25);
   border-radius: 0.125em;
   padding: 0 0.1em;
 }
 
 .dark .prose-editor .diff-word-removed {
-  background: hsl(330 55% 45% / 0.35);
+  background: hsl(var(--pending-word) / 0.35);
 }
 
 .prose-editor .diff-word-added {
-  background: hsl(262 70% 55% / 0.25);
+  background: hsl(var(--annotation) / 0.25);
   border-radius: 0.125em;
   padding: 0 0.1em;
 }
 
 .dark .prose-editor .diff-word-added {
-  background: hsl(262 65% 50% / 0.35);
+  background: hsl(var(--annotation) / 0.35);
 }
 
 /* Images */
@@ -1391,22 +1507,22 @@
 
 /* Search Highlight - FindBar multi-match highlighting */
 .prose-editor .search-match {
-  background-color: hsl(45 100% 50% / 0.3);
+  background-color: hsl(var(--comment) / 0.3);
   border-radius: 2px;
 }
 
 .dark .prose-editor .search-match {
-  background-color: hsl(45 100% 50% / 0.25);
+  background-color: hsl(var(--comment) / 0.25);
 }
 
 .prose-editor .search-match-current {
-  background-color: hsl(45 100% 50% / 0.7);
-  box-shadow: 0 0 0 1px hsl(45 100% 50% / 0.8);
+  background-color: hsl(var(--comment) / 0.7);
+  box-shadow: 0 0 0 1px hsl(var(--comment) / 0.8);
 }
 
 .dark .prose-editor .search-match-current {
-  background-color: hsl(45 100% 50% / 0.55);
-  box-shadow: 0 0 0 1px hsl(45 100% 60% / 0.7);
+  background-color: hsl(var(--comment) / 0.55);
+  box-shadow: 0 0 0 1px hsl(var(--comment) / 0.7);
 }
 
 /* Table styles */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -33,25 +33,84 @@
     --ring: 240 5.9% 10%;
     --radius: 0.5rem;
 
-    /* Feature-semantic color tokens — Mono baseline (light).
-       Values match the original hardcoded literals exactly. */
-    --diff-suggest:       210 100% 50%;   /* blue: diff suggestion container */
-    --diff-del:           0 70% 50%;      /* red: deletion text/bg */
-    --diff-ins:           140 60% 35%;    /* green: insertion text/bg */
-    --diff-accept-btn:    140 60% 45%;    /* green: accept-change button */
-    --diff-reject-btn:    0 65% 50%;      /* red: reject-change button */
-    --comment:            45 100% 50%;    /* amber: comment marks & search highlights */
-    --comment-bg:         45 60% 20%;     /* dark amber: comment popover bg */
-    --ai-suggest:         270 70% 50%;    /* violet: AI suggestion marks */
-    --ai-action:          270 60% 50%;    /* violet: AI popover action buttons */
-    --annotation:         262 83% 58%;    /* deep violet: AI annotation primary */
-    --annotation-end:     270 70% 50%;    /* violet: gradient endpoint / dark base */
-    --annotation-shimmer: 262 90% 70%;   /* violet: shimmer highlight stop */
-    --pending:            330 81% 60%;    /* pink: pending annotation state */
-    --pending-word:       330 60% 50%;    /* pink: word-diff removed highlight */
-    --spell-error:        0 75% 55%;      /* red: spell-check underline */
-    --grammar-error:      45 80% 50%;     /* amber: grammar-check underline */
-    --frontmatter-ins:    145 70% 45%;    /* green: frontmatter pending indicator */
+    /* Feature-semantic color tokens — Mono light baseline.
+       Every value equals the original hardcoded literal exactly. */
+
+    /* Diff suggestion container (blue-210) */
+    --diff-suggest:            210 100% 50%;  /* border & bg base */
+    --diff-suggest-dark-bg:    210 100% 30%;  /* bg only in .dark (deliberately dimmer) */
+
+    /* Deletion text/bg in diff suggestions (red-0) */
+    --diff-del:                0 70% 50%;     /* text color + bg tint base */
+    --diff-del-bg-dark:        0 70% 40%;     /* bg tint in .dark (lower lightness) */
+
+    /* Insertion text/bg in diff suggestions (green-140) */
+    --diff-ins:                140 60% 35%;   /* text color */
+    --diff-ins-bg:             140 60% 40%;   /* bg tint (different from text lightness) */
+    --diff-ins-bg-dark:        140 60% 30%;   /* bg tint in .dark */
+
+    /* Accept / reject buttons in diff suggestion bar */
+    --diff-accept-btn:         140 60% 45%;
+    --diff-accept-btn-hover:   140 60% 38%;
+    --diff-reject-btn:         0 65% 50%;
+    --diff-reject-btn-hover:   0 65% 42%;
+
+    /* Comment marks (amber-45) */
+    --comment-mark-bg:         45 100% 70%;   /* mark highlight bg */
+    --comment:                 45 100% 50%;   /* mark border & search/grammar anchors */
+    --comment-bg:              45 60% 20%;    /* popover text-box bg (opaque) */
+    --comment-text-fg:         45 70% 80%;    /* popover text-box fg */
+
+    /* Comment popover remove button (distinct dark red, not same as diff-reject) */
+    --comment-remove-btn:      0 60% 40%;
+    --comment-remove-btn-hover:0 60% 35%;
+
+    /* AI suggestion marks (violet-270 70%) */
+    --ai-suggest-mark-bg:      270 70% 70%;   /* mark highlight bg (lightness 70) */
+    --ai-suggest:              270 70% 50%;   /* mark border */
+    --ai-suggest-reply-bg:     270 70% 60%;   /* [data-ai-user-reply] bg */
+    --ai-suggest-reply-border: 270 70% 50%;   /* [data-ai-user-reply] border */
+
+    /* AI suggestion popover — suggested text block (green-145) */
+    --ai-suggest-text-bg:      145 60% 20%;   /* opaque bg */
+    --ai-suggest-text-fg:      145 70% 75%;   /* fg text */
+    --ai-suggest-text-border:  145 70% 45%;   /* left border accent */
+
+    /* AI suggestion popover — accept button (green-145, distinct hue from diff-accept) */
+    --ai-suggest-accept-btn:   145 60% 40%;
+    --ai-suggest-accept-hover: 145 60% 35%;
+
+    /* AI action buttons: feedback / process / submit (violet-270 60%) */
+    --ai-action:               270 60% 50%;
+    --ai-action-hover:         270 60% 45%;
+    --ai-action-muted:         270 60% 30%;   /* feedback-text bg (lower lightness) */
+    --ai-action-link:          270 60% 60%;   /* edit-feedback-btn text */
+    --ai-action-link-hover:    270 60% 70%;
+
+    /* AI annotations — violet-262 gradient */
+    --annotation:              262 83% 58%;   /* primary gradient start + border */
+    --annotation-end:          270 70% 50%;   /* gradient tail endpoint */
+    --annotation-shimmer:      262 90% 70%;   /* hover shimmer highlight */
+
+    /* Pending annotation state (pink-330) */
+    --pending:                 330 81% 60%;   /* dashed border */
+
+    /* Word-diff removed highlight (pink-330 60%) */
+    --pending-word:            330 60% 50%;
+
+    /* Word-diff added highlight (violet-262 70%) */
+    --diff-word-added:         262 70% 55%;
+
+    /* Spell / grammar underlines */
+    --spell-error:             0 75% 55%;
+    --grammar-error:           45 80% 50%;
+
+    /* Frontmatter pending overlay (green-145) */
+    --frontmatter-bg:          145 60% 20%;   /* overlay background */
+    --frontmatter-ins:         145 70% 45%;   /* border, label */
+    --frontmatter-val:         145 60% 55%;   /* value text */
+    --frontmatter-accept-btn:  145 60% 40%;
+    --frontmatter-accept-hover:145 60% 35%;
   }
 
   .dark {
@@ -76,24 +135,50 @@
     --ring: 240 4.9% 83.9%;
 
     /* Feature-semantic token overrides — Mono dark baseline.
-       Values match the original hardcoded dark literals exactly. */
-    --diff-suggest:       210 100% 60%;   /* blue: brighter for dark bg */
-    --diff-del:           0 70% 65%;      /* red: lighter for dark bg */
-    --diff-ins:           140 60% 60%;    /* green: lighter for dark bg */
-    --diff-accept-btn:    140 60% 45%;    /* green: same — solid button */
-    --diff-reject-btn:    0 65% 50%;      /* red: same — solid button */
-    --comment:            45 100% 60%;    /* amber: brighter for dark bg */
-    --comment-bg:         45 60% 20%;     /* dark amber: same — dark popover */
-    --ai-suggest:         270 70% 60%;    /* violet: lighter for dark bg */
-    --ai-action:          270 60% 50%;    /* violet: same — solid button */
-    --annotation:         262 70% 60%;    /* deep violet: lighter for dark bg */
-    --annotation-end:     270 60% 45%;    /* violet: gradient endpoint dark */
-    --annotation-shimmer: 262 80% 65%;   /* violet: shimmer highlight dark */
-    --pending:            330 70% 55%;    /* pink: slightly muted for dark */
-    --pending-word:       330 55% 45%;    /* pink: word-diff dark */
-    --spell-error:        0 80% 60%;      /* red: brighter for dark bg */
-    --grammar-error:      45 85% 55%;     /* amber: brighter for dark bg */
-    --frontmatter-ins:    145 70% 40%;    /* green: slightly darker for dark */
+       Every value equals the original hardcoded dark literal exactly. */
+
+    --diff-suggest:            210 100% 60%;  /* dark: border brighter */
+    /* --diff-suggest-dark-bg not overridden here; it IS the dark-specific value */
+
+    --diff-del:                0 70% 65%;     /* dark: text lighter */
+    --diff-del-bg-dark:        0 70% 40%;     /* (no change — already dark-specific) */
+
+    --diff-ins:                140 60% 60%;   /* dark: text lighter */
+    --diff-ins-bg:             140 60% 40%;   /* (bg tint light stays same hue) */
+    --diff-ins-bg-dark:        140 60% 30%;   /* (no change — already dark-specific) */
+
+    /* buttons unchanged in dark */
+
+    --comment-mark-bg:         45 100% 40%;   /* dark: mark bg dimmer (was 70% light → 40% dark) */
+    --comment:                 45 100% 60%;   /* dark: border brighter */
+    /* comment-bg / comment-text-fg: same in dark — popover is always dark-styled */
+    --comment-text-fg:         45 70% 80%;    /* unchanged */
+
+    /* ai-suggest-mark-bg in dark: original was 270 70% 40% */
+    --ai-suggest-mark-bg:      270 70% 40%;
+    --ai-suggest:              270 70% 60%;   /* dark: border brighter */
+    --ai-suggest-reply-bg:     270 70% 45%;   /* dark: [data-ai-user-reply] bg */
+    --ai-suggest-reply-border: 270 70% 65%;   /* dark: [data-ai-user-reply] border */
+
+    /* ai-suggest-text-bg unchanged (dark popover stays dark) */
+
+    /* annotation */
+    --annotation:              262 70% 60%;   /* dark: lighter */
+    --annotation-end:          270 60% 45%;   /* dark: gradient tail */
+    --annotation-shimmer:      262 80% 65%;   /* dark: shimmer */
+
+    --pending:                 330 70% 55%;   /* dark: slightly muted */
+    --pending-word:            330 55% 45%;   /* dark: word-diff */
+
+    --diff-word-added:         262 65% 50%;   /* dark: word-diff added */
+
+    --spell-error:             0 80% 60%;     /* dark: brighter */
+    --grammar-error:           45 85% 55%;    /* dark: brighter */
+
+    --frontmatter-bg:          145 60% 15%;   /* dark: overlay bg (dimmer) */
+    --frontmatter-ins:         145 70% 55%;   /* dark: label color (was 55%) */
+    --frontmatter-val:         145 60% 65%;   /* dark: value text (was 65%) */
+    /* frontmatter-accept-btn unchanged in dark */
   }
 
   .termy-green-dark {
@@ -165,23 +250,50 @@
     --ring: 39.1 42.6% 42.4%;
 
     /* Prose feature tokens — warm/gold tints for parchment theme */
-    --diff-suggest:       210 80% 48%;    /* slightly de-saturated blue on warm bg */
-    --diff-del:           5 65% 48%;      /* warm red-orange deletion */
-    --diff-ins:           142 50% 32%;    /* warm forest green insertion */
-    --diff-accept-btn:    142 50% 40%;    /* warm forest green accept button */
-    --diff-reject-btn:    5 60% 47%;      /* warm red-orange reject button */
-    --comment:            40 90% 45%;     /* gold amber — natural for Prose */
-    --comment-bg:         40 55% 18%;     /* deep gold bg */
-    --ai-suggest:         280 55% 50%;    /* slightly warmer violet mark */
-    --ai-action:          280 55% 48%;    /* violet action button */
-    --annotation:         268 75% 55%;    /* warm deep violet annotation */
-    --annotation-end:     280 60% 48%;    /* warm violet gradient end */
-    --annotation-shimmer: 268 85% 68%;   /* warm shimmer */
-    --pending:            340 70% 57%;    /* warm pink pending */
-    --pending-word:       340 55% 48%;    /* warm pink word-diff */
-    --spell-error:        5 70% 52%;      /* warm red spell error */
-    --grammar-error:      40 75% 45%;     /* gold grammar error */
-    --frontmatter-ins:    148 60% 40%;    /* warm green frontmatter */
+    --diff-suggest:            210 80% 48%;
+    --diff-suggest-dark-bg:    210 80% 25%;
+    --diff-del:                5 65% 48%;
+    --diff-del-bg-dark:        5 65% 35%;
+    --diff-ins:                142 50% 32%;
+    --diff-ins-bg:             142 50% 38%;
+    --diff-ins-bg-dark:        142 50% 25%;
+    --diff-accept-btn:         142 50% 40%;
+    --diff-accept-btn-hover:   142 50% 33%;
+    --diff-reject-btn:         5 60% 47%;
+    --diff-reject-btn-hover:   5 60% 40%;
+    --comment-mark-bg:         40 90% 68%;
+    --comment:                 40 90% 45%;
+    --comment-bg:              40 55% 18%;
+    --comment-text-fg:         40 65% 78%;
+    --comment-remove-btn:      5 58% 38%;
+    --comment-remove-btn-hover:5 58% 32%;
+    --ai-suggest-mark-bg:      280 55% 68%;
+    --ai-suggest:              280 55% 50%;
+    --ai-suggest-reply-bg:     280 55% 58%;
+    --ai-suggest-reply-border: 280 55% 48%;
+    --ai-suggest-text-bg:      148 50% 18%;
+    --ai-suggest-text-fg:      148 60% 73%;
+    --ai-suggest-text-border:  148 60% 42%;
+    --ai-suggest-accept-btn:   148 50% 38%;
+    --ai-suggest-accept-hover: 148 50% 32%;
+    --ai-action:               280 55% 48%;
+    --ai-action-hover:         280 55% 42%;
+    --ai-action-muted:         280 55% 28%;
+    --ai-action-link:          280 55% 58%;
+    --ai-action-link-hover:    280 55% 68%;
+    --annotation:              268 75% 55%;
+    --annotation-end:          280 60% 48%;
+    --annotation-shimmer:      268 85% 68%;
+    --pending:                 340 70% 57%;
+    --pending-word:            340 55% 48%;
+    --diff-word-added:         268 65% 53%;
+    --spell-error:             5 70% 52%;
+    --grammar-error:           40 75% 45%;
+    --frontmatter-bg:          148 50% 18%;
+    --frontmatter-ins:         148 60% 42%;
+    --frontmatter-val:         148 50% 53%;
+    --frontmatter-accept-btn:  148 50% 38%;
+    --frontmatter-accept-hover:148 50% 32%;
   }
 
   .theme-prose.dark {
@@ -204,23 +316,26 @@
     --ring: 40.4 50% 56.9%;
 
     /* Prose dark feature tokens — warm/gold tints on dark parchment */
-    --diff-suggest:       210 85% 62%;    /* brighter blue on dark warm bg */
-    --diff-del:           5 65% 62%;      /* warm red-orange on dark */
-    --diff-ins:           142 55% 58%;    /* warm forest green on dark */
-    --diff-accept-btn:    142 50% 42%;    /* forest green button */
-    --diff-reject-btn:    5 60% 47%;      /* warm red button */
-    --comment:            40 90% 58%;     /* bright gold amber */
-    --comment-bg:         40 55% 18%;     /* deep gold bg */
-    --ai-suggest:         280 60% 62%;    /* warmer violet on dark */
-    --ai-action:          280 55% 50%;    /* violet button */
-    --annotation:         268 70% 62%;    /* warm deep violet on dark */
-    --annotation-end:     280 60% 47%;    /* warm gradient end dark */
-    --annotation-shimmer: 268 80% 67%;   /* warm shimmer dark */
-    --pending:            340 70% 57%;    /* warm pink pending */
-    --pending-word:       340 55% 47%;    /* warm pink word-diff */
-    --spell-error:        5 75% 58%;      /* warm red on dark */
-    --grammar-error:      40 80% 55%;     /* gold grammar on dark */
-    --frontmatter-ins:    148 60% 42%;    /* warm green frontmatter */
+    --diff-suggest:            210 85% 62%;
+    --diff-del:                5 65% 62%;
+    --diff-ins:                142 55% 58%;
+    --comment-mark-bg:         40 90% 40%;
+    --comment:                 40 90% 58%;
+    --ai-suggest-mark-bg:      280 60% 40%;
+    --ai-suggest:              280 60% 62%;
+    --ai-suggest-reply-bg:     280 60% 45%;
+    --ai-suggest-reply-border: 280 60% 65%;
+    --annotation:              268 70% 62%;
+    --annotation-end:          280 60% 47%;
+    --annotation-shimmer:      268 80% 67%;
+    --pending:                 340 70% 57%;
+    --pending-word:            340 55% 47%;
+    --diff-word-added:         268 60% 50%;
+    --spell-error:             5 75% 58%;
+    --grammar-error:           40 80% 55%;
+    --frontmatter-bg:          148 50% 15%;
+    --frontmatter-ins:         148 60% 55%;
+    --frontmatter-val:         148 50% 63%;
   }
 
   .theme-termy {
@@ -243,23 +358,50 @@
     --ring: 137.7 57.4% 26.7%;
 
     /* Termy feature tokens — phosphor/green tints for terminal theme */
-    --diff-suggest:       160 70% 38%;    /* teal-green for diff suggestion */
-    --diff-del:           0 65% 45%;      /* red-on-green deletion */
-    --diff-ins:           130 55% 30%;    /* deeper phosphor green insertion */
-    --diff-accept-btn:    130 55% 38%;    /* phosphor green accept button */
-    --diff-reject-btn:    0 60% 45%;      /* red reject button */
-    --comment:            80 70% 38%;     /* yellow-green amber comment */
-    --comment-bg:         80 45% 18%;     /* deep yellow-green bg */
-    --ai-suggest:         160 55% 38%;    /* teal violet-adjacent for marks */
-    --ai-action:          155 50% 36%;    /* teal action button */
-    --annotation:         155 65% 38%;    /* phosphor annotation */
-    --annotation-end:     160 55% 35%;    /* annotation gradient end */
-    --annotation-shimmer: 155 80% 55%;   /* phosphor shimmer */
-    --pending:            100 55% 42%;    /* lime-green pending */
-    --pending-word:       100 45% 38%;    /* lime word-diff */
-    --spell-error:        0 70% 48%;      /* red on green bg */
-    --grammar-error:      80 65% 40%;     /* yellow-green grammar */
-    --frontmatter-ins:    135 60% 35%;    /* phosphor green frontmatter */
+    --diff-suggest:            160 70% 38%;
+    --diff-suggest-dark-bg:    160 70% 22%;
+    --diff-del:                0 65% 45%;
+    --diff-del-bg-dark:        0 65% 32%;
+    --diff-ins:                130 55% 30%;
+    --diff-ins-bg:             130 55% 36%;
+    --diff-ins-bg-dark:        130 55% 22%;
+    --diff-accept-btn:         130 55% 38%;
+    --diff-accept-btn-hover:   130 55% 32%;
+    --diff-reject-btn:         0 60% 45%;
+    --diff-reject-btn-hover:   0 60% 38%;
+    --comment-mark-bg:         80 70% 68%;
+    --comment:                 80 70% 38%;
+    --comment-bg:              80 45% 18%;
+    --comment-text-fg:         80 60% 78%;
+    --comment-remove-btn:      0 58% 38%;
+    --comment-remove-btn-hover:0 58% 32%;
+    --ai-suggest-mark-bg:      160 55% 68%;
+    --ai-suggest:              160 55% 38%;
+    --ai-suggest-reply-bg:     160 55% 58%;
+    --ai-suggest-reply-border: 160 55% 38%;
+    --ai-suggest-text-bg:      135 50% 18%;
+    --ai-suggest-text-fg:      135 60% 73%;
+    --ai-suggest-text-border:  135 60% 35%;
+    --ai-suggest-accept-btn:   135 50% 35%;
+    --ai-suggest-accept-hover: 135 50% 28%;
+    --ai-action:               155 50% 36%;
+    --ai-action-hover:         155 50% 30%;
+    --ai-action-muted:         155 50% 22%;
+    --ai-action-link:          155 50% 48%;
+    --ai-action-link-hover:    155 50% 58%;
+    --annotation:              155 65% 38%;
+    --annotation-end:          160 55% 35%;
+    --annotation-shimmer:      155 80% 55%;
+    --pending:                 100 55% 42%;
+    --pending-word:            100 45% 38%;
+    --diff-word-added:         155 60% 38%;
+    --spell-error:             0 70% 48%;
+    --grammar-error:           80 65% 40%;
+    --frontmatter-bg:          135 50% 18%;
+    --frontmatter-ins:         135 60% 35%;
+    --frontmatter-val:         135 50% 48%;
+    --frontmatter-accept-btn:  135 50% 35%;
+    --frontmatter-accept-hover:135 50% 28%;
   }
 
   .theme-termy.dark {
@@ -282,23 +424,27 @@
     --ring: 149.9 100% 50%;
 
     /* Termy dark feature tokens — phosphor/green on black terminal */
-    --diff-suggest:       160 80% 55%;    /* bright teal on black */
-    --diff-del:           0 70% 55%;      /* red on dark terminal */
-    --diff-ins:           130 70% 55%;    /* bright phosphor green */
-    --diff-accept-btn:    130 65% 48%;    /* phosphor accept button */
-    --diff-reject-btn:    0 65% 48%;      /* red reject button */
-    --comment:            80 90% 55%;     /* bright yellow-green */
-    --comment-bg:         80 45% 12%;     /* deep phosphor bg */
-    --ai-suggest:         155 75% 52%;    /* bright teal mark */
-    --ai-action:          155 65% 48%;    /* teal action button */
-    --annotation:         150 80% 48%;    /* bright phosphor annotation */
-    --annotation-end:     155 65% 42%;    /* gradient end dark */
-    --annotation-shimmer: 150 90% 65%;   /* bright phosphor shimmer */
-    --pending:            100 65% 52%;    /* bright lime pending */
-    --pending-word:       100 55% 45%;    /* lime word-diff dark */
-    --spell-error:        0 75% 58%;      /* red on dark terminal */
-    --grammar-error:      80 80% 55%;     /* yellow-green grammar */
-    --frontmatter-ins:    140 75% 50%;    /* bright phosphor frontmatter */
+    --diff-suggest:            160 80% 55%;
+    --diff-del:                0 70% 55%;
+    --diff-ins:                130 70% 55%;
+    --comment-mark-bg:         80 90% 40%;
+    --comment:                 80 90% 55%;
+    --comment-bg:              80 45% 12%;
+    --ai-suggest-mark-bg:      155 75% 40%;
+    --ai-suggest:              155 75% 52%;
+    --ai-suggest-reply-bg:     155 75% 45%;
+    --ai-suggest-reply-border: 155 75% 65%;
+    --annotation:              150 80% 48%;
+    --annotation-end:          155 65% 42%;
+    --annotation-shimmer:      150 90% 65%;
+    --pending:                 100 65% 52%;
+    --pending-word:            100 55% 45%;
+    --diff-word-added:         150 70% 45%;
+    --spell-error:             0 75% 58%;
+    --grammar-error:           80 80% 55%;
+    --frontmatter-bg:          140 55% 12%;
+    --frontmatter-ins:         140 75% 50%;
+    --frontmatter-val:         140 60% 60%;
   }
 }
 
@@ -656,7 +802,7 @@
 
 .dark .prose-editor .diff-suggestion {
   border-color: hsl(var(--diff-suggest) / 0.3);
-  background: hsl(var(--diff-suggest) / 0.2);
+  background: hsl(var(--diff-suggest-dark-bg) / 0.2);
 }
 
 /* Visual separator between consecutive diffs */
@@ -674,12 +820,12 @@
 
 .dark .prose-editor .diff-suggestion [data-diff-suggestion-old] {
   color: hsl(var(--diff-del));
-  background: hsl(var(--diff-del) / 0.25);
+  background: hsl(var(--diff-del-bg-dark) / 0.25);
 }
 
 .prose-editor .diff-suggestion [data-diff-suggestion-new] {
   color: hsl(var(--diff-ins));
-  background: hsl(var(--diff-ins) / 0.15);
+  background: hsl(var(--diff-ins-bg) / 0.15);
   padding: 0 0.1em;
   border-radius: 0.125em;
   margin-left: 0.25em;
@@ -687,7 +833,7 @@
 
 .dark .prose-editor .diff-suggestion [data-diff-suggestion-new] {
   color: hsl(var(--diff-ins));
-  background: hsl(var(--diff-ins) / 0.25);
+  background: hsl(var(--diff-ins-bg-dark) / 0.25);
 }
 
 .prose-editor .diff-suggestion-content {
@@ -719,7 +865,7 @@
 }
 
 .prose-editor .diff-accept-btn:hover {
-  background: hsl(var(--diff-accept-btn) / 0.85);
+  background: hsl(var(--diff-accept-btn-hover));
 }
 
 .prose-editor .diff-reject-btn {
@@ -728,12 +874,12 @@
 }
 
 .prose-editor .diff-reject-btn:hover {
-  background: hsl(var(--diff-reject-btn) / 0.85);
+  background: hsl(var(--diff-reject-btn-hover));
 }
 
 /* Comment Marks */
 .prose-editor .comment-mark {
-  background: hsl(var(--comment) / 0.4);
+  background: hsl(var(--comment-mark-bg) / 0.4);
   border-bottom: 2px solid hsl(var(--comment));
   padding: 0 0.1em;
   border-radius: 0.125em;
@@ -742,16 +888,16 @@
 }
 
 .dark .prose-editor .comment-mark {
-  background: hsl(var(--comment) / 0.3);
+  background: hsl(var(--comment-mark-bg) / 0.3);
   border-bottom-color: hsl(var(--comment));
 }
 
 .prose-editor .comment-mark:hover {
-  background: hsl(var(--comment) / 0.6);
+  background: hsl(var(--comment-mark-bg) / 0.6);
 }
 
 .dark .prose-editor .comment-mark:hover {
-  background: hsl(var(--comment) / 0.5);
+  background: hsl(var(--comment-mark-bg) / 0.5);
 }
 
 /* Comment Popover (click to open) */
@@ -774,7 +920,7 @@
 
 .comment-popover .comment-text {
   background: hsl(var(--comment-bg));
-  color: hsl(var(--comment) / 0.9);
+  color: hsl(var(--comment-text-fg));
   padding: 0.75rem 1rem;
   border-radius: 0.375rem;
   font-family: var(--font-mono);
@@ -814,17 +960,17 @@
 }
 
 .comment-popover .process-btn:hover {
-  background: hsl(var(--ai-action) / 0.88);
+  background: hsl(var(--ai-action-hover));
 }
 
 .comment-popover .remove-btn {
-  background: hsl(var(--diff-reject-btn) / 0.85);
+  background: hsl(var(--comment-remove-btn));
   color: white;
   border: none;
 }
 
 .comment-popover .remove-btn:hover {
-  background: hsl(var(--diff-reject-btn) / 0.72);
+  background: hsl(var(--comment-remove-btn-hover));
 }
 
 .comment-popover .close-btn {
@@ -839,7 +985,7 @@
 
 /* AI Suggestion Marks - Purple highlighting for AI edit suggestions */
 .prose-editor .ai-suggestion-mark {
-  background: hsl(var(--ai-suggest) / 0.4);
+  background: hsl(var(--ai-suggest-mark-bg) / 0.4);
   border-bottom: 2px solid hsl(var(--ai-suggest));
   padding: 0 0.1em;
   border-radius: 0.125em;
@@ -848,16 +994,16 @@
 }
 
 .dark .prose-editor .ai-suggestion-mark {
-  background: hsl(var(--ai-suggest) / 0.3);
+  background: hsl(var(--ai-suggest-mark-bg) / 0.3);
   border-bottom-color: hsl(var(--ai-suggest));
 }
 
 .prose-editor .ai-suggestion-mark:hover {
-  background: hsl(var(--ai-suggest) / 0.6);
+  background: hsl(var(--ai-suggest-mark-bg) / 0.6);
 }
 
 .dark .prose-editor .ai-suggestion-mark:hover {
-  background: hsl(var(--ai-suggest) / 0.5);
+  background: hsl(var(--ai-suggest-mark-bg) / 0.5);
 }
 
 /* Hide AI annotations when toggled off */
@@ -908,15 +1054,15 @@
 }
 
 .ai-suggestion-popover .suggested-text {
-  background: hsl(var(--frontmatter-ins) / 0.2);
-  color: hsl(var(--frontmatter-ins) / 0.9);
+  background: hsl(var(--ai-suggest-text-bg));
+  color: hsl(var(--ai-suggest-text-fg));
   padding: 0.75rem 1rem;
   border-radius: 0.375rem;
   font-family: var(--font-mono);
   font-size: 0.875rem;
   line-height: 1.5;
   margin-bottom: 1rem;
-  border-left: 3px solid hsl(var(--frontmatter-ins));
+  border-left: 3px solid hsl(var(--ai-suggest-text-border));
 }
 
 .ai-suggestion-popover .explanation-label {
@@ -944,7 +1090,7 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: hsl(var(--diff-accept-btn));
+  background: hsl(var(--ai-suggest-accept-btn));
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -955,7 +1101,7 @@
 }
 
 .ai-suggestion-popover .accept-btn:hover {
-  background: hsl(var(--diff-accept-btn) / 0.85);
+  background: hsl(var(--ai-suggest-accept-hover));
 }
 
 .ai-suggestion-popover .reject-btn {
@@ -997,7 +1143,7 @@
 }
 
 .ai-suggestion-popover .feedback-btn:hover {
-  background: hsl(var(--ai-action) / 0.88);
+  background: hsl(var(--ai-action-hover));
 }
 
 /* Feedback section styles */
@@ -1051,7 +1197,7 @@
 }
 
 .ai-suggestion-popover .feedback-submit-btn:hover:not(:disabled) {
-  background: hsl(var(--ai-action) / 0.88);
+  background: hsl(var(--ai-action-hover));
 }
 
 .ai-suggestion-popover .feedback-submit-btn:disabled {
@@ -1082,7 +1228,7 @@
 }
 
 .ai-suggestion-popover .feedback-text {
-  background: hsl(var(--ai-action) / 0.2);
+  background: hsl(var(--ai-action-muted) / 0.2);
   color: hsl(var(--foreground));
   padding: 0.5rem 0.75rem;
   border-radius: 0.375rem;
@@ -1095,7 +1241,7 @@
 .ai-suggestion-popover .edit-feedback-btn {
   padding: 0.25rem 0.5rem;
   background: transparent;
-  color: hsl(var(--ai-action) / 0.85);
+  color: hsl(var(--ai-action-link));
   border: none;
   font-size: 0.75rem;
   cursor: pointer;
@@ -1103,19 +1249,19 @@
 }
 
 .ai-suggestion-popover .edit-feedback-btn:hover {
-  color: hsl(var(--ai-action));
+  color: hsl(var(--ai-action-link-hover));
 }
 
 /* Visual indicator for suggestions with pending feedback */
 .prose-editor .ai-suggestion-mark[data-ai-user-reply] {
-  background: hsl(var(--ai-suggest) / 0.5);
-  border-bottom: 2px dashed hsl(var(--ai-suggest));
+  background: hsl(var(--ai-suggest-reply-bg) / 0.5);
+  border-bottom: 2px dashed hsl(var(--ai-suggest-reply-border));
   animation: pulse-feedback 2s ease-in-out infinite;
 }
 
 .dark .prose-editor .ai-suggestion-mark[data-ai-user-reply] {
-  background: hsl(var(--ai-suggest) / 0.4);
-  border-bottom-color: hsl(var(--ai-suggest));
+  background: hsl(var(--ai-suggest-reply-bg) / 0.4);
+  border-bottom-color: hsl(var(--ai-suggest-reply-border));
 }
 
 @keyframes pulse-feedback {
@@ -1125,12 +1271,12 @@
 
 /* Frontmatter pending overlay — shown when AI proposes frontmatter changes (#488) */
 .frontmatter-pending-overlay {
-  background: hsl(var(--frontmatter-ins) / 0.25);
+  background: hsl(var(--frontmatter-bg) / 0.25);
   border-color: hsl(var(--frontmatter-ins) / 0.6);
 }
 
 .dark .frontmatter-pending-overlay {
-  background: hsl(var(--frontmatter-ins) / 0.35);
+  background: hsl(var(--frontmatter-bg) / 0.35);
   border-color: hsl(var(--frontmatter-ins) / 0.5);
 }
 
@@ -1146,11 +1292,11 @@
 }
 
 .frontmatter-pending-value {
-  color: hsl(var(--frontmatter-ins) / 0.85);
+  color: hsl(var(--frontmatter-val));
 }
 
 .dark .frontmatter-pending-value {
-  color: hsl(var(--frontmatter-ins) / 0.9);
+  color: hsl(var(--frontmatter-val));
 }
 
 .frontmatter-pending-accept-btn {
@@ -1158,7 +1304,7 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.125rem 0.5rem;
-  background: hsl(var(--diff-accept-btn));
+  background: hsl(var(--frontmatter-accept-btn));
   color: white;
   border: none;
   border-radius: 0.25rem;
@@ -1170,7 +1316,7 @@
 }
 
 .frontmatter-pending-accept-btn:hover {
-  background: hsl(var(--diff-accept-btn) / 0.85);
+  background: hsl(var(--frontmatter-accept-hover));
 }
 
 .frontmatter-pending-reject-btn {
@@ -1412,13 +1558,13 @@
 }
 
 .prose-editor .diff-word-added {
-  background: hsl(var(--annotation) / 0.25);
+  background: hsl(var(--diff-word-added) / 0.25);
   border-radius: 0.125em;
   padding: 0 0.1em;
 }
 
 .dark .prose-editor .diff-word-added {
-  background: hsl(var(--annotation) / 0.35);
+  background: hsl(var(--diff-word-added) / 0.35);
 }
 
 /* Images */


### PR DESCRIPTION
## Summary

- Replace all ~80 hardcoded `hsl(N N% N%)` literals in `src/renderer/index.css` feature-color blocks with `hsl(var(--token))` references
- Declare 17 new feature-semantic tokens under `:root` and `.dark` — Mono baseline values match the original literals exactly (pixel-identical)
- Add per-theme overrides under `.theme-prose` / `.theme-prose.dark` (warm/gold tints) and `.theme-termy` / `.theme-termy.dark` (phosphor/green tints)
- Add `docs/design/v1.2-appearance/feature-token-map.md` as a reference mapping token → what it colors

## Tokens Added (17)

`--diff-suggest`, `--diff-del`, `--diff-ins`, `--diff-accept-btn`, `--diff-reject-btn`, `--comment`, `--comment-bg`, `--ai-suggest`, `--ai-action`, `--annotation`, `--annotation-end`, `--annotation-shimmer`, `--pending`, `--pending-word`, `--spell-error`, `--grammar-error`, `--frontmatter-ins`

## Verification

- `npm run build` — green, no errors
- `grep -nE 'hsl\(\s*[0-9]' src/renderer/index.css` — zero matches (all feature-block literals replaced)
- Mono theme unchanged: `:root` token values equal the original hardcoded literals

## Scope note

> This PR targets `release/v1.4-appearance`; the cloud review may check against `main` and produce false-positive findings about foundation tokens and types that exist only on the umbrella branch — please review against the umbrella base.

Closes #503. Refs #499.