### PR TITLE
fix(settings): loadSettings ReferenceError — persisted toolMode never restored (#592)

### DIFF
--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -238,7 +238,7 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
       // Hydrate chatStore toolMode from persisted settings (global, applies to all tabs).
       // Import lazily to avoid a static top-level import that could cause sandbox issues.
       // The persisted value takes priority; fall back to the store's in-memory default.
-      const persistedToolMode = settings.toolMode ?? defaultSettings.toolMode ?? 'editor'
+      const persistedToolMode = migrated.toolMode ?? defaultSettings.toolMode ?? 'editor'
       const { useChatStore } = await import('./chatStore')
       useChatStore.getState().setToolMode(persistedToolMode)
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug where `settingsStore.loadSettings()` throws on every launch and the user's persisted `toolMode` never restores. Closes #592.

## Root cause

`src/renderer/stores/settingsStore.ts:241` referenced a bare `settings` identifier that doesn't exist in `loadSettings`'s scope:

```ts
const persistedToolMode = settings.toolMode ?? defaultSettings.toolMode ?? 'editor'
```

This throws `ReferenceError: settings is not defined`. Because it sits inside the `try`, the throw aborts the rest of `loadSettings` — toolMode hydration (242–243), Sentry init (246), and the launch-time model refresh (249) — and lands in the `catch` (`console.error('Failed to load settings:', …)`). The `set({ settings })` at line 214 runs *before* the throw, so appearance/settings still load; only the post-214 steps are lost. **User-visible effect: the persisted `toolMode` (Chat/Editor/Create) never restores — the app always starts in `editor`.**

## Fix

One line: `settings.toolMode` → `migrated.toolMode`. `migrated` (`= migrateOnDiskSettings(raw)`, line 211) is the persisted on-disk settings already in scope, which is exactly what the surrounding comment intends to hydrate. The `?? defaultSettings.toolMode ?? 'editor'` fallback is unchanged.

## Verification

- `npm run build` — clean.
- Playwright `_electron` launch of the built app (exited 0): the `Failed to load settings` console error is **gone** (it was logged 8× on the unfixed code), `settingsErrorCount: 0`, editor mounts normally, no other console errors.

## Context

Found during QA for #591 (legacy diff-suggestions removal); pre-existing on `main` and independent of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
