### PR TITLE
fix(editor): preserve pending AI suggestions across HMR remount (#531)

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -373,11 +373,25 @@ export function Editor() {
     }
   }, [editor, document.content, document.documentId])
 
-  // Register editor instance in store for cross-component access
+  // Register editor instance in store for cross-component access.
+  // On cleanup (HMR remount or unmount), snapshot any live AI suggestions into
+  // the suggestion store so the next mount can replay them via the existing
+  // restoreAISuggestions useEffect — without touching the autosave pipeline.
   useEffect(() => {
     setEditorInstance(editor)
-    return () => setEditorInstance(null)
-  }, [editor, setEditorInstance])
+    return () => {
+      setEditorInstance(null)
+      // Snapshot live suggestions for HMR replay (option 2 from issue #531).
+      // Only runs when there is an editor with an active document — skips
+      // clean unmounts where document.documentId is empty (e.g., empty state).
+      if (editor && document.documentId) {
+        const liveSuggestions = getAISuggestions(editor)
+        if (liveSuggestions.length > 0) {
+          useSuggestionStore.getState().snapshotSuggestions(document.documentId, liveSuggestions)
+        }
+      }
+    }
+  }, [editor, setEditorInstance, document.documentId])
 
   // Cache selection on selectionUpdate for read_selection fallback
   // This preserves the selection when chat input steals focus.

--- a/src/renderer/extensions/ai-suggestions/store.ts
+++ b/src/renderer/extensions/ai-suggestions/store.ts
@@ -34,6 +34,13 @@ interface SuggestionPersistenceState {
 
   /** Delete suggestions from IndexedDB for a document */
   deleteSuggestions: (documentId: string) => Promise<void>
+
+  /**
+   * Snapshot live suggestions into memory so they survive an HMR remount.
+   * Called by Editor's cleanup on unmount; the existing restoreAISuggestions
+   * useEffect picks them up on the next mount without touching IndexedDB.
+   */
+  snapshotSuggestions: (documentId: string, suggestions: AISuggestionData[]) => void
 }
 
 export const useSuggestionStore = create<SuggestionPersistenceState>((set, get) => ({
@@ -86,5 +93,16 @@ export const useSuggestionStore = create<SuggestionPersistenceState>((set, get) 
     if (state.documentId === documentId) {
       set({ pendingSuggestions: [] })
     }
+  },
+
+  snapshotSuggestions: (documentId: string, suggestions: AISuggestionData[]) => {
+    if (suggestions.length === 0) return
+
+    console.log('[SuggestionStore] Snapshotting live suggestions for HMR replay:', {
+      documentId,
+      count: suggestions.length
+    })
+
+    set({ documentId, pendingSuggestions: suggestions })
   }
 }))


### PR DESCRIPTION
## Summary

- On HMR, TipTap's editor is reconstructed from `document.content` in the store, which never has pending suggestion marks — those are applied post-mount and never written back. This caused suggestions to silently disappear on any renderer file touch during dev.
- Implements **option 2** from the issue: replay from the suggestion store on mount. On Editor cleanup (HMR unmount), a new `snapshotSuggestions()` action captures the live marks from ProseMirror into `useSuggestionStore.pendingSuggestions`. The existing `restoreAISuggestions` `useEffect` (already present for the tab-switch case) picks them up on the next mount and calls `restoreAISuggestions()`.
- No IndexedDB writes, no autosave pipeline interaction — it's a pure in-memory snapshot that lives only for the duration of the HMR cycle.

## Why option 2 over option 1

Option 1 (persist marks back to `document.content` before remount) would serialize the marked-up document into the store's content field, entangling the autosave pipeline and potentially persisting internal mark state to disk. Option 2 reuses the existing store + restore machinery already used for tab switches — the blast radius is two small, well-scoped changes.

## Guards against double-apply and stale data

- **Double-apply**: `clearSuggestions()` is called inside the existing restore `useEffect` immediately after replay, so the snapshot is consumed once.
- **Stale data**: `restoreAISuggestions` searches for `suggestion.originalText` in the document before applying. If the text changed (e.g., the user edited between HMR cycles), the search fails and the suggestion is skipped with a `console.warn` — no crash, no silent corruption.

## How to verify (dev-only repro)

1. `npm run dev`
2. Open a document with some text
3. Use the chat agent to request an edit (or run `suggest_edit` via MCP) — a pending suggestion highlight appears
4. Do NOT accept it
5. Touch any renderer file: `echo >> src/renderer/index.css`
6. Vite HMR fires → the suggestion highlight **survives** (was lost before this fix)
7. Accept/reject works normally after restore

## Files changed

- `src/renderer/extensions/ai-suggestions/store.ts` — adds `snapshotSuggestions()` action (in-memory only, no IndexedDB)
- `src/renderer/components/editor/Editor.tsx` — adds snapshot call in editor-instance registration effect cleanup

Closes #531

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>