### PR TITLE
fix(updater): apply staged updates on quit (#577)

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -92,10 +92,17 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
 
     let updateDownloaded = false
     let installInvoked = false
+    // Set if quitAndInstall() throws before it can quit/relaunch. Gates the
+    // before-quit auto-apply so a persistently failing install can't trap the
+    // user in a can't-quit loop — the staged update simply retries on next
+    // launch instead.
+    let installFailed = false
 
     // Single guarded entry point for applying a staged update. Both the explicit
     // install button (updater:install) and the auto-install-on-quit path funnel
     // through here so the macOS quit/relaunch hardening is applied uniformly.
+    // Returns true once quitAndInstall has been handed off, false if it could
+    // not start (no update, re-entrant call, or a thrown failure).
     const installUpdate = (): boolean => {
       if (!updateDownloaded) return false
       // Re-entrancy guard: a second QuitAndInstall double-registers an observer
@@ -114,8 +121,19 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
       // but no relaunch.
       markQuitting()
       logger.info('Applying staged update via quitAndInstall')
-      autoUpdater.quitAndInstall()
-      return true
+      try {
+        autoUpdater.quitAndInstall()
+        return true
+      } catch (err) {
+        // quitAndInstall threw before it could quit/relaunch. Re-arm so an
+        // explicit "Restart" can retry this session, and flag the failure so the
+        // before-quit handler stops intercepting (the user must still be able to
+        // quit). The staged update stays in pending/ and retries on next launch.
+        installInvoked = false
+        installFailed = true
+        logger.error('quitAndInstall failed:', err instanceof Error ? err.message : String(err))
+        return false
+      }
     }
 
     autoUpdater.on('update-available', (info) => {
@@ -161,9 +179,13 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
     // quitAndInstall can drive a clean quit+relaunch itself rather than racing a
     // half-finished termination.
     app.on('before-quit', (event) => {
-      if (!updateDownloaded || installInvoked) return
+      if (!updateDownloaded || installInvoked || installFailed) return
       event.preventDefault()
-      installUpdate()
+      // If quitAndInstall can't even start, honor the user's quit so they're
+      // never left unable to exit; the update retries on next launch.
+      if (!installUpdate()) {
+        app.quit()
+      }
     })
 
     // IPC handlers

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,7 +1,58 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { app, BrowserWindow, ipcMain } from 'electron'
 import { is } from '@electron-toolkit/utils'
+import { mkdirSync } from 'node:fs'
+import { appendFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import { IS_MAS_BUILD } from './env'
 import { markQuitting } from './quitState'
+
+// Persistent updater logger. electron-updater accepts any object with
+// info/warn/error/debug methods. We mirror to the console (visible in dev /
+// terminal) AND append to a file under the OS logs dir, because previously
+// updater output went to the console only and was lost on packaged builds —
+// making field failures like "downloaded but never applied" undiagnosable.
+function createUpdaterLogger(): {
+  info: (...a: unknown[]) => void
+  warn: (...a: unknown[]) => void
+  error: (...a: unknown[]) => void
+  debug: (...a: unknown[]) => void
+} {
+  let logPath: string | null = null
+  try {
+    logPath = join(app.getPath('logs'), 'updater.log')
+    mkdirSync(dirname(logPath), { recursive: true })
+  } catch {
+    // No writable logs dir — fall back to console-only logging.
+    logPath = null
+  }
+
+  const write = (level: string, args: unknown[]): void => {
+    if (!logPath) return
+    const msg = args
+      .map((a) => (a instanceof Error ? a.stack ?? a.message : typeof a === 'string' ? a : JSON.stringify(a)))
+      .join(' ')
+    // Fire-and-forget; logging must never crash or block the updater.
+    void appendFile(logPath, `${new Date().toISOString()} [${level}] ${msg}\n`).catch(() => {})
+  }
+
+  return {
+    info: (...args) => {
+      console.log('[Updater]', ...args)
+      write('info', args)
+    },
+    warn: (...args) => {
+      console.warn('[Updater]', ...args)
+      write('warn', args)
+    },
+    error: (...args) => {
+      console.error('[Updater]', ...args)
+      write('error', args)
+    },
+    debug: (...args) => {
+      write('debug', args)
+    }
+  }
+}
 
 export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> {
   if (IS_MAS_BUILD) {
@@ -24,15 +75,51 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
       throw new Error('electron-updater: autoUpdater export not found')
     }
 
+    const logger = createUpdaterLogger()
+    autoUpdater.logger = logger
+
     autoUpdater.autoDownload = false
-    autoUpdater.autoInstallOnAppQuit = true
+    // We apply staged updates ourselves (see the before-quit handler below) so
+    // that both the explicit "Restart" button and the install-on-quit path run
+    // through the SAME guarded `installUpdate()`. electron-updater's built-in
+    // autoInstallOnAppQuit fires from the `quit` event — too late on macOS,
+    // where the app is already terminating so Squirrel never stages the
+    // relaunch — and it bypasses both the markQuitting() hide-on-close guard
+    // and the re-entrancy guard. Disabling it makes our before-quit handler the
+    // single source of truth.
+    autoUpdater.autoInstallOnAppQuit = false
     autoUpdater.allowPrerelease = false
 
     let updateDownloaded = false
     let installInvoked = false
 
+    // Single guarded entry point for applying a staged update. Both the explicit
+    // install button (updater:install) and the auto-install-on-quit path funnel
+    // through here so the macOS quit/relaunch hardening is applied uniformly.
+    const installUpdate = (): boolean => {
+      if (!updateDownloaded) return false
+      // Re-entrancy guard: a second QuitAndInstall double-registers an observer
+      // in Electron's native auto-updater and trips a NOTREACHED
+      // (electron_api_auto_updater.cc:118), which bails out before the actual
+      // quit/relaunch — see Sentry PROSE-H.
+      if (installInvoked) {
+        logger.warn('install ignored — already invoked')
+        return false
+      }
+      installInvoked = true
+      // electron-updater calls Electron's native autoUpdater.quitAndInstall(),
+      // which closes all windows BEFORE firing `before-quit`. Our macOS
+      // hide-on-close handler would otherwise swallow the close and leave the
+      // app running in the background, with the user seeing the window vanish
+      // but no relaunch.
+      markQuitting()
+      logger.info('Applying staged update via quitAndInstall')
+      autoUpdater.quitAndInstall()
+      return true
+    }
+
     autoUpdater.on('update-available', (info) => {
-      console.log('[Updater] Update available:', info.version)
+      logger.info('Update available:', info.version)
       if (!mainWindow.isDestroyed()) {
         mainWindow.webContents.send('updater:update-available', {
           version: info.version,
@@ -54,7 +141,7 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
 
     autoUpdater.on('update-downloaded', (info) => {
       updateDownloaded = true
-      console.log('[Updater] Update downloaded:', info.version)
+      logger.info('Update downloaded:', info.version)
       if (!mainWindow.isDestroyed()) {
         mainWindow.webContents.send('updater:update-downloaded', {
           version: info.version
@@ -63,7 +150,20 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
     })
 
     autoUpdater.on('error', (error) => {
-      console.error('[Updater] Error:', error.message)
+      logger.error('Error:', error.message)
+    })
+
+    // Apply a staged update when the user quits normally (Cmd+Q, menu Quit, dock
+    // Quit, logout/shutdown). With autoInstallOnAppQuit disabled, this is what
+    // applies the update in prose-updater/pending/ — otherwise the user would
+    // relaunch on the old version. We run on `before-quit` (not `quit`) so we're
+    // early enough for Squirrel.Mac to stage the relaunch, and preventDefault so
+    // quitAndInstall can drive a clean quit+relaunch itself rather than racing a
+    // half-finished termination.
+    app.on('before-quit', (event) => {
+      if (!updateDownloaded || installInvoked) return
+      event.preventDefault()
+      installUpdate()
     })
 
     // IPC handlers
@@ -73,33 +173,17 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
     })
 
     ipcMain.handle('updater:install', () => {
-      if (!updateDownloaded) return
-      // Re-entrancy guard: a second QuitAndInstall call double-registers an
-      // observer in Electron's native auto-updater and trips a NOTREACHED
-      // (electron_api_auto_updater.cc:118), which bails out before the actual
-      // quit/relaunch — see Sentry PROSE-H.
-      if (installInvoked) {
-        console.warn('[Updater] install ignored — already invoked')
-        return
-      }
-      installInvoked = true
-      // electron-updater calls Electron's native autoUpdater.quitAndInstall(),
-      // which closes all windows BEFORE firing `before-quit`. Our macOS
-      // hide-on-close handler would otherwise swallow the close and leave the
-      // app running in the background, with the user seeing the window vanish
-      // but no relaunch.
-      markQuitting()
-      autoUpdater.quitAndInstall()
+      installUpdate()
     })
 
     ipcMain.handle('updater:check', async () => {
       try {
         const result = await autoUpdater.checkForUpdates()
-        console.log('[Updater] Check result:', JSON.stringify(result?.updateInfo))
+        logger.info('Check result:', JSON.stringify(result?.updateInfo))
         return { updateAvailable: !!result?.updateInfo, version: result?.updateInfo?.version }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
-        console.error('[Updater] Check error:', message)
+        logger.error('Check error:', message)
         return { updateAvailable: false, error: message }
       }
     })
@@ -107,7 +191,7 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
     // Initial check after a short delay (don't slow startup)
     setTimeout(() => {
       autoUpdater.checkForUpdates().catch((err) => {
-        console.warn('[Updater] Initial check failed:', err.message)
+        logger.warn('Initial check failed:', err.message)
       })
     }, 10_000)
 
@@ -115,7 +199,7 @@ export async function initAutoUpdater(mainWindow: BrowserWindow): Promise<void> 
     setInterval(
       () => {
         autoUpdater.checkForUpdates().catch((err) => {
-          console.warn('[Updater] Periodic check failed:', err.message)
+          logger.warn('Periodic check failed:', err.message)
         })
       },
       4 * 60 * 60 * 1000


### PR DESCRIPTION
## Summary

Fixes the macOS auto-update bug where a new version **downloads and stages but never applies on restart** — the app relaunches on the old version with the staged update left in `~/Library/Caches/prose-updater/pending/`.

Closes #577

## Root cause

`autoInstallOnAppQuit = true` made electron-updater apply the staged update from the **`quit` event**. On macOS that's too late — the app is already terminating, so Squirrel.Mac never stages the relaunch. That path also bypassed both guards that only the explicit `updater:install` handler had:

- `markQuitting()` — without it, the macOS hide-on-close handler swallows the window close (app hides instead of quitting+relaunching).
- `installInvoked` re-entrancy guard — a second `quitAndInstall` trips a native `NOTREACHED` (`electron_api_auto_updater.cc:118`) that bails before quit/relaunch (Sentry PROSE-H).

So the two install paths (auto-on-quit vs. explicit button) were not protected equally, and the auto path fired at the wrong moment.

## Changes (`src/main/updater.ts`)

- **Disable `autoInstallOnAppQuit`** and apply staged updates ourselves.
- **Single guarded `installUpdate()`** — both the "Restart" button (`updater:install`) and the auto-on-quit path funnel through it, so `markQuitting()` + the re-entrancy guard apply uniformly.
- **Trigger auto-install from `before-quit`** (not `quit`) with `event.preventDefault()`, so `quitAndInstall` drives a clean quit+relaunch early enough for Squirrel — rather than racing a half-finished termination.
- **Persistent updater log** — wire `autoUpdater.logger` to a file under the OS logs dir (`~/Library/Logs/Prose/updater.log`), since updater output previously went to console only and was lost on packaged builds (investigation lead #4). Logging is fire-and-forget and degrades to console-only if the dir isn't writable.

## Verification

This is **dev-disabled** (`if (is.dev) return`) and only exercisable in a packaged build against a published newer release, so it can't be verified via the dev server / HMR:

- ✅ `npm run build` compiles cleanly (electron-vite main + preload + renderer).
- ✅ No new TypeScript errors in `updater.ts`.
- ⏳ **End-to-end (requires release pipeline):** install an older signed build in `/Applications`, publish a newer release, let it download, then **Cmd+Q** (or click "Restart"). Expected: relaunches on the new version; `prose-updater/pending/` is consumed. Check `~/Library/Logs/Prose/updater.log` for `Applying staged update via quitAndInstall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)