### PR TITLE
fix(statusbar): live counts, cursor position, hide model selector when AI off (#561, #563, #564)

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -336,7 +336,8 @@ export function Editor() {
   }, [editor, setEditorInstance])
 
   // Cache selection on selectionUpdate for read_selection fallback
-  // This preserves the selection when chat input steals focus
+  // This preserves the selection when chat input steals focus.
+  // Also computes and pushes the live cursor position to editorStore (#564).
   useEffect(() => {
     if (!editor) return
 
@@ -346,6 +347,15 @@ export function Editor() {
         const text = editor.state.doc.textBetween(from, to)
         useEditorStore.getState().setLastSelection({ text, from, to })
       }
+
+      // Derive line/column from the resolved head position
+      const $head = editor.state.selection.$head
+      // Count newlines before the cursor to find the 1-based line number
+      const textBeforeCursor = editor.state.doc.textBetween(0, $head.pos, '\n')
+      const lines = textBeforeCursor.split('\n')
+      const line = lines.length
+      const column = lines[lines.length - 1].length + 1
+      useEditorStore.getState().setCursorPosition(line, column)
     }
 
     editor.on('selectionUpdate', handleSelectionUpdate)

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -81,11 +81,11 @@ export function StatusBar() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, editor?.state.doc])
 
-  const wordCount = document.content
-    .split(/\s+/)
-    .filter((word) => word.length > 0).length
-
-  const charCount = document.content.length
+  // Compute word/char counts from the live TipTap instance so they update on
+  // every keystroke without waiting for the debounced store write (#563).
+  const liveText = editor ? editor.state.doc.textContent : document.content
+  const wordCount = liveText.split(/\s+/).filter((word) => word.length > 0).length
+  const charCount = liveText.length
 
   // Mode configuration.
   // ToolMode union renamed to chat / editor / create in #467 Chunk 3.
@@ -173,46 +173,50 @@ export function StatusBar() {
           </>
         )}
 
-        {/* Model selector */}
-        <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer max-w-[120px] truncate">
-                  {modelDisplayName}
-                </button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="top">
-              <p>{settings.llm.provider} / {settings.llm.model}</p>
-            </TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent align="end" className="max-h-[300px] overflow-y-auto">
-            <DropdownMenuLabel className="text-xs text-muted-foreground">
-              {settings.llm.provider}
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {availableModels.map((model) => (
-              <DropdownMenuItem
-                key={model.id}
-                onClick={() => handleModelChange(model.id)}
-                className="cursor-pointer font-mono text-xs"
-              >
-                <div className="flex flex-col items-start">
-                  <span>{model.name}</span>
-                  {model.description && (
-                    <span className="text-[10px] text-muted-foreground">{model.description}</span>
-                  )}
-                </div>
-                {model.id === settings.llm.model && (
-                  <span className="ml-auto pl-2 text-primary">✓</span>
-                )}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {/* Model selector — hidden when user chose "Continue without AI" (#561) */}
+        {settings.aiConsent?.consented === true && (
+          <>
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <button className="hover:text-foreground focus-visible:text-foreground focus-visible:outline-none transition-colors cursor-pointer max-w-[120px] truncate">
+                      {modelDisplayName}
+                    </button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>{settings.llm.provider} / {settings.llm.model}</p>
+                </TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="end" className="max-h-[300px] overflow-y-auto">
+                <DropdownMenuLabel className="text-xs text-muted-foreground">
+                  {settings.llm.provider}
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {availableModels.map((model) => (
+                  <DropdownMenuItem
+                    key={model.id}
+                    onClick={() => handleModelChange(model.id)}
+                    className="cursor-pointer font-mono text-xs"
+                  >
+                    <div className="flex flex-col items-start">
+                      <span>{model.name}</span>
+                      {model.description && (
+                        <span className="text-[10px] text-muted-foreground">{model.description}</span>
+                      )}
+                    </div>
+                    {model.id === settings.llm.model && (
+                      <span className="ml-auto pl-2 text-primary">✓</span>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
 
-        <span className="text-muted-foreground/40 mx-1">|</span>
+            <span className="text-muted-foreground/40 mx-1">|</span>
+          </>
+        )}
 
         {/* Mode selector */}
         <DropdownMenu>


### PR DESCRIPTION
## Summary

- **#563 — Live word/char count**: StatusBar now reads `editor.state.doc.textContent` from the live TipTap instance (via `useEditorInstanceStore`) instead of `document.content` from `editorStore`. Counts update on every keystroke, no debounce lag.

- **#564 — Cursor position**: Added a `selectionUpdate` handler in `Editor.tsx` (merged into the existing selection-cache handler) that computes line/column from `editor.state.selection.$head` and calls `useEditorStore.getState().setCursorPosition(line, column)` on every caret move. The store and StatusBar were already wired; the update call was simply missing.

- **#561 — Hide model selector when AI disabled**: Wrapped the model-selector `<DropdownMenu>` and its adjacent `|` separator in a `settings.aiConsent?.consented === true` guard. Both are hidden when the user chose "Continue without AI".

## Files changed

- `src/renderer/components/layout/StatusBar.tsx` — live counts (#563) + model selector guard (#561)
- `src/renderer/components/editor/Editor.tsx` — cursor position update on selectionUpdate (#564)

## Test plan

- [ ] Open a document, type a word — word/char count in status bar increments immediately (no ~500ms lag)
- [ ] Click around the document — "Ln N, Col N" updates to reflect actual cursor position
- [ ] In a fresh install or with `"aiConsent": { "consented": false }` in settings.json, confirm the model selector chip and its separator are absent from the status bar
- [ ] With `"aiConsent": { "consented": true }`, confirm the model selector is visible and functional

Closes #561
Closes #563
Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)