### PR TITLE
fix(appearance): theme-card badges reflect Mono as default (#499)

### DIFF
--- a/src/renderer/components/settings/ThemeCard.tsx
+++ b/src/renderer/components/settings/ThemeCard.tsx
@@ -16,8 +16,8 @@ export interface ThemeCardEntry {
 }
 
 export const THEMES: ThemeCardEntry[] = [
-  { id: 'mono',  name: 'Mono',  subtitle: 'shadcn neutral',  tag: 'LEGACY 1.0' },
-  { id: 'prose', name: 'Prose', subtitle: 'paper + gold',    tag: 'DEFAULT', official: true },
+  { id: 'mono',  name: 'Mono',  subtitle: 'shadcn neutral',  tag: 'DEFAULT' },
+  { id: 'prose', name: 'Prose', subtitle: 'paper + gold',    tag: 'NEW', official: true },
   { id: 'termy', name: 'Termy', subtitle: 'phosphor green',  tag: 'DEEP CUT' },
 ]
 


### PR DESCRIPTION
Follow-up to the defaults change: Mono is now the fresh-install default, so the color-card badges were stale (Prose still tagged 'DEFAULT'). Now: Mono='DEFAULT', Prose='NEW', Termy unchanged. Cosmetic copy only. Folds into rollup #587. Refs #499, #504.