### PR TITLE
fix(editor/chat): live cursor position, instant word count, guard comment/suggestion removal

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -346,6 +346,12 @@ export function Editor() {
         const text = editor.state.doc.textBetween(from, to)
         useEditorStore.getState().setLastSelection({ text, from, to })
       }
+
+      // Update cursor position for status bar (#564)
+      const headPos = editor.state.selection.$head.pos
+      const textBefore = editor.state.doc.textBetween(0, headPos, '\n')
+      const lines = textBefore.split('\n')
+      useEditorStore.getState().setCursorPosition(lines.length, (lines[lines.length - 1]?.length ?? 0) + 1)
     }
 
     editor.on('selectionUpdate', handleSelectionUpdate)

--- a/src/renderer/components/layout/StatusBar.tsx
+++ b/src/renderer/components/layout/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useRef, useState } from 'react'
+import { useMemo, useEffect, useRef, useState, useCallback } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { useSettings } from '../../hooks/useSettings'
 import { useChat } from '../../hooks/useChat'
@@ -81,11 +81,29 @@ export function StatusBar() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, editor?.state.doc])
 
-  const wordCount = document.content
-    .split(/\s+/)
-    .filter((word) => word.length > 0).length
+  // Live word/char count from editor state, not debounced store (#563)
+  const [wordCount, setWordCount] = useState(0)
+  const [charCount, setCharCount] = useState(0)
 
-  const charCount = document.content.length
+  const updateCounts = useCallback(() => {
+    if (editor) {
+      const doc = editor.state.doc
+      const text = doc.textBetween(0, doc.content.size, '\n')
+      setCharCount(text.length)
+      setWordCount(text.split(/\s+/).filter((w) => w.length > 0).length)
+    } else {
+      const text = document.content
+      setCharCount(text.length)
+      setWordCount(text.split(/\s+/).filter((w) => w.length > 0).length)
+    }
+  }, [editor, document.content])
+
+  useEffect(() => {
+    updateCounts()
+    if (!editor) return
+    editor.on('update', updateCounts)
+    return () => { editor.off('update', updateCounts) }
+  }, [editor, updateCounts])
 
   // Mode configuration.
   // ToolMode union renamed to chat / editor / create in #467 Chunk 3.

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -505,9 +505,9 @@ export function useChat() {
   }, [])
 
   const sendMessage = useCallback(
-    async (content: string, options?: { hidden?: boolean }) => {
+    async (content: string, options?: { hidden?: boolean }): Promise<boolean> => {
       console.log('[useChat] sendMessage called with:', content?.substring(0, 50), 'isLoading:', isLoading)
-      if (!content.trim() || isLoading) return
+      if (!content.trim() || isLoading) return false
       console.log('[useChat] sendMessage passed initial check')
       // Read toolMode fresh from the store rather than relying on the
       // React-closure-captured value. Necessary because callers (notably
@@ -531,7 +531,7 @@ export function useChat() {
           content: 'AI features are not enabled. Enable them in Settings → LLM to use the assistant.',
           timestamp: new Date()
         })
-        return
+        return false
       }
 
       // Validate config first
@@ -546,7 +546,7 @@ export function useChat() {
           content: `${configError}. Please configure your API settings (Cmd+,).`,
           timestamp: new Date()
         })
-        return
+        return false
       }
       console.log('[useChat] Config validated successfully')
 
@@ -694,6 +694,7 @@ export function useChat() {
         completeStreaming()
         clearStreamRefs()
       }
+      return true
     },
     [
       context,
@@ -746,12 +747,11 @@ export function useChat() {
     // Build the prompt from comments
     const commentsPrompt = buildCommentsPrompt(comments)
 
-    // Send the message (this will trigger agent mode to apply edits)
-    await sendMessage(commentsPrompt)
-
-    // Remove all comments after sending (they'll be processed by AI)
-    // We do this immediately since the user triggered "Process Comments"
-    editor.commands.unsetAllComments()
+    // Only remove comments if the message was actually dispatched to the AI (#631)
+    const dispatched = await sendMessage(commentsPrompt)
+    if (dispatched) {
+      editor.commands.unsetAllComments()
+    }
   }, [sendMessage])
 
   // Process a single comment by id — same prompt shape as processComments,
@@ -764,8 +764,10 @@ export function useChat() {
     if (!target) return
 
     const commentsPrompt = buildCommentsPrompt([target])
-    await sendMessage(commentsPrompt)
-    editor.commands.unsetComment(commentId)
+    const dispatched = await sendMessage(commentsPrompt)
+    if (dispatched) {
+      editor.commands.unsetComment(commentId)
+    }
   }, [sendMessage])
 
   // Helper to get current comment count
@@ -785,14 +787,13 @@ export function useChat() {
     // Build the prompt from suggestions with feedback
     const feedbackPrompt = buildSuggestionRepliesPrompt(suggestionsWithFeedback)
 
-    // Send the message (this will trigger agent mode to create new suggestions)
-    await sendMessage(feedbackPrompt)
-
-    // Remove the old suggestions after sending (they'll be replaced by new suggestions)
-    // We do this immediately since the user triggered "Process Feedback"
-    suggestionsWithFeedback.forEach((suggestion) => {
-      editor.commands.rejectAISuggestion(suggestion.id)
-    })
+    // Only remove suggestions if the message was actually dispatched to the AI (#631)
+    const dispatched = await sendMessage(feedbackPrompt)
+    if (dispatched) {
+      suggestionsWithFeedback.forEach((suggestion) => {
+        editor.commands.rejectAISuggestion(suggestion.id)
+      })
+    }
   }, [sendMessage])
 
   // Helper to get count of suggestions with pending feedback


### PR DESCRIPTION
## Summary

- **#564** — Status bar cursor position (Ln/Col) now updates live in WYSIWYG mode. Previously stuck at Ln 1, Col 1 because `setCursorPosition` was never called from TipTap's `selectionUpdate`.
- **#563** — Word and character counts update instantly on every keystroke. Previously lagged ~500ms because they derived from the debounced store value.
- **#631** — `sendMessage` now returns `boolean`. `processComments`, `processComment`, and `processSuggestionReplies` only remove marks/suggestions when the message was actually dispatched. Prevents silent data loss when AI is not configured.

## Test plan

- [ ] Open a document in WYSIWYG mode, click around / use arrow keys — Ln/Col in status bar should update in real time
- [ ] Type in the editor — word and character counts should update instantly (no visible delay)
- [ ] Add a comment (Cmd+Shift+A) without AI configured, click the comment mark, click Process — comment should be preserved
- [ ] Add an AI suggestion reply without AI configured, process feedback — suggestion should be preserved
- [ ] Verify counts work correctly across multiple paragraphs (word count should not merge words at block boundaries)

Closes #563, closes #564, closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)