### PR TITLE
docs(agents): route planning to docs/roadmap.md + guard against stale worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,12 @@ Key areas:
 - `src/renderer/` - React app, TipTap editor, Zustand stores, UI components.
 - `src/shared/` - Shared schemas, tools, LLM utilities, and cross-process types.
 - `src/mcp-stdio/` - Stdio MCP server used by Claude Desktop.
-- `docs/` - Architecture notes, patterns, issue plans, troubleshooting, and release docs.
+- `docs/` - Architecture notes, patterns, issue plans, troubleshooting, release docs, and `docs/roadmap.md` (the canonical roadmap + operating model).
 - `.claude/` - Claude Code settings, hooks, and skills. Do not treat these as Codex configuration.
+
+## Roadmap & Planning
+
+Before any planning, prioritization, sequencing, or parallelization work — including "what to work on next," scoping a wave or epic, or splitting work across agents — read [`docs/roadmap.md`](docs/roadmap.md) first. It is the canonical, resumable source for what is being built, in what order (the wave model), and how work is parallelized (three concurrent Wave 1 tracks on an A→B→C merge ladder). The strategy already exists there; build on it rather than reinventing it. Project board #5 is the live queue; the roadmap is the narrative and operating model. It changes frequently, so read the current version — if your branch may be behind `main`, run `git fetch origin` and read `git show origin/main:docs/roadmap.md` rather than a possibly-stale worktree copy. Branch new worktrees off freshly-fetched `origin/main`.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,16 @@ OpenAI Codex and other non-Claude agents use `AGENTS.md` as their repository ent
 Claude agents should also read `AGENTS.md` for shared cross-agent coordination rules, then use
 this file for Claude-specific workflows, skills, and deeper project context.
 
+## Roadmap & Planning — read `docs/roadmap.md` first
+
+**Before any planning, prioritization, sequencing, or parallelization work** — including "what should we work on / what's next," scoping a wave or epic, or proposing how to split work across agents — **read [`docs/roadmap.md`](docs/roadmap.md) first.** It is the canonical, resumable source of truth for *what* we're building, *in what order* (the wave model), and *how the work is parallelized* (the three concurrent Wave 1 tracks and the **A→B→C merge ladder**). The sequencing and parallelization strategy already lives there — build on it, don't reinvent it. The [project board (#5)](https://github.com/orgs/solo-ist/projects/5/views/1) is the live queue; the roadmap is the narrative + operating model (column = phase, milestone = wave). It changes frequently, so **read the current version**: if your branch may be behind `main`, run `git fetch origin` and read `git show origin/main:docs/roadmap.md` (or sync first) — a stale worktree can show an outdated or even retired roadmap.
+
 ## Development Environment
 
 This project uses an **agentic, multi-agent development workflow**:
 
 - **Multiple Claude Code agents** may run simultaneously on the same machine — across terminal sessions, git worktrees, different branches, or different repos. Never assume you're the only agent running.
-- **Prefer Agent Teams and git worktrees** for parallelizing independent work. Use `isolation: "worktree"` when spawning agents that need to make changes without conflicting with the main working tree. This avoids branch conflicts and lets multiple agents write code simultaneously.
+- **Prefer Agent Teams and git worktrees** for parallelizing independent work. Use `isolation: "worktree"` when spawning agents that need to make changes without conflicting with the main working tree. This avoids branch conflicts and lets multiple agents write code simultaneously. **Branch new worktrees off freshly-fetched `origin/main`** (`git fetch origin` first) — a worktree cut from a stale base shows outdated docs, including an old `roadmap.md`.
 - **Worktree git commands**: Always use `git -C <worktree-path> <subcommand>` instead of `cd <path> && git <subcommand>`. Single commands match the `Bash(git:*)` allowlist; compound `cd && git` chains get flagged for manual approval, which blocks unattended agents.
 - **Cloud agents** (via GitHub Actions) handle PR reviews, automated fixes, and pipeline triage. Local agents handle implementation, QA, and complex features.
 - **The CI pipeline is self-enhancing** — automated review (`claude.yml`), scoring (`pipeline-triage.yml`), and auto-fix (`ci-gate.yml`) run on every PR. Skills and workflows evolve alongside the codebase.
@@ -37,9 +41,10 @@ npm run build:linux  # Build Linux distributable
 
 Before writing any code, complete this checklist:
 
-1. **Branch**: Create or switch to issue branch: `git checkout -b issue-<number>-<description>`
-2. **Docs**: For complex issues, create `docs/issues/<number>/plan.md`
-3. **Verify**: Run `git branch --show-current` to confirm you're not on `main`
+1. **Roadmap**: Read [`docs/roadmap.md`](docs/roadmap.md) — confirm where the issue sits (wave / track) and how it sequences against other work. (Mandatory for any planning/sequencing/parallelization task.)
+2. **Branch**: Create or switch to issue branch: `git checkout -b issue-<number>-<description>`
+3. **Docs**: For complex issues, create `docs/issues/<number>/plan.md`
+4. **Verify**: Run `git branch --show-current` to confirm you're not on `main`
 
 ## Before Presenting Work for Review
 


### PR DESCRIPTION
## Why
A planning agent in another session was asked for a Wave 0 parallelization plan and **never found `docs/roadmap.md`** — it explored the code and reinvented the parallelization model that already exists in the roadmap. Compounding it, that agent's worktree was **52 commits behind `main`**, so even when it reached `roadmap.md` it read the *retired stub*, not the handoff doc.

Two failure modes: **discoverability** (nothing routed it there) and **staleness** (stale worktree → stale roadmap).

## Fix
**`CLAUDE.md`** (auto-loaded by every Claude agent):
- New prominent **"Roadmap & Planning — read `docs/roadmap.md` first"** section as the first `##`, keyword-rich for planning / sequencing / parallelization / prioritization / "what's next."
- Added as **step 1 of the Before Implementation checklist**.
- Worktree bullet now says to **branch off freshly-fetched `origin/main`** (a stale base shows an old `roadmap.md`).
- Roadmap pointer warns the doc changes often — read `git show origin/main:docs/roadmap.md` if the branch is behind.

**`AGENTS.md`** (cross-agent entry point; Codex et al.):
- Matching **"Roadmap & Planning"** section + a `docs/roadmap.md` pointer in the Project Snapshot, with the same read-current / fresh-worktree guidance.

No behavior change — instructions only. Closes the gap that let the roadmap get missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)