### PR TITLE
fix(comments): persist comment marks across tab switch (#595)

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -46,6 +46,7 @@ import { AISuggestionPopover } from '../AISuggestionPopover'
 import { CommentPopover } from '../CommentPopover'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import type { AISuggestionData } from '../../extensions/ai-suggestions/types'
+import { useCommentStore } from '../../extensions/comments/store'
 import { LinkPopover } from './LinkPopover'
 import { SourceEditor, SourceEditorHandle } from './SourceEditor'
 import { getApi } from '../../lib/browserApi'
@@ -437,6 +438,32 @@ export function Editor() {
       return () => clearTimeout(timer)
     }
   }, [editor, document.documentId, pendingSuggestions, suggestionStoreDocumentId])
+
+  // Subscribe to pending comment marks reactively for restoration
+  const pendingComments = useCommentStore((state) => state.pendingComments)
+  const commentStoreDocumentId = useCommentStore((state) => state.documentId)
+
+  // Restore comment marks when document changes or pending comments are loaded
+  useEffect(() => {
+    if (!editor || !document.documentId) return
+
+    // Only restore if there are pending comments and they match current document
+    if (pendingComments.length > 0 && commentStoreDocumentId === document.documentId) {
+      console.log(`[Editor:${SESSION_ID}] Restoring comments:`, {
+        documentId: document.documentId,
+        count: pendingComments.length
+      })
+
+      // Small delay to ensure editor content is fully loaded (same pattern as suggestions)
+      const timer = setTimeout(() => {
+        editor.commands.restoreComments(pendingComments)
+        // Clear pending comments from memory after restoring
+        useCommentStore.getState().clearComments()
+      }, 100)
+
+      return () => clearTimeout(timer)
+    }
+  }, [editor, document.documentId, pendingComments, commentStoreDocumentId])
 
   // Auto-focus editor once when document loads (not on every content change)
   const hasFocusedRef = useRef(false)

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -35,6 +35,10 @@ declare module '@tiptap/core' {
        * Remove all comments
        */
       unsetAllComments: () => ReturnType
+      /**
+       * Restore comment marks from persisted data (used after tab switch)
+       */
+      restoreComments: (comments: CommentData[]) => ReturnType
     }
   }
 }
@@ -175,6 +179,90 @@ export const Comment = Mark.create<CommentOptions>({
         () =>
         ({ commands }) => {
           return commands.unsetComment()
+        },
+
+      restoreComments:
+        (comments) =>
+        ({ tr, state, dispatch }) => {
+          if (!dispatch || comments.length === 0) return false
+
+          const { doc, schema } = state
+          let restored = 0
+
+          for (const comment of comments) {
+            // Use the stored marked text to locate where the comment mark should be applied.
+            // We search for the first occurrence of the marked text in the document.
+            const searchText = comment.markedText
+            if (!searchText) {
+              console.warn('[Comment] Cannot restore comment without markedText:', comment.id)
+              continue
+            }
+
+            const docText = doc.textContent
+            const textIndex = docText.indexOf(searchText)
+            if (textIndex === -1) {
+              console.warn('[Comment] Cannot find markedText in document:', {
+                id: comment.id,
+                markedText: searchText.substring(0, 50)
+              })
+              continue
+            }
+
+            // Walk the document to map char index → ProseMirror positions
+            let charCount = 0
+            let foundStart = -1
+            let foundEnd = -1
+
+            doc.descendants((node, nodePos) => {
+              if (foundStart !== -1 && foundEnd !== -1) return false
+
+              if (node.isText && node.text) {
+                const nodeText = node.text
+                const nodeStart = charCount
+                const nodeEnd = charCount + nodeText.length
+
+                if (foundStart === -1 && textIndex >= nodeStart && textIndex < nodeEnd) {
+                  foundStart = nodePos + (textIndex - nodeStart)
+                }
+
+                const targetEnd = textIndex + searchText.length
+                if (foundStart !== -1 && targetEnd > nodeStart && targetEnd <= nodeEnd) {
+                  foundEnd = nodePos + (targetEnd - nodeStart)
+                  return false
+                }
+
+                charCount += nodeText.length
+              }
+            })
+
+            if (foundStart === -1 || foundEnd === -1) {
+              console.warn('[Comment] Could not map text position for comment:', comment.id)
+              continue
+            }
+
+            const mark = schema.marks.comment.create({
+              id: comment.id,
+              comment: comment.comment,
+              createdAt: comment.createdAt,
+            })
+
+            tr.addMark(foundStart, foundEnd, mark)
+            restored++
+
+            console.log('[Comment] Restored comment mark:', {
+              id: comment.id,
+              from: foundStart,
+              to: foundEnd
+            })
+          }
+
+          if (restored > 0) {
+            dispatch(tr)
+            console.log('[Comment] Restored', restored, 'of', comments.length, 'comments')
+            return true
+          }
+
+          return false
         },
     }
   },

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -271,7 +271,7 @@ export const Comment = Mark.create<CommentOptions>({
 /**
  * Extract all comments from the editor
  */
-export function getComments(editor: { state: { doc: { descendants: (fn: (node: { marks: Array<{ type: { name: string }; attrs: { id: string; comment: string; createdAt: number } }>; nodeSize: number; textContent: string }, pos: number) => void) => void } } }): CommentData[] {
+export function getComments(editor: { state: { doc: { descendants: (fn: (node: { marks: Array<{ type: { name: string }; attrs: { id: string; comment: string; createdAt: number } }>; nodeSize: number; textContent: string }, pos: number) => void) => void; textBetween: (from: number, to: number, blockSeparator?: string) => string } } }): CommentData[] {
   // Map to collect all text nodes for each comment ID
   const commentMap = new Map<string, {
     texts: string[]
@@ -310,7 +310,7 @@ export function getComments(editor: { state: { doc: { descendants: (fn: (node: {
   commentMap.forEach((data, id) => {
     comments.push({
       id,
-      markedText: data.texts.join('\n\n'),
+      markedText: editor.state.doc.textBetween(data.from, data.to, ' '),
       comment: data.comment,
       createdAt: data.createdAt,
       from: data.from,

--- a/src/renderer/extensions/comments/index.ts
+++ b/src/renderer/extensions/comments/index.ts
@@ -1,2 +1,3 @@
 export { Comment, getComments, commentMarkdownSerializer } from './extension'
 export type { CommentMark, CommentData, CommentOptions } from './types'
+export { useCommentStore } from './store'

--- a/src/renderer/extensions/comments/store.ts
+++ b/src/renderer/extensions/comments/store.ts
@@ -1,0 +1,90 @@
+/**
+ * Comment mark persistence store
+ *
+ * Manages saving/loading pending comment marks to IndexedDB,
+ * allowing them to persist across tab switches.
+ */
+
+import { create } from 'zustand'
+import type { CommentData } from './types'
+import {
+  saveComments as persistComments,
+  loadComments as fetchComments,
+  deleteComments as removeComments
+} from '../../lib/persistence'
+
+interface CommentPersistenceState {
+  /** Current document ID being tracked */
+  documentId: string | null
+
+  /** Pending comments for the current document (loaded from IndexedDB) */
+  pendingComments: CommentData[]
+
+  /** Set the current document ID and clear pending comments */
+  setDocumentId: (documentId: string) => void
+
+  /** Save current comments to IndexedDB */
+  saveComments: (documentId: string, comments: CommentData[]) => Promise<void>
+
+  /** Load comments from IndexedDB for a document */
+  loadComments: (documentId: string) => Promise<void>
+
+  /** Clear pending comments from memory (not from IndexedDB) */
+  clearComments: () => void
+
+  /** Delete comments from IndexedDB for a document */
+  deleteComments: (documentId: string) => Promise<void>
+}
+
+export const useCommentStore = create<CommentPersistenceState>((set, get) => ({
+  documentId: null,
+  pendingComments: [],
+
+  setDocumentId: (documentId: string) => {
+    set({ documentId, pendingComments: [] })
+  },
+
+  saveComments: async (documentId: string, comments: CommentData[]) => {
+    if (!documentId) {
+      console.warn('[CommentStore] No documentId provided, skipping save')
+      return
+    }
+
+    console.log('[CommentStore] Saving comments:', {
+      documentId,
+      count: comments.length
+    })
+
+    await persistComments(documentId, comments)
+  },
+
+  loadComments: async (documentId: string) => {
+    console.log('[CommentStore] Loading comments for:', documentId)
+
+    const comments = await fetchComments(documentId)
+
+    set({
+      documentId,
+      pendingComments: comments
+    })
+
+    console.log('[CommentStore] Loaded comments:', {
+      documentId,
+      count: comments.length
+    })
+  },
+
+  clearComments: () => {
+    set({ pendingComments: [] })
+  },
+
+  deleteComments: async (documentId: string) => {
+    await removeComments(documentId)
+
+    // Clear from memory if it's the current document
+    const state = get()
+    if (state.documentId === documentId) {
+      set({ pendingComments: [] })
+    }
+  }
+}))

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -6,6 +6,8 @@ import { useChatStore, setCurrentDocumentId } from '../stores/chatStore'
 import { useAnnotationStore } from '../extensions/ai-annotations'
 import { useSuggestionStore } from '../extensions/ai-suggestions/store'
 import { getAISuggestions } from '../extensions/ai-suggestions'
+import { useCommentStore } from '../extensions/comments/store'
+import { getComments } from '../extensions/comments'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useFileListStore } from '../stores/fileListStore'
 import { parseMarkdown, serializeMarkdown, prepareTextContent } from '../lib/markdown'
@@ -22,6 +24,7 @@ import {
   loadAnnotations,
   deleteAnnotations,
   deleteSuggestions,
+  deleteComments,
   SESSION_ID
 } from '../lib/persistence'
 import type { DraftState } from '../lib/persistence'
@@ -89,14 +92,21 @@ export function useTabs() {
     // Save annotations for current document
     await useAnnotationStore.getState().saveAnnotations()
 
-    // Save AI suggestions for current document
+    // Save AI suggestions and comment marks for current document
     const editor = useEditorInstanceStore.getState().editor
     if (editor) {
-      const suggestions = getAISuggestions(editor)
       const docId = activeTab.documentId
+
+      const suggestions = getAISuggestions(editor)
       console.log(`[useTabs:${SESSION_ID}] Saving suggestions:`, { documentId: docId, count: suggestions.length })
       if (docId) {
         await useSuggestionStore.getState().saveSuggestions(docId, suggestions)
+      }
+
+      const comments = getComments(editor)
+      console.log(`[useTabs:${SESSION_ID}] Saving comments:`, { documentId: docId, count: comments.length })
+      if (docId) {
+        await useCommentStore.getState().saveComments(docId, comments)
       }
     }
 
@@ -160,6 +170,11 @@ export function useTabs() {
     console.log(`[useTabs:${SESSION_ID}] loading suggestions for:`, newDocumentId)
     await useSuggestionStore.getState().loadSuggestions(newDocumentId)
     console.log(`[useTabs:${SESSION_ID}] suggestions loaded:`, useSuggestionStore.getState().pendingSuggestions.length)
+
+    // Load comment marks for the target document
+    console.log(`[useTabs:${SESSION_ID}] loading comments for:`, newDocumentId)
+    await useCommentStore.getState().loadComments(newDocumentId)
+    console.log(`[useTabs:${SESSION_ID}] comments loaded:`, useCommentStore.getState().pendingComments.length)
 
     // Clear reMarkable read-only state
     useEditorStore.getState().setRemarkableReadOnly(false, null)
@@ -245,6 +260,9 @@ export function useTabs() {
 
     // Clear suggestions
     useSuggestionStore.getState().setDocumentId(newDocumentId)
+
+    // Clear comment marks
+    useCommentStore.getState().setDocumentId(newDocumentId)
 
     // Clear reMarkable read-only state
     useEditorStore.getState().setRemarkableReadOnly(false, null)
@@ -375,6 +393,9 @@ export function useTabs() {
     // Load suggestions for the document
     await useSuggestionStore.getState().loadSuggestions(newDocumentId)
 
+    // Load comment marks for the document
+    await useCommentStore.getState().loadComments(newDocumentId)
+
     // Clear reMarkable read-only state
     useEditorStore.getState().setRemarkableReadOnly(false, null)
 
@@ -484,6 +505,7 @@ export function useTabs() {
       await loadChatForDocument(newDocumentId)
       await useAnnotationStore.getState().loadAnnotations(newDocumentId)
       await useSuggestionStore.getState().loadSuggestions(newDocumentId)
+      await useCommentStore.getState().loadComments(newDocumentId)
       useEditorStore.getState().setRemarkableReadOnly(false, null)
       setEditing(true)
 
@@ -546,6 +568,7 @@ export function useTabs() {
     await loadChatForDocument(newDocumentId)
     await useAnnotationStore.getState().loadAnnotations(newDocumentId)
     await useSuggestionStore.getState().loadSuggestions(newDocumentId)
+    await useCommentStore.getState().loadComments(newDocumentId)
     useEditorStore.getState().setRemarkableReadOnly(false, null)
     setEditing(true)
 
@@ -584,6 +607,7 @@ export function useTabs() {
       await deleteConversations(tab.documentId)
       await deleteAnnotations(tab.documentId)
       await deleteSuggestions(tab.documentId)
+      await deleteComments(tab.documentId)
     }
 
     // If we closed the last tab, create a new one
@@ -618,6 +642,7 @@ export function useTabs() {
       await deleteConversations(tab.documentId)
       await deleteAnnotations(tab.documentId)
       await deleteSuggestions(tab.documentId)
+      await deleteComments(tab.documentId)
     }
 
     // If we closed the last tab, create a new one
@@ -645,6 +670,7 @@ export function useTabs() {
         await deleteConversations(tab.documentId)
         await deleteAnnotations(tab.documentId)
         await deleteSuggestions(tab.documentId)
+        await deleteComments(tab.documentId)
       }
     }
 
@@ -666,6 +692,7 @@ export function useTabs() {
         await deleteConversations(tab.documentId)
         await deleteAnnotations(tab.documentId)
         await deleteSuggestions(tab.documentId)
+        await deleteComments(tab.documentId)
       }
     }
 

--- a/src/renderer/lib/persistence.ts
+++ b/src/renderer/lib/persistence.ts
@@ -63,7 +63,7 @@ export interface EmojiCacheEntry {
 
 // Database constants
 const DB_NAME = 'prose-db'
-const DB_VERSION = 7
+const DB_VERSION = 8
 const STORES = {
   DRAFTS: 'drafts',
   CONVERSATIONS: 'conversations',
@@ -71,7 +71,8 @@ const STORES = {
   COMMAND_HISTORY: 'command_history',
   SUGGESTIONS: 'suggestions',
   EMOJI_CACHE: 'emoji_cache',
-  SUMMARIES: 'summaries'
+  SUMMARIES: 'summaries',
+  COMMENTS: 'comments'
 } as const
 
 // Recovery types
@@ -102,6 +103,7 @@ export interface DatabaseBackup {
  * v5: (no schema change, version alignment)
  * v6: Added emoji_cache store (LLM-generated emoji icons for tabs)
  * v7: Added summaries store (AI-generated document summaries)
+ * v8: Added comments store (persists comment marks across tab switches)
  *
  * When bumping version:
  * 1. Update DB_VERSION above
@@ -395,6 +397,9 @@ function getDB(): Promise<IDBDatabase> {
               if (!db.objectStoreNames.contains(STORES.SUMMARIES)) {
                 db.createObjectStore(STORES.SUMMARIES)
               }
+              if (!db.objectStoreNames.contains(STORES.COMMENTS)) {
+                db.createObjectStore(STORES.COMMENTS)
+              }
             }
           })
 
@@ -485,6 +490,9 @@ function getDB(): Promise<IDBDatabase> {
       }
       if (!db.objectStoreNames.contains(STORES.SUMMARIES)) {
         db.createObjectStore(STORES.SUMMARIES)
+      }
+      if (!db.objectStoreNames.contains(STORES.COMMENTS)) {
+        db.createObjectStore(STORES.COMMENTS)
       }
     }
   })
@@ -908,6 +916,90 @@ export async function deleteSuggestions(documentId: string): Promise<void> {
     })
   }, ensureSuggestionsStore).catch((error) => {
     console.error('Failed to delete suggestions:', error)
+  })
+}
+
+// ============ Comment Operations ============
+
+/**
+ * Save comment marks for a document (keyed by documentId).
+ * Comments are stored as plain data and re-applied as marks after tab switch.
+ */
+export async function saveComments(
+  documentId: string,
+  comments: import('../extensions/comments/types').CommentData[]
+): Promise<void> {
+  console.log(`[persistence:${SESSION_ID}] saveComments:`, { documentId, count: comments.length })
+  await withDb(async (db) => {
+    if (!db.objectStoreNames.contains(STORES.COMMENTS)) {
+      console.warn('[persistence] comments store missing - skipping save')
+      return
+    }
+    return new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(STORES.COMMENTS, 'readwrite')
+      const store = transaction.objectStore(STORES.COMMENTS)
+      const request = store.put(comments, documentId)
+
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => {
+        console.log(`[persistence:${SESSION_ID}] saveComments SUCCESS:`, { documentId })
+        resolve()
+      }
+    })
+  }).catch((error) => {
+    console.error('Failed to save comments:', error)
+  })
+}
+
+/**
+ * Load comment marks for a document.
+ */
+export async function loadComments(
+  documentId: string
+): Promise<import('../extensions/comments/types').CommentData[]> {
+  console.log(`[persistence:${SESSION_ID}] loadComments:`, { documentId })
+  return withDb(async (db) => {
+    if (!db.objectStoreNames.contains(STORES.COMMENTS)) {
+      console.warn('[persistence] comments store missing - returning empty')
+      return []
+    }
+    return new Promise<import('../extensions/comments/types').CommentData[]>((resolve, reject) => {
+      const transaction = db.transaction(STORES.COMMENTS, 'readonly')
+      const store = transaction.objectStore(STORES.COMMENTS)
+      const request = store.get(documentId)
+
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => {
+        const result = request.result ?? []
+        console.log(`[persistence:${SESSION_ID}] loadComments SUCCESS:`, { documentId, count: result.length })
+        resolve(result)
+      }
+    })
+  }).then((result) => result ?? []).catch((error) => {
+    console.error('Failed to load comments:', error)
+    return []
+  })
+}
+
+/**
+ * Delete comment marks for a document (e.g., when closing an unsaved tab).
+ */
+export async function deleteComments(documentId: string): Promise<void> {
+  await withDb(async (db) => {
+    if (!db.objectStoreNames.contains(STORES.COMMENTS)) {
+      console.warn('[persistence] comments store missing - skipping delete')
+      return
+    }
+    return new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(STORES.COMMENTS, 'readwrite')
+      const store = transaction.objectStore(STORES.COMMENTS)
+      const request = store.delete(documentId)
+
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve()
+    })
+  }).catch((error) => {
+    console.error('Failed to delete comments:', error)
   })
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: Comment marks live only in ProseMirror in-memory state and the markdown serializer deliberately emits nothing for them, so every tab switch (which resets `EditorState`) silently drops all comments.
- **Fix**: Mirrors the existing AI-suggestions persistence pattern end-to-end — IndexedDB store → Zustand wrapper → save-on-tab-leave → load-on-tab-enter → `restoreComments` editor command.

## Changes

| File | Change |
|---|---|
| `persistence.ts` | Add `comments` object store; bump `DB_VERSION` 7→8; add `saveComments` / `loadComments` / `deleteComments` |
| `comments/store.ts` | New `useCommentStore` Zustand store (same shape as `useSuggestionStore`) |
| `comments/extension.ts` | Add `restoreComments` editor command — walks `markedText` back to ProseMirror positions and re-applies the mark |
| `comments/index.ts` | Re-export `useCommentStore` |
| `useTabs.ts` | Save in `saveCurrentTabState`; load in `switchToTab` / `openFileInTab` / `openFileInPreviewTab` / `createNewTab`; delete on tab close (unsaved docs only) |
| `Editor.tsx` | Subscribe to `pendingComments` + `commentStoreDocumentId`; call `restoreComments` after `EditorState.create` reset (100 ms delay, same as suggestions) |

## Test plan

- [ ] Open a document, select text, add a comment
- [ ] Switch to another tab — return — comment mark is still present with correct text highlighted
- [ ] Reload the app — open the document — comment mark survives (IndexedDB persisted)
- [ ] Close an unsaved tab and reopen it — comments not leaked to the new document
- [ ] Verify `DB_VERSION` is now 8 in DevTools → Application → IndexedDB → prose-db
- [ ] Existing AI suggestions still persist correctly (no regression)

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)