### PR TITLE
Fix file watcher refresh gaps

### DIFF
--- a/src/main/fileWatcher.ts
+++ b/src/main/fileWatcher.ts
@@ -6,7 +6,7 @@
  * disposed and a new one is started. File-system events are forwarded to the
  * renderer via IPC push events:
  *
- *   file:watch:event  — { type: 'created' | 'deleted', path: string }
+ *   file:watch:event  — { type: 'created' | 'deleted' | 'changed', path: string }
  *
  * Renames are reported as an unlink + add pair by chokidar (no native rename
  * event), so we don't model them separately. The renderer just reloads on
@@ -15,23 +15,30 @@
 
 import { ipcMain, BrowserWindow } from 'electron'
 import chokidar from 'chokidar'
-import { basename } from 'path'
+import { basename, isAbsolute, relative } from 'path'
 import { validatePath } from './ipc'
 
 export interface FileWatchEvent {
   // chokidar emits 'unlink' + 'add' for renames rather than a 'rename' event,
   // so we don't model 'renamed' explicitly — the renderer just reloads on any
   // event regardless of type.
-  type: 'created' | 'deleted'
+  type: 'created' | 'deleted' | 'changed'
   path: string
 }
 
-// The single active watcher (null when no directory is being watched).
+type ChokidarWatcher = ReturnType<typeof chokidar.watch>
+
+// The single active root watcher (null when no directory is being watched).
 // Single-window assumption: state is global; if Prose ever opens multiple
 // windows with different File Explorer roots, both will share one watcher
 // and broadcast each other's events. Revisit when adding multi-window.
-let activeWatcher: ReturnType<typeof chokidar.watch> | null = null
+let activeWatcher: ChokidarWatcher | null = null
 let watchedDirectory: string | null = null
