### PR TITLE
fix(editor): keep comment popover below nav

### DIFF
--- a/src/renderer/components/CommentPopover.tsx
+++ b/src/renderer/components/CommentPopover.tsx
@@ -9,6 +9,9 @@ import type { Editor } from '@tiptap/core'
 import { Trash2, X, Sparkles } from 'lucide-react'
 import { useChat } from '../hooks/useChat'
 
+const NAV_BAR_HEIGHT = 48
+const VIEWPORT_PADDING = 16
+
 interface CommentPopoverProps {
   editor: Editor
 }
@@ -86,15 +89,20 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
     const rect = popoverRef.current.getBoundingClientRect()
     const viewportWidth = window.innerWidth
     const viewportHeight = window.innerHeight
+    const minY = NAV_BAR_HEIGHT + VIEWPORT_PADDING
     const newPosition = { ...popover.position }
-    if (newPosition.x + rect.width / 2 > viewportWidth - 16) {
-      newPosition.x = viewportWidth - rect.width / 2 - 16
+    if (newPosition.x + rect.width / 2 > viewportWidth - VIEWPORT_PADDING) {
+      newPosition.x = viewportWidth - rect.width / 2 - VIEWPORT_PADDING
     }
-    if (newPosition.x - rect.width / 2 < 16) {
-      newPosition.x = rect.width / 2 + 16
+    if (newPosition.x - rect.width / 2 < VIEWPORT_PADDING) {
+      newPosition.x = rect.width / 2 + VIEWPORT_PADDING
     }
-    if (newPosition.y + rect.height > viewportHeight - 16) {
-      newPosition.y = popover.position.y - rect.height - 40
+    if (newPosition.y + rect.height > viewportHeight - VIEWPORT_PADDING) {
+      const aboveY = popover.position.y - rect.height - 40
+      newPosition.y = aboveY >= minY ? aboveY : popover.position.y
+    }
+    if (newPosition.y < minY) {
+      newPosition.y = minY
     }
     if (newPosition.x !== popover.position.x || newPosition.y !== popover.position.y) {
       setAdjustedPosition(newPosition)


### PR DESCRIPTION
## Summary
- keep the comment popover from flipping above the top nav when there is not enough nav-safe space
- reuse the existing viewport padding for horizontal and top clamping

## Verification
- npm run build

Closes #562