### PR TITLE
feat(appearance): Settings → Appearance pane (#499 PR 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -211,6 +211,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1155,7 +1156,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1177,7 +1177,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1194,7 +1193,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1209,7 +1207,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2327,6 +2324,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2348,6 +2346,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
       "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -2360,6 +2359,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2783,6 +2783,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
       "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2799,6 +2800,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
       "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/resources": "2.6.0",
@@ -2816,6 +2818,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4823,6 +4826,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.1.tgz",
       "integrity": "sha512-nkerkl8syHj44ZzAB7oA2GPmmZINKBKCa79FuNvmGJrJ4qyZwlkDzszud23YteFZEytbc87kVd/fP76ROS6sLg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5235,6 +5239,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.1.tgz",
       "integrity": "sha512-ijKo3+kIjALthYsnBmkRXAuw2Tswd9gd7BUR5OMfIcjGp8v576vKxOxrRfuYiUM78GPt//P0sVc1WV82H5N0PQ==",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -5514,6 +5519,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5524,6 +5530,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5683,6 +5690,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5741,6 +5749,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6387,6 +6396,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7072,8 +7082,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7274,6 +7283,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -7448,6 +7458,7 @@
       "integrity": "sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -7704,7 +7715,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -7725,7 +7735,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -7764,16 +7773,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -8866,6 +8865,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9250,6 +9250,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9961,7 +9962,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10644,6 +10644,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10821,7 +10822,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10839,7 +10839,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10995,6 +10994,7 @@
       "version": "1.25.4",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11021,6 +11021,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11065,6 +11066,7 @@
       "version": "1.41.4",
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
       "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -11206,6 +11208,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11217,6 +11220,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11481,7 +11485,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11525,6 +11528,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12203,6 +12207,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -12276,7 +12281,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -12415,6 +12419,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12613,6 +12618,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12824,6 +12830,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13420,6 +13427,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13608,6 +13616,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -75,7 +75,7 @@ export function App() {
   const googleDocsEnabled = useGoogleDocsEnabled()
   const { openFile, openFileFromPath, saveFile, saveFileAs, newFile } = useEditor()
   const { createNewTab, openFileInTab } = useTabs()
-  const { setDialogOpen, isShortcutsDialogOpen, setShortcutsDialogOpen, isAboutDialogOpen, setAboutDialogOpen, isModelPickerOpen, setModelPickerOpen, settings, autosaveActive, isLoaded: settingsLoaded } = useSettings()
+  const { setDialogOpen, isShortcutsDialogOpen, setShortcutsDialogOpen, isAboutDialogOpen, setAboutDialogOpen, isModelPickerOpen, setModelPickerOpen, settings, effectiveTheme, autosaveActive, isLoaded: settingsLoaded } = useSettings()
   const [recoveryDialogOpen, setRecoveryDialogOpen] = useState(false)
   const [pendingDraft, setPendingDraft] = useState<DraftState | null>(null)
   const [pendingSession, setPendingSession] = useState<SessionState | null>(null)
@@ -920,7 +920,13 @@ export function App() {
   return (
     <PanelLayoutProvider value={panelLayout}>
     <TooltipProvider delayDuration={300}>
-      <div className="flex h-screen flex-col bg-background text-foreground">
+      <div
+        className={[
+          'flex h-screen flex-col bg-background text-foreground',
+          settings.appearance?.color === 'termy' && effectiveTheme === 'dark' ? 'termy-scanline-scope' : '',
+        ].filter(Boolean).join(' ')}
+        data-color={settings.appearance?.color}
+      >
         <Toolbar />
         <UpdateBanner />
 

--- a/src/renderer/components/settings/AppearancePane.tsx
+++ b/src/renderer/components/settings/AppearancePane.tsx
@@ -1,0 +1,261 @@
+// AppearancePane.tsx — Settings → Appearance pane (#504, #499 PR 2).
+// Three sections: Mode (segmented), Color (3 ThemeCards), App Icon (11 IconCells).
+// All three sections implement ARIA radio group semantics with full keyboard nav.
+
+import { useRef, useCallback } from 'react'
+import { Sun, Moon, Monitor, Info } from 'lucide-react'
+import { Button } from '../ui/button'
+import { ThemeCard, THEMES, DEFAULT_COLOR } from './ThemeCard'
+import { IconCell } from './IconCell'
+import { PROSE_ICONS } from '../../lib/prose-icons'
+import type { ColorTheme, ThemeMode, IconId } from '../../types'
+import type { Appearance } from '../../types'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const MODES: { id: ThemeMode; label: string; Icon: typeof Sun }[] = [
+  { id: 'light',  label: 'Light',  Icon: Sun },
+  { id: 'dark',   label: 'Dark',   Icon: Moon },
+  { id: 'system', label: 'System', Icon: Monitor },
+]
+
+const DEFAULT_MODE: ThemeMode = 'dark'
+const DEFAULT_ICON: IconId = 'pilcrow'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Make an arrow-key radio-group keyboard handler for a list of items. */
+function makeRadioKeyHandler<T extends string>(
+  items: T[],
+  current: T,
+  onSelect: (id: T) => void,
+): React.KeyboardEventHandler<HTMLElement> {
+  return (e) => {
+    const idx = items.indexOf(current)
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault()
+      onSelect(items[(idx + 1) % items.length])
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      onSelect(items[(idx - 1 + items.length) % items.length])
+    } else if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      onSelect(current)
+    }
+  }
+}
+
+// ── Section label ─────────────────────────────────────────────────────────────
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2.5 mb-3">
+      <span
+        className="text-[10px] tracking-[0.18em] uppercase font-normal text-muted-foreground"
+        style={{ fontFamily: '"IBM Plex Mono", monospace' }}
+      >
+        {children}
+      </span>
+      <div className="h-px flex-1 max-w-[200px] bg-border" />
+    </div>
+  )
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface AppearancePaneProps {
+  appearance: Appearance
+  effectiveMode: 'light' | 'dark'
+  onAppearanceChange: (patch: Partial<Appearance>) => void
+}
+
+// ── Pane ──────────────────────────────────────────────────────────────────────
+
+export function AppearancePane({ appearance, effectiveMode, onAppearanceChange }: AppearancePaneProps) {
+  const { color, mode, icon } = appearance
+
+  const isAllDefault =
+    color === DEFAULT_COLOR &&
+    mode === DEFAULT_MODE &&
+    icon === DEFAULT_ICON
+
+  const currentTheme = THEMES.find((t) => t.id === color) ?? THEMES[0]
+  const currentIcon = PROSE_ICONS.find((i) => i.id === icon) ?? PROSE_ICONS[0]
+
+  // ── Refs for focus management after arrow-key selection ──────────────────
+  const modeButtonRefs = useRef<Map<ThemeMode, HTMLButtonElement | null>>(new Map())
+  const themeButtonRefs = useRef<Map<ColorTheme, HTMLButtonElement | null>>(new Map())
+  const iconButtonRefs = useRef<Map<IconId, HTMLButtonElement | null>>(new Map())
+
+  // ── Selection handlers with focus follow ──────────────────────────────────
+  const handleModeSelect = useCallback((id: ThemeMode) => {
+    onAppearanceChange({ mode: id })
+    // Focus the newly selected button after state update
+    requestAnimationFrame(() => modeButtonRefs.current.get(id)?.focus())
+  }, [onAppearanceChange])
+
+  const handleColorSelect = useCallback((id: ColorTheme) => {
+    onAppearanceChange({ color: id })
+    requestAnimationFrame(() => themeButtonRefs.current.get(id)?.focus())
+  }, [onAppearanceChange])
+
+  const handleIconSelect = useCallback((id: IconId) => {
+    onAppearanceChange({ icon: id })
+    requestAnimationFrame(() => iconButtonRefs.current.get(id)?.focus())
+  }, [onAppearanceChange])
+
+  // ── Arrow-key handlers per group ──────────────────────────────────────────
+  const modeIds = MODES.map((m) => m.id)
+  const colorIds = THEMES.map((t) => t.id)
+  const iconIds = PROSE_ICONS.map((i) => i.id)
+
+  const modeKeyHandler = makeRadioKeyHandler(modeIds, mode, handleModeSelect)
+  const colorKeyHandler = makeRadioKeyHandler(colorIds, color, handleColorSelect)
+  const iconKeyHandler = makeRadioKeyHandler(iconIds, icon, handleIconSelect)
+
+  return (
+    <div
+      className="flex-1 overflow-auto bg-background text-foreground"
+      style={{ padding: '22px 28px', fontFamily: '"IBM Plex Mono", monospace' }}
+    >
+      {/* Page title + current state summary */}
+      <div className="flex items-baseline justify-between mb-5">
+        <h1
+          className="text-[19px] font-normal tracking-tight text-foreground"
+          style={{ fontFamily: '"IBM Plex Mono", monospace' }}
+        >
+          Appearance
+        </h1>
+        <div className="text-[10.5px] text-muted-foreground tracking-[0.04em]">
+          <span className="text-foreground">{currentTheme.name}</span>
+          <span className="mx-1.5">·</span>
+          <span>
+            {mode === 'system' ? `System · ${effectiveMode}` : effectiveMode}
+          </span>
+          <span className="mx-1.5">·</span>
+          <span className="text-foreground">{currentIcon.name}</span>
+        </div>
+      </div>
+
+      {/* ── MODE ── */}
+      <SectionLabel>Mode</SectionLabel>
+      <div className="mb-5">
+        <div
+          role="radiogroup"
+          aria-label="Display mode"
+          className="inline-flex bg-muted border border-border rounded-lg p-[3px] gap-0.5"
+        >
+          {MODES.map((m) => {
+            const selected = mode === m.id
+            return (
+              <button
+                key={m.id}
+                ref={(el) => modeButtonRefs.current.set(m.id, el)}
+                role="radio"
+                aria-checked={selected}
+                tabIndex={selected ? 0 : -1}
+                onClick={() => handleModeSelect(m.id)}
+                onKeyDown={modeKeyHandler as React.KeyboardEventHandler<HTMLButtonElement>}
+                className={[
+                  'inline-flex items-center gap-1.5 px-3 py-[5px] rounded-md text-[11.5px] border-none cursor-pointer',
+                  'transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                  selected
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-transparent text-muted-foreground hover:text-foreground',
+                ].join(' ')}
+                style={{ fontFamily: '"IBM Plex Mono", monospace' }}
+              >
+                <m.Icon className="w-3 h-3" strokeWidth={1.7} />
+                {m.label}
+                {m.id === 'system' && mode === 'system' && (
+                  <span className="text-[9px] opacity-70 ml-0.5 tracking-[0.05em]">
+                    · {effectiveMode}
+                  </span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* ── COLOR ── */}
+      <SectionLabel>Color</SectionLabel>
+      <div
+        role="radiogroup"
+        aria-label="Color theme"
+        className="grid grid-cols-3 gap-3.5 mb-5"
+      >
+        {THEMES.map((t) => (
+          <ThemeCard
+            key={t.id}
+            theme={t}
+            selected={t.id === color}
+            effectiveMode={effectiveMode}
+            onSelect={handleColorSelect}
+            onKeyDown={colorKeyHandler as React.KeyboardEventHandler<HTMLButtonElement>}
+            tabIndex={t.id === color ? 0 : -1}
+            ref={(el: HTMLButtonElement | null) => themeButtonRefs.current.set(t.id, el)}
+          />
+        ))}
+      </div>
+
+      {/* ── APP ICON ── */}
+      <SectionLabel>App icon</SectionLabel>
+      <p
+        className="text-[11.5px] font-light text-muted-foreground leading-relaxed mb-4 max-w-[560px]"
+        style={{ fontFamily: '"IBM Plex Mono", monospace' }}
+      >
+        Default is{' '}
+        <em style={{ fontFamily: '"Fraunces", serif', fontStyle: 'italic', color: 'hsl(var(--foreground))' }}>
+          Pilcrow
+        </em>{' '}
+        — the paragraph mark used by prose typographers since the 12th century.{' '}
+        <span className="text-muted-foreground/60">Changes apply immediately.</span>
+      </p>
+      <div
+        role="radiogroup"
+        aria-label="App icon"
+        className="grid grid-cols-6 gap-3.5 mb-5"
+      >
+        {PROSE_ICONS.map((item) => (
+          <IconCell
+            key={item.id}
+            item={item}
+            selected={item.id === icon}
+            onSelect={handleIconSelect}
+            onKeyDown={iconKeyHandler as React.KeyboardEventHandler<HTMLButtonElement>}
+            tabIndex={item.id === icon ? 0 : -1}
+            ref={(el: HTMLButtonElement | null) => iconButtonRefs.current.set(item.id, el)}
+          />
+        ))}
+      </div>
+
+      {/* ── Reset row ── */}
+      <div className="flex items-center justify-between pt-3.5 border-t border-border text-[11px] text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Info className="w-3 h-3 text-muted-foreground/60" strokeWidth={1.6} />
+          <span>
+            Using{' '}
+            <span className="text-foreground">{currentTheme.name}</span>
+            <span className="text-muted-foreground"> · </span>
+            <span className="text-foreground">{effectiveMode}</span>
+            <span className="text-muted-foreground"> · </span>
+            <span className="text-foreground">{currentIcon.name}</span>
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isAllDefault}
+          onClick={() => {
+            onAppearanceChange({ color: DEFAULT_COLOR, mode: DEFAULT_MODE, icon: DEFAULT_ICON })
+          }}
+          className="text-[11px] h-7 px-3"
+          style={{ fontFamily: '"IBM Plex Mono", monospace' }}
+        >
+          Reset all to default
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/settings/AppearancePane.tsx
+++ b/src/renderer/components/settings/AppearancePane.tsx
@@ -24,14 +24,15 @@ const DEFAULT_ICON: IconId = 'pilcrow'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/** Make an arrow-key radio-group keyboard handler for a list of items. */
+/** Make an arrow-key radio-group keyboard handler for a list of items.
+ *  `selected` is the currently-selected value in the group. */
 function makeRadioKeyHandler<T extends string>(
   items: T[],
-  current: T,
+  selected: T,
   onSelect: (id: T) => void,
 ): React.KeyboardEventHandler<HTMLElement> {
   return (e) => {
-    const idx = items.indexOf(current)
+    const idx = items.indexOf(selected)
     if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
       e.preventDefault()
       onSelect(items[(idx + 1) % items.length])
@@ -40,7 +41,11 @@ function makeRadioKeyHandler<T extends string>(
       onSelect(items[(idx - 1 + items.length) % items.length])
     } else if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault()
-      onSelect(current)
+      // The focused button's id is stored in aria-checked; use e.currentTarget
+      // to read the id of the focused item. Skip if it's already selected.
+      const focusedId = (e.currentTarget as HTMLElement).dataset.radioId as T | undefined
+      if (focusedId === undefined || focusedId === selected) return
+      onSelect(focusedId)
     }
   }
 }
@@ -154,6 +159,7 @@ export function AppearancePane({ appearance, effectiveMode, onAppearanceChange }
                 role="radio"
                 aria-checked={selected}
                 tabIndex={selected ? 0 : -1}
+                data-radio-id={m.id}
                 onClick={() => handleModeSelect(m.id)}
                 onKeyDown={modeKeyHandler as React.KeyboardEventHandler<HTMLButtonElement>}
                 className={[
@@ -238,7 +244,9 @@ export function AppearancePane({ appearance, effectiveMode, onAppearanceChange }
             Using{' '}
             <span className="text-foreground">{currentTheme.name}</span>
             <span className="text-muted-foreground"> · </span>
-            <span className="text-foreground">{effectiveMode}</span>
+            <span className="text-foreground">
+              {mode === 'system' ? `System · ${effectiveMode}` : effectiveMode}
+            </span>
             <span className="text-muted-foreground"> · </span>
             <span className="text-foreground">{currentIcon.name}</span>
           </span>

--- a/src/renderer/components/settings/IconCell.tsx
+++ b/src/renderer/components/settings/IconCell.tsx
@@ -28,13 +28,13 @@ export const IconCell = forwardRef<HTMLButtonElement, IconCellProps>(function Ic
       aria-checked={selected}
       aria-label={item.name}
       tabIndex={tabIndex}
+      data-radio-id={item.id}
       onClick={() => onSelect(item.id)}
       onKeyDown={onKeyDown}
       className={[
         'flex flex-col items-center gap-2 p-1 bg-transparent border-none cursor-pointer',
-        'focus:outline-none',
-        'hover:-translate-y-0.5 transition-transform duration-150',
-        selected ? 'translate-y-0' : '',
+        'focus:outline-none transition-transform duration-150',
+        selected ? '' : 'hover:-translate-y-0.5',
       ].join(' ')}
       style={{ fontFamily: '"IBM Plex Mono", monospace' }}
     >

--- a/src/renderer/components/settings/IconCell.tsx
+++ b/src/renderer/components/settings/IconCell.tsx
@@ -1,0 +1,86 @@
+// IconCell.tsx — App icon selection cell for Settings → Appearance.
+// Renders a 78px IconThumb, a label, and DEFAULT/LEGACY badges.
+// Used inside a 6-column ARIA radio group grid in AppearancePane.
+
+import { forwardRef } from 'react'
+import { Check } from 'lucide-react'
+import { IconThumb } from '../../lib/prose-icons'
+import type { ProseIconEntry } from '../../lib/prose-icons'
+import type { IconId } from '../../types'
+
+interface IconCellProps {
+  item: ProseIconEntry
+  selected: boolean
+  onSelect: (id: IconId) => void
+  /** For ARIA radio group — keyboard handler passed from parent */
+  onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>
+  tabIndex?: number
+}
+
+export const IconCell = forwardRef<HTMLButtonElement, IconCellProps>(function IconCell(
+  { item, selected, onSelect, onKeyDown, tabIndex = -1 },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      role="radio"
+      aria-checked={selected}
+      aria-label={item.name}
+      tabIndex={tabIndex}
+      onClick={() => onSelect(item.id)}
+      onKeyDown={onKeyDown}
+      className={[
+        'flex flex-col items-center gap-2 p-1 bg-transparent border-none cursor-pointer',
+        'focus:outline-none',
+        'hover:-translate-y-0.5 transition-transform duration-150',
+        selected ? 'translate-y-0' : '',
+      ].join(' ')}
+      style={{ fontFamily: '"IBM Plex Mono", monospace' }}
+    >
+      {/* Icon with selection ring */}
+      <div
+        className="relative p-[5px] rounded-[22px] transition-all duration-150"
+        style={{
+          background: selected ? 'hsl(var(--primary) / 0.12)' : 'transparent',
+          boxShadow: selected ? '0 0 0 2px hsl(var(--primary))' : 'none',
+        }}
+      >
+        <IconThumb Component={item.Component} size={78} />
+
+        {/* Selection check badge */}
+        {selected && (
+          <div
+            className="absolute -top-1.5 -right-1.5 w-[19px] h-[19px] rounded-full flex items-center justify-center"
+            style={{
+              background: 'hsl(var(--primary))',
+              boxShadow: '0 0 0 3px hsl(var(--background))',
+            }}
+          >
+            <Check className="w-3 h-3" style={{ color: 'hsl(var(--primary-foreground))', strokeWidth: 3 }} />
+          </div>
+        )}
+      </div>
+
+      {/* Label + badges */}
+      <div className="text-center">
+        <div
+          className="text-[10.5px] font-normal tracking-tight leading-tight"
+          style={{ color: selected ? 'hsl(var(--foreground))' : 'hsl(var(--muted-foreground))' }}
+        >
+          {item.name}
+        </div>
+        {item.official && (
+          <div className="text-[8.5px] tracking-[0.16em] uppercase font-medium mt-0.5" style={{ color: 'hsl(var(--primary))' }}>
+            DEFAULT
+          </div>
+        )}
+        {item.legacy && (
+          <div className="text-[8.5px] tracking-[0.16em] uppercase font-medium mt-0.5 text-muted-foreground">
+            LEGACY
+          </div>
+        )}
+      </div>
+    </button>
+  )
+})

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -21,6 +21,7 @@ import { Button } from '../ui/button'
 import { Separator } from '../ui/separator'
 import { Slider } from '../ui/slider'
 import { Switch } from '../ui/switch'
+import { AppearancePane } from './AppearancePane'
 import { RemarkableIntegration } from './RemarkableIntegration'
 import { GoogleDocsIntegration } from './GoogleDocsIntegration'
 import { McpIntegration } from './McpIntegration'
@@ -59,8 +60,10 @@ export function SettingsDialog() {
     settings,
     isDialogOpen,
     dialogTab,
+    effectiveTheme,
     setDialogOpen,
     setDialogTab,
+    setAppearance,
     setLLMConfig,
     setEditorConfig,
     setRecoveryConfig,
@@ -102,6 +105,7 @@ export function SettingsDialog() {
 
   // Refs for scrollable tab content
   const generalTabRef = useRef<HTMLDivElement>(null)
+  const appearanceTabRef = useRef<HTMLDivElement>(null)
   const editorTabRef = useRef<HTMLDivElement>(null)
   const llmTabRef = useRef<HTMLDivElement>(null)
   const integrationsTabRef = useRef<HTMLDivElement>(null)
@@ -182,6 +186,7 @@ export function SettingsDialog() {
     // ensures it starts at the top when the user returns to it.
     const tabRefs: Record<string, React.RefObject<HTMLDivElement>> = {
       general: generalTabRef,
+      appearance: appearanceTabRef,
       editor: editorTabRef,
       llm: llmTabRef,
       integrations: integrationsTabRef,
@@ -244,8 +249,9 @@ export function SettingsDialog() {
         </DialogHeader>
 
         <Tabs value={dialogTab} onValueChange={handleTabChange} className="mt-4 flex-1 min-h-0 flex flex-col">
-          <TabsList className="grid w-full grid-cols-5 flex-shrink-0">
+          <TabsList className="grid w-full grid-cols-6 flex-shrink-0">
             <TabsTrigger value="general">General</TabsTrigger>
+            <TabsTrigger value="appearance">Appearance</TabsTrigger>
             <TabsTrigger value="editor">Editor</TabsTrigger>
             <TabsTrigger value="llm">LLM</TabsTrigger>
             <TabsTrigger value="integrations">Integrations</TabsTrigger>
@@ -394,6 +400,14 @@ export function SettingsDialog() {
                 }}
               />
             </div>
+          </TabsContent>
+
+          <TabsContent value="appearance" className="mt-4 overflow-y-auto flex-1 min-h-0 flex flex-col px-0 mx-0" ref={appearanceTabRef}>
+            <AppearancePane
+              appearance={settings.appearance}
+              effectiveMode={effectiveTheme}
+              onAppearanceChange={setAppearance}
+            />
           </TabsContent>
 
           <TabsContent value="editor" className="space-y-6 mt-4 overflow-y-auto flex-1 px-1 -mx-1" ref={editorTabRef}>

--- a/src/renderer/components/settings/ThemeCard.tsx
+++ b/src/renderer/components/settings/ThemeCard.tsx
@@ -1,0 +1,121 @@
+// ThemeCard.tsx — Color theme selection card for Settings → Appearance.
+// The nested theme-scoped wrapper applies `theme-{id}` + effective `dark` class
+// so the preview tile renders in ITS OWN theme even when the surrounding pane
+// uses a different theme.
+
+import { forwardRef } from 'react'
+import { Check } from 'lucide-react'
+import type { ColorTheme } from '../../types'
+
+export interface ThemeCardEntry {
+  id: ColorTheme
+  name: string
+  subtitle: string
+  tag: string
+  official?: boolean
+}
+
+export const THEMES: ThemeCardEntry[] = [
+  { id: 'mono',  name: 'Mono',  subtitle: 'shadcn neutral',  tag: 'LEGACY 1.0' },
+  { id: 'prose', name: 'Prose', subtitle: 'paper + gold',    tag: 'DEFAULT', official: true },
+  { id: 'termy', name: 'Termy', subtitle: 'phosphor green',  tag: 'DEEP CUT' },
+]
+
+export const DEFAULT_COLOR: ColorTheme = 'prose'
+
+interface ThemeCardProps {
+  theme: ThemeCardEntry
+  selected: boolean
+  /** Effective mode ('light' | 'dark') used for the nested preview tile. */
+  effectiveMode: 'light' | 'dark'
+  onSelect: (id: ColorTheme) => void
+  /** For ARIA radio group — keyboard handler passed from parent */
+  onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>
+  tabIndex?: number
+}
+
+export const ThemeCard = forwardRef<HTMLButtonElement, ThemeCardProps>(function ThemeCard(
+  { theme, selected, effectiveMode, onSelect, onKeyDown, tabIndex = -1 },
+  ref
+) {
+  // Build the class list for the nested preview wrapper.
+  // Mono has no dedicated class — :root defaults apply naturally.
+  const previewClasses: string[] = []
+  if (theme.id === 'prose') previewClasses.push('theme-prose')
+  if (theme.id === 'termy') previewClasses.push('theme-termy')
+  if (effectiveMode === 'dark') previewClasses.push('dark')
+
+  return (
+    <button
+      ref={ref}
+      role="radio"
+      aria-checked={selected}
+      tabIndex={tabIndex}
+      onClick={() => onSelect(theme.id)}
+      onKeyDown={onKeyDown}
+      className={[
+        'relative text-left rounded-[10px] p-3 cursor-pointer transition-all duration-150',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+        selected
+          ? 'bg-accent/10 border border-primary shadow-sm'
+          : 'bg-transparent border border-border hover:-translate-y-0.5',
+      ].join(' ')}
+      style={{ fontFamily: '"IBM Plex Mono", monospace' }}
+    >
+      {/* Nested theme-scoped preview tile */}
+      <div
+        className={previewClasses.join(' ')}
+        style={{
+          height: 78,
+          background: 'var(--background)',
+          borderRadius: 6,
+          border: '1px solid hsl(var(--border))',
+          padding: '10px 12px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 6,
+          overflow: 'hidden',
+        }}
+      >
+        {/* Mini titlebar traffic lights */}
+        <div style={{ display: 'flex', gap: 3, marginBottom: 2 }}>
+          <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#ff5f57', opacity: 0.7 }} />
+          <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#febc2e', opacity: 0.7 }} />
+          <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#28c840', opacity: 0.7 }} />
+        </div>
+        <div style={{ height: 5, width: '80%', background: 'hsl(var(--foreground))', borderRadius: 1, opacity: 0.85 }} />
+        <div style={{ height: 4, width: '60%', background: 'hsl(var(--muted-foreground))', borderRadius: 1 }} />
+        <div style={{ display: 'flex', gap: 5, alignItems: 'center', marginTop: 'auto' }}>
+          <div style={{ width: 6, height: 6, borderRadius: '50%', background: 'hsl(var(--primary))' }} />
+          <div style={{ height: 3, width: 28, background: 'hsl(var(--muted-foreground))', borderRadius: 1 }} />
+          <div style={{ height: 3, width: 16, background: 'hsl(var(--muted-foreground))', borderRadius: 1, opacity: 0.5 }} />
+        </div>
+      </div>
+
+      {/* Label row */}
+      <div className="mt-2.5 flex items-baseline gap-2">
+        <span className="text-[13px] font-normal text-foreground tracking-tight">{theme.name}</span>
+        <span className="text-[10.5px] text-muted-foreground">{theme.subtitle}</span>
+      </div>
+
+      {theme.tag && (
+        <div
+          className="mt-1 text-[8.5px] tracking-[0.16em] uppercase font-medium"
+          style={{ color: theme.official ? 'hsl(var(--primary))' : 'hsl(var(--muted-foreground))' }}
+        >
+          {theme.tag}
+        </div>
+      )}
+
+      {/* Selection check dot */}
+      {selected && (
+        <div
+          className="absolute top-2.5 right-2.5 w-[18px] h-[18px] rounded-full flex items-center justify-center"
+          style={{ background: 'hsl(var(--primary))', boxShadow: '0 0 0 2px hsl(var(--background))' }}
+        >
+          <Check className="w-3 h-3" style={{ color: 'hsl(var(--primary-foreground))', strokeWidth: 3 }} />
+        </div>
+      )}
+    </button>
+  )
+})

--- a/src/renderer/components/settings/ThemeCard.tsx
+++ b/src/renderer/components/settings/ThemeCard.tsx
@@ -51,6 +51,7 @@ export const ThemeCard = forwardRef<HTMLButtonElement, ThemeCardProps>(function 
       role="radio"
       aria-checked={selected}
       tabIndex={tabIndex}
+      data-radio-id={theme.id}
       onClick={() => onSelect(theme.id)}
       onKeyDown={onKeyDown}
       className={[

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -8,7 +8,7 @@ import type { ToolMode } from '../../shared/tools/types'
 
 const MAX_RECENT_FILES = 15
 
-type SettingsTab = 'general' | 'editor' | 'llm' | 'integrations' | 'account'
+type SettingsTab = 'general' | 'appearance' | 'editor' | 'llm' | 'integrations' | 'account'
 
 export const AI_CONSENT_VERSION = 1
 


### PR DESCRIPTION
## Summary

- Adds `Settings → Appearance` pane with three sections: **Mode** (Light/Dark/System segmented control), **Color** (3 ThemeCards — mono/prose/termy — each with a self-themed preview tile), **App Icon** (6-column grid of 11 IconCells)
- All three sections implement ARIA `role="radiogroup"` with arrow-key navigation (←→↑↓), Tab between sections, and Space/Enter to select
- Mode button shows `System · dark` inline when System is selected and effectiveMode is dark
- Each ThemeCard preview tile renders in its own theme via a nested `theme-{id}` + `dark` class wrapper, regardless of the surrounding pane's theme
- "Reset all to default" button disables itself when already at defaults (`prose · dark · pilcrow`)

## Files changed

| File | Change |
|---|---|
| `src/renderer/components/settings/AppearancePane.tsx` | New — main pane component |
| `src/renderer/components/settings/ThemeCard.tsx` | New — forwardRef card with nested theme scope |
| `src/renderer/components/settings/IconCell.tsx` | New — forwardRef 78px icon cell + badges |
| `src/renderer/components/settings/SettingsDialog.tsx` | Add Appearance tab; `grid-cols-5` → `grid-cols-6`; `appearanceTabRef` |
| `src/renderer/stores/settingsStore.ts` | `SettingsTab` union: add `'appearance'` |
| `src/renderer/components/layout/App.tsx` | Add `data-color` + `termy-scanline-scope` hook on outermost wrapper |

## ARIA / keyboard decisions

- **Roving tabindex**: each group exposes exactly one `tabIndex=0` (the selected item); all others are `tabIndex=-1`. Tab moves focus between the three groups naturally.
- **Arrow keys**: `makeRadioKeyHandler` wraps around (modulo). Left/Up go back; Right/Down go forward. This matches the WAI-ARIA radio group pattern.
- **Selection + focus**: `handleXxxSelect` calls `onAppearanceChange` then moves focus to the newly-selected button via `requestAnimationFrame` (waits for React re-render before focusing).
- **forwardRef**: ThemeCard and IconCell expose their button refs so the parent can focus them after arrow-key selection.

## Test plan

- [ ] Open Settings → confirm "Appearance" tab appears between General and Editor
- [ ] Click Appearance tab → see Mode / Color / App Icon sections
- [ ] Mode: click Light/Dark/System — confirm selection highlighted; System shows `· dark/light` suffix
- [ ] Color: click each card — preview tile reflects that card's own theme (not the pane's theme)
- [ ] Icons: click each icon cell — selection ring + check badge appear; DEFAULT on Pilcrow, LEGACY on Legacy
- [ ] Keyboard: Tab into Mode group, arrow keys cycle; Tab to Color, arrow keys cycle; Tab to Icons, arrow keys cycle
- [ ] "Reset all to default" button disabled at defaults, enabled after any change
- [ ] Selection persists across dialog close/reopen (via `setAppearance` → `saveSettings`)

## Notes for reviewers

Targets `release/v1.4-appearance`; cloud review may check against `main` and false-positive on foundation types (`Appearance`, `IconId`, `effectiveTheme`, theme tokens) / `prose-icons.tsx` that exist only on the umbrella branch — please review against the umbrella base.

Closes #504. Refs #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)