+
+// Additional shallow watchers for expanded folders beneath watchedDirectory.
+// This keeps work bounded to visible tree state instead of recursively watching
+// the entire root directory.
+const expandedFolderWatchers = new Map<string, ChokidarWatcher>()
 
 /**
  * Serialize lifecycle operations on the watcher. Without this, fire-and-forget
@@ -58,40 +65,11 @@ function sendEvent(event: FileWatchEvent): void {
   }
 }
 
-/**
- * Stop and dispose the current watcher, if any.
- */
-async function stopWatcher(): Promise<void> {
-  if (activeWatcher) {
-    try {
-      await activeWatcher.close()
-    } catch {
-      // Ignore close errors
-    }
-    activeWatcher = null
-    watchedDirectory = null
-    console.log('[FileWatcher] Watcher stopped')
-  }
-}
-
-/**
- * Start watching a new directory. Disposes any existing watcher first.
- * Caller is responsible for path validation; this function takes an already-
- * normalized absolute path (the IPC handler runs validatePath upstream).
- */
-async function startWatcher(normalized: string): Promise<void> {
-  // No-op if we're already watching this exact directory
-  if (watchedDirectory === normalized) return
-
-  await stopWatcher()
-
-  console.log('[FileWatcher] Starting watcher for:', normalized)
-
+function createShallowWatcher(normalized: string): ChokidarWatcher {
   const watcher = chokidar.watch(normalized, {
-    // Watch only the immediate children of the directory, not subdirectories.
-    // The File Explorer uses lazy loading for subdirectories, so we only need
-    // to detect top-level changes to trigger a reload. Watching recursively
-    // would fire excessive events for large trees and is not needed.
+    // Watch only the immediate children of this directory, not subdirectories.
+    // The File Explorer uses lazy loading for subdirectories; expanded folders
+    // get their own shallow watcher when needed.
     depth: 0,
     // Ignore dotfiles — match only the LEAF segment, never an ancestor.
     // A naive `/(^|[/\\])\../` regex would suppress every event when the
@@ -118,6 +96,10 @@ async function startWatcher(normalized: string): Promise<void> {
     sendEvent({ type: 'created', path: dirPath })
   })
 
+  watcher.on('change', (filePath) => {
+    sendEvent({ type: 'changed', path: filePath })
+  })
+
   watcher.on('unlink', (filePath) => {
     sendEvent({ type: 'deleted', path: filePath })
   })
@@ -126,14 +108,96 @@ async function startWatcher(normalized: string): Promise<void> {
     sendEvent({ type: 'deleted', path: dirPath })
   })
 
-  // chokidar fires 'unlink' + 'add' for renames; we map that via the 'add'
-  // event above. No native 'rename' event needed — the renderer just reloads.
+  // chokidar fires 'unlink' + 'add' for renames; we map that via the events
+  // above. No native 'rename' event needed — the renderer just reloads.
 
   watcher.on('error', (error) => {
     console.error('[FileWatcher] Watcher error:', error)
   })
 
-  activeWatcher = watcher
+  return watcher
+}
+
+async function closeExpandedFolderWatchers(): Promise<void> {
+  const closes = Array.from(expandedFolderWatchers.values()).map(async (watcher) => {
+    try {
+      await watcher.close()
+    } catch {
+      // Ignore close errors
+    }
+  })
+  expandedFolderWatchers.clear()
+  await Promise.all(closes)
+}
+
+function isWatchableExpandedFolder(dirPath: string): boolean {
+  if (!watchedDirectory || dirPath === watchedDirectory) return false
+  const relativePath = relative(watchedDirectory, dirPath)
+  return relativePath !== '' && !relativePath.startsWith('..') && !isAbsolute(relativePath)
+}
+
+async function syncExpandedFolderWatchers(expandedFolders: string[]): Promise<void> {
+  if (!watchedDirectory) {
+    await closeExpandedFolderWatchers()
+    return
+  }
+
+  const nextExpandedFolders = new Set(
+    expandedFolders.filter(isWatchableExpandedFolder)
+  )
+
+  const closeRemoved = Array.from(expandedFolderWatchers.entries()).map(
+    async ([dirPath, watcher]) => {
+      if (nextExpandedFolders.has(dirPath)) return
+      expandedFolderWatchers.delete(dirPath)
+      try {
+        await watcher.close()
+      } catch {
+        // Ignore close errors
+      }
+      console.log('[FileWatcher] Expanded folder watcher stopped:', dirPath)
+    }
+  )
+  await Promise.all(closeRemoved)
+
+  for (const dirPath of nextExpandedFolders) {
+    if (expandedFolderWatchers.has(dirPath)) continue
+    console.log('[FileWatcher] Starting expanded folder watcher for:', dirPath)
+    expandedFolderWatchers.set(dirPath, createShallowWatcher(dirPath))
+  }
+}
+
+/**
+ * Stop and dispose the current watcher, if any.
+ */
+async function stopWatcher(): Promise<void> {
+  await closeExpandedFolderWatchers()
+  if (activeWatcher) {
+    try {
+      await activeWatcher.close()
+    } catch {
+      // Ignore close errors
+    }
+    activeWatcher = null
+    watchedDirectory = null
+    console.log('[FileWatcher] Watcher stopped')
+  }
+}
+
+/**
+ * Start watching a new directory. Disposes any existing watcher first.
+ * Caller is responsible for path validation; this function takes an already-
+ * normalized absolute path (the IPC handler runs validatePath upstream).
+ */
+async function startWatcher(normalized: string): Promise<void> {
+  // No-op if we're already watching this exact directory
+  if (watchedDirectory === normalized) return
+
+  await stopWatcher()
+
+  console.log('[FileWatcher] Starting watcher for:', normalized)
+
+  activeWatcher = createShallowWatcher(normalized)
   watchedDirectory = normalized
 }
 
@@ -144,6 +208,7 @@ async function startWatcher(normalized: string): Promise<void> {
  * Channels:
  *   file:watch:start  (invokable) — start watching a directory
  *   file:watch:stop   (invokable) — stop the current watcher
+ *   file:watch:set-expanded-folders (invokable) — sync expanded folder paths
  */
 export function setupFileWatcherHandlers(): void {
   ipcMain.handle('file:watch:start', async (_event, dirPath: string) => {
@@ -163,6 +228,21 @@ export function setupFileWatcherHandlers(): void {
 
   ipcMain.handle('file:watch:stop', async () => {
     await enqueueWatcherOp(() => stopWatcher())
+  })
+
+  ipcMain.handle('file:watch:set-expanded-folders', async (_event, folderPaths: string[]) => {
+    if (!Array.isArray(folderPaths)) return
+    const normalizedPaths: string[] = []
+    for (const folderPath of folderPaths) {
+      if (!folderPath || typeof folderPath !== 'string') continue
+      try {
+        normalizedPaths.push(validatePath(folderPath))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.warn('[FileWatcher] Rejected expanded folder path:', folderPath, '—', message)
+      }
+    }
+    await enqueueWatcherOp(() => syncExpandedFolderWatchers(normalizedPaths))
   })
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -287,7 +287,8 @@ export interface ElectronAPI {
   // File watcher — subscribe to filesystem events for the File Explorer
   startWatchingDirectory: (dirPath: string) => Promise<void>
   stopWatchingDirectory: () => Promise<void>
-  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted'; path: string }) => void) => () => void
+  setWatchedExpandedFolders: (folderPaths: string[]) => Promise<void>
+  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted' | 'changed'; path: string }) => void) => () => void
   // Appearance: live dock icon swap (macOS only; no-op on other platforms)
   setAppIcon: (iconId: IconId) => Promise<void>
 }
@@ -558,8 +559,9 @@ const api: ElectronAPI = {
   // File watcher — subscribe to filesystem events for the File Explorer
   startWatchingDirectory: (dirPath: string) => ipcRenderer.invoke('file:watch:start', dirPath),
   stopWatchingDirectory: () => ipcRenderer.invoke('file:watch:stop'),
-  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted'; path: string }) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, fileEvent: { type: 'created' | 'deleted'; path: string }): void => {
+  setWatchedExpandedFolders: (folderPaths: string[]) => ipcRenderer.invoke('file:watch:set-expanded-folders', folderPaths),
+  onFileWatchEvent: (callback: (event: { type: 'created' | 'deleted' | 'changed'; path: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, fileEvent: { type: 'created' | 'deleted' | 'changed'; path: string }): void => {
       callback(fileEvent)
     }
     ipcRenderer.on('file:watch:event', handler)

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -56,6 +56,59 @@ function mergeExpandedChildren(
   return merge(newFiles)
 }
 
+function collectVisibleExpandedFolderPaths(
+  files: FileItem[],
+  expandedFolders: Set<string>
+): string[] {
+  const paths: string[] = []
+
+  const walk = (items: FileItem[]): void => {
+    for (const item of items) {
+      if (!item.isDirectory || !expandedFolders.has(item.path)) continue
+      paths.push(item.path)
+      if (item.children) walk(item.children)
+    }
+  }
+
+  walk(files)
+  return paths
+}
+
+function syncWatchedExpandedFolders(
+  files: FileItem[],
+  expandedFolders: Set<string>
+): void {
+  if (!window.api?.setWatchedExpandedFolders) return
+
+  window.api.setWatchedExpandedFolders(
+    collectVisibleExpandedFolderPaths(files, expandedFolders)
+  ).catch((err: unknown) => {
+    console.error('[FileListStore] Failed to sync expanded folder watchers:', err)
+  })
+}
+
+function isDescendantPath(path: string, folderPath: string): boolean {
+  return path.startsWith(`${folderPath}/`) || path.startsWith(`${folderPath}\\`)
+}
+
+function findDeepestVisibleExpandedAncestor(
+  path: string,
+  files: FileItem[],
+  expandedFolders: Set<string>
+): string | null {
+  const visibleExpandedFolders = collectVisibleExpandedFolderPaths(files, expandedFolders)
+  let deepest: string | null = null
+
+  for (const folderPath of visibleExpandedFolders) {
+    if (!isDescendantPath(path, folderPath)) continue
+    if (!deepest || folderPath.length > deepest.length) {
+      deepest = folderPath
+    }
+  }
+
+  return deepest
+}
+
 interface FileListState {
   // Panel state
   isPanelOpen: boolean
@@ -223,18 +276,52 @@ export const useFileListStore = create<FileListState>()(
       }
 
       let reloadTimeout: ReturnType<typeof setTimeout> | null = null
+      let pendingEventPaths: string[] = []
 
-      const unsubscribe = window.api.onFileWatchEvent((_event) => {
+      const unsubscribe = window.api.onFileWatchEvent((event) => {
         const { viewMode, rootPath } = get()
         // Only react in folder view — other views don't use the file tree
         if (viewMode !== 'folder' || !rootPath) return
 
         // Debounce: batch rapid file-system events (e.g., editor save = unlink + write)
         // into a single reload 150ms after the last event.
+        pendingEventPaths.push(event.path)
         if (reloadTimeout !== null) clearTimeout(reloadTimeout)
-        reloadTimeout = setTimeout(() => {
+        reloadTimeout = setTimeout(async () => {
           reloadTimeout = null
-          get().loadFiles()
+          const eventPaths = pendingEventPaths
+          pendingEventPaths = []
+          const {
+            files,
+            expandedFolders,
+            loadFiles,
+            loadFolderChildren
+          } = get()
+          const expandedFoldersToReload = new Set<string>()
+          let shouldReloadRoot = false
+
+          for (const path of eventPaths) {
+            const expandedAncestor = findDeepestVisibleExpandedAncestor(
+              path,
+              files,
+              expandedFolders
+            )
+
+            if (expandedAncestor) {
+              expandedFoldersToReload.add(expandedAncestor)
+            } else {
+              shouldReloadRoot = true
+            }
+          }
+
+          if (shouldReloadRoot) {
+            await loadFiles()
+          }
+          await Promise.all(
+            Array.from(expandedFoldersToReload, (folderPath) =>
+              loadFolderChildren(folderPath)
+            )
+          )
         }, 150)
       })
 
@@ -328,9 +415,11 @@ export const useFileListStore = create<FileListState>()(
         // collapses/reopens) for not bursting IPC reads on every event.
         const merged = mergeExpandedChildren(fresh, oldFiles, expandedFolders)
         set({ files: merged, isLoading: false })
+        syncWatchedExpandedFolders(merged, expandedFolders)
       } catch (error) {
         console.error('Failed to load files:', error)
         set({ files: [], isLoading: false })
+        syncWatchedExpandedFolders([], expandedFolders)
       }
     },
 
@@ -363,7 +452,9 @@ export const useFileListStore = create<FileListState>()(
           })
         }
 
-        set({ files: updateFolder(files) })
+        const updatedFiles = updateFolder(files)
+        set({ files: updatedFiles })
+        syncWatchedExpandedFolders(updatedFiles, get().expandedFolders)
       } catch (error) {
         console.error('Failed to load folder children:', error)
       } finally {
@@ -477,6 +568,7 @@ export const useFileListStore = create<FileListState>()(
       }
 
       set({ expandedFolders: newExpanded })
+      syncWatchedExpandedFolders(get().files, newExpanded)
     },
 
     setExpanded: (path, expanded) => {
@@ -488,6 +580,7 @@ export const useFileListStore = create<FileListState>()(
         newExpanded.delete(path)
       }
       set({ expandedFolders: newExpanded })
+      syncWatchedExpandedFolders(get().files, newExpanded)
     },
 
     revealAndSelectPath: (path: string) => {
@@ -542,6 +635,7 @@ export const useFileListStore = create<FileListState>()(
       }
 
       set({ expandedFolders: newExpanded, selectedPath: targetPath })
+      syncWatchedExpandedFolders(get().files, newExpanded)
     }
   }))
 )

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -516,6 +516,11 @@ export interface ElectronAPI {
   downloadSkill?: () => Promise<{ success: boolean; error?: string }>
   // Build info
   isMasBuild?: boolean
+  // File watcher — Electron-only live reload support for the File Explorer
+  startWatchingDirectory?: (dirPath: string) => Promise<void>
+  stopWatchingDirectory?: () => Promise<void>
+  setWatchedExpandedFolders?: (folderPaths: string[]) => Promise<void>
+  onFileWatchEvent?: (callback: (event: { type: 'created' | 'deleted' | 'changed'; path: string }) => void) => () => void
   // Auto-updater
   onUpdateAvailable?: (callback: (info: { version: string; releaseNotes?: string }) => void) => () => void
   onDownloadProgress?: (callback: (progress: { percent: number }) => void) => () => void


### PR DESCRIPTION
## Summary
- Emit `changed` file-watch events for chokidar `change` notifications so external saves refresh file metadata.
- Track visible expanded folders and attach additional shallow watchers for those paths, tearing them down when the visible expansion set changes.
- Refresh affected expanded subtrees on watcher events so external changes inside expanded folders appear without collapsing/re-expanding.

## Verification
- `npm run build` (installed missing `zip` package in the sandbox first)

Closes #517
Closes #518

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/72b25b37-985f-434d-9446-75b8fe429b65_
_Run: https://oz.warp.dev/runs/019e6290-942a-77ed-a2dd-d93f5ceb4637_

_This PR was generated with [Oz](https://warp.dev/oz)._
