### PR TITLE
fix(appearance): align 'Reset to default' with mono/system defaults (#499)

### DIFF
--- a/src/renderer/components/settings/AppearancePane.tsx
+++ b/src/renderer/components/settings/AppearancePane.tsx
@@ -19,7 +19,9 @@ const MODES: { id: ThemeMode; label: string; Icon: typeof Sun }[] = [
   { id: 'system', label: 'System', Icon: Monitor },
 ]
 
-const DEFAULT_MODE: ThemeMode = 'dark'
+// Must match FRESH_INSTALL_APPEARANCE in settingsStore (mono / system / pilcrow)
+// so "Reset all to default" and the at-defaults check agree with fresh installs.
+const DEFAULT_MODE: ThemeMode = 'system'
 const DEFAULT_ICON: IconId = 'pilcrow'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/renderer/components/settings/ThemeCard.tsx
+++ b/src/renderer/components/settings/ThemeCard.tsx
@@ -21,7 +21,7 @@ export const THEMES: ThemeCardEntry[] = [
   { id: 'termy', name: 'Termy', subtitle: 'phosphor green',  tag: 'DEEP CUT' },
 ]
 
-export const DEFAULT_COLOR: ColorTheme = 'prose'
+export const DEFAULT_COLOR: ColorTheme = 'mono'
 
 interface ThemeCardProps {
   theme: ThemeCardEntry


### PR DESCRIPTION
Follow-up from the rollup review (#587). The Appearance pane's reset/at-defaults constants still read the original `prose`/`dark`, but fresh installs now default to **mono / system / pilcrow** (changed in #585). So "Reset all to default" reset to the wrong values and the at-defaults check (reset-button disabled state) was inconsistent.

- `ThemeCard.tsx` — `DEFAULT_COLOR: 'prose'` → `'mono'`
- `AppearancePane.tsx` — `DEFAULT_MODE: 'dark'` → `'system'` (`DEFAULT_ICON` was already `pilcrow`)

Now matches `FRESH_INSTALL_APPEARANCE` in `settingsStore`.

Targets `release/v1.4-appearance` (folds into rollup #587). Refs #499, #504.