### PR TITLE
fix(editor): insert(after_node) on a heading creates a sibling paragraph (#571)

### DIFF
--- a/src/renderer/extensions/ai-suggestions/extension.ts
+++ b/src/renderer/extensions/ai-suggestions/extension.ts
@@ -29,13 +29,14 @@ function isMultiBlock(text: string): boolean {
 /**
  * Parse a markdown string into a ProseMirror Slice using the editor's
  * configured tiptap-markdown parser, preserving block structure (paragraphs,
- * headings, lists, etc.). Used only for multi-block acceptance so that
- * inline accepts keep the existing schema.text() path byte-for-byte.
+ * headings, lists, etc.). Used for multi-block suggestion acceptance and for
+ * block-anchor insertions (after_node / before_node) so that content is placed
+ * as a document-level sibling rather than being absorbed into the anchor node.
  *
  * Returns null if the editor doesn't have a markdown parser in storage
  * (e.g., during tests) so callers can fall back to the text path.
  */
-function parseMarkdownToSlice(editor: Editor, schema: Schema, text: string): Slice | null {
+export function parseMarkdownToSlice(editor: Editor, schema: Schema, text: string): Slice | null {
   const parser = editor.storage?.markdown?.parser
   if (!parser || typeof parser.parse !== 'function') return null
 

--- a/src/renderer/extensions/ai-suggestions/index.ts
+++ b/src/renderer/extensions/ai-suggestions/index.ts
@@ -1,4 +1,4 @@
-export { AISuggestion, getAISuggestions, getSuggestionsWithFeedback, aiSuggestionMarkdownSerializer } from './extension'
+export { AISuggestion, getAISuggestions, getSuggestionsWithFeedback, aiSuggestionMarkdownSerializer, parseMarkdownToSlice } from './extension'
 export { useSuggestionStore } from './store'
 export type {
   AISuggestionMark,

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -479,7 +479,11 @@ export async function executeInsert(
         const slice = parseMarkdownToSlice(editor, editor.state.schema, text)
         if (slice) {
           const sizeBefore = editor.state.doc.content.size
-          editor.view.dispatch(editor.state.tr.insert(insertFrom, slice.content))
+          try {
+            editor.view.dispatch(editor.state.tr.insert(insertFrom, slice.content))
+          } catch (e) {
+            return toolError(`Failed to insert text: ${e}`, 'INSERT_FAILED')
+          }
           const sizeAfter = editor.state.doc.content.size
 
           if (provenance && provenance.documentId && text.length > 0) {

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -12,7 +12,7 @@ import { useAnnotationStore } from '../../../extensions/ai-annotations'
 import { createWordDiffAnnotations } from '../../diffUtils'
 import { findNodeById, findNodeByContent, getNodesWithIds, flattenNodes } from '../../../extensions/node-ids'
 import { generateId } from '../../persistence'
-import { getAISuggestions } from '../../../extensions/ai-suggestions'
+import { getAISuggestions, parseMarkdownToSlice } from '../../../extensions/ai-suggestions'
 import { parseMarkdown, FRONTMATTER_REGEX } from '../../markdown'
 import { load as parseYaml } from 'js-yaml'
 
@@ -458,6 +458,51 @@ export async function executeInsert(
       insertFrom =
         position === 'after_node' ? found.pos + found.node.nodeSize : found.pos
       insertTo = insertFrom
+
+      // Block-anchor insert: `insertFrom` is a between-block-nodes position at
+      // document depth. Routing through setTextSelection + insertContent would
+      // resolve that position to the nearest text cursor — biasing toward the
+      // anchor heading's inline content when the heading is the last block, or
+      // when bias resolution happens to snap backward. The inserted markdown
+      // would then land INSIDE the heading node (inheriting heading styling).
+      //
+      // Fix (#571): bypass the selection-based path entirely for after_node /
+      // before_node. Parse the markdown text into a proper ProseMirror Slice
+      // using the same parseMarkdownToSlice helper used by suggestion acceptance
+      // (#578). Then dispatch a direct tr.insert() at the exact between-block
+      // position, which guarantees the content is placed as a sibling block
+      // rather than merged into the anchor heading's inline content.
+      //
+      // When the parser is unavailable (tests / edge case), fall through to
+      // applyInsertion so there is always a useful result.
+      {
+        const slice = parseMarkdownToSlice(editor, editor.state.schema, text)
+        if (slice) {
+          const sizeBefore = editor.state.doc.content.size
+          editor.view.dispatch(editor.state.tr.insert(insertFrom, slice.content))
+          const sizeAfter = editor.state.doc.content.size
+
+          if (provenance && provenance.documentId && text.length > 0) {
+            const insertedSize = (sizeAfter - sizeBefore) + (insertTo - insertFrom)
+            createWordDiffAnnotations({
+              documentId: provenance.documentId,
+              originalText: '',
+              newText: text,
+              rangeFrom: insertFrom,
+              rangeTo: insertFrom + insertedSize,
+              provenance: {
+                model: provenance.model,
+                conversationId: provenance.conversationId,
+                messageId: provenance.messageId,
+              },
+              explanation: comment,
+            })
+          }
+
+          return toolSuccess({ inserted: true, position })
+        }
+        // Parser unavailable — fall through to the generic applyInsertion path.
+      }
       break
     }
     case 'cursor':


### PR DESCRIPTION
## Summary

- When `insert` with `position=after_node` targeted a heading nodeId, the inserted text was absorbed into the heading node and rendered as a heading instead of as a sibling paragraph.
- Root cause: `applyInsertion` uses `setTextSelection(insertFrom)` where `insertFrom = found.pos + found.node.nodeSize` — a between-block-nodes position. `TextSelection.create` with default bias resolves this to the nearest text cursor, which snaps backward into the heading's inline content when the heading is the last block (no forward text position exists).
- Fix: for `after_node`/`before_node`, bypass `setTextSelection + insertContent` entirely. Parse the markdown text via `parseMarkdownToSlice` (already used by suggestion acceptance in #578, now exported from `ai-suggestions`) and dispatch `tr.insert(insertFrom, slice.content)` directly. This inserts at the exact document-level position as a sibling block, regardless of what's before or after the anchor.

## Verification

The fix guarantees a sibling block because:
1. `insertFrom = found.pos + found.node.nodeSize` is the position immediately after the heading's closing token — a valid document-level between-block position.
2. `tr.insert(pos, fragment)` in ProseMirror inserts block nodes at document depth without going through selection resolution — no bias snapping possible.
3. `parseMarkdownToSlice` returns a slice parsed from the markdown (via tiptap-markdown's HTML serializer + ProseMirrorDOMParser), so a plain paragraph input produces a `<p>` node, not inline text. The resulting fragment inserted at a between-block position becomes a sibling paragraph node.

To verify manually: open a document with `# Heading` as the last block, trigger `insert` with `position=after_node` on the heading's nodeId, and confirm the inserted text renders as a paragraph (not a heading) immediately after it.

Closes #571
Refs #578 #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)