### PR TITLE
docs(skills): sync roadmap skills with the roadmap doc + fix stale board column

### DIFF
--- a/.claude/skills/roadmap-prioritization/SKILL.md
+++ b/.claude/skills/roadmap-prioritization/SKILL.md
@@ -7,6 +7,10 @@ description: Analyze the project board and open issues to recommend what to work
 
 Read the project board and open issues, then recommend what to tackle next.
 
+## Read `docs/roadmap.md` first — and keep it in sync
+
+`docs/roadmap.md` is the canonical roadmap *narrative*: what we're building, the wave model, the track structure, and the A→B→C merge ladder. The [project board (#5)](https://github.com/orgs/solo-ist/projects/5/views/1) is the live *queue* (column = phase, milestone = wave). Ground every recommendation in the doc's sequencing — board order is the primary signal, but the doc explains *why* that order exists. **If you (with approval) move cards in a way that changes the narrative, reflect it in `docs/roadmap.md` in the same pass** so the two don't drift.
+
 ## Usage
 
 ```
@@ -26,6 +30,8 @@ gh project item-list 5 --owner solo-ist --format json --limit 500
 gh issue list --repo solo-ist/prose --state open --limit 200 --json number,title,labels,updatedAt,createdAt,comments,body,milestone
 gh pr list --repo solo-ist/prose --state open --limit 50 --json number,title,state,body,headRefName
 ```
+
+Also read the current `docs/roadmap.md` for the wave/track/merge-ladder context behind the board's ordering. If your worktree may be behind `main`, read the live version with `git show origin/main:docs/roadmap.md` after `git fetch origin`.
 
 Use `--jq` for data extraction instead of piping to external processors (e.g., `python3`, `jq`). This keeps each command as a single `gh` invocation that matches the Bash allowlist:
 
@@ -74,7 +80,7 @@ Apply these prioritization heuristics in order:
 2. **Bugs before features** — bugs degrade existing experience
 3. **Launch blockers first** — if release is approaching, these gate shipping
 4. **Quick wins pair well** — a small fix alongside a bigger feature maintains momentum
-5. **Logical sequencing** — does issue A unblock issue B? Do A first.
+5. **Logical sequencing** — does issue A unblock issue B? Do A first. The wave/track model and A→B→C merge ladder in `docs/roadmap.md` define much of this sequencing — follow it.
 6. **Avoid context-switching** — prefer issues in the same area of the codebase
 
 ### 5. Present Recommendations
@@ -133,6 +139,8 @@ gh project item-delete 5 --owner solo-ist --id <ITEM_ID>
 
 Never move items without explicit approval.
 
+**Keep the doc in sync:** If approved board moves change the roadmap narrative (re-sequencing a wave, promoting a track, retiring a shipped epic), edit `docs/roadmap.md` to match in the same change. That's a normal file edit on a branch — not a `gh project` operation.
+
 ## Dangerous Operations — DO NOT USE
 
 **NEVER use `updateProjectV2Field` to modify single-select field options.** This GraphQL mutation replaces option IDs, which silently disconnects every board item from its status — effectively wiping the entire board. This has happened before and required manual recovery.
@@ -146,4 +154,5 @@ If the board needs a new status column or option changes, tell the user to do it
 - **Pragmatic sequencing.** Prefer shipping a bug fix + quick win over starting a multi-day feature.
 - **Context-aware.** If there are open PRs or in-progress branches, factor that in.
 - **Opinionated but deferential.** Give a clear recommendation, but the user decides.
+- **The doc and the board move together.** `docs/roadmap.md` is the narrative behind the board's order; if approved moves change that narrative, update the doc in the same pass.
 - **Never mutate field definitions.** Only move items between existing columns.

--- a/.claude/skills/roadmap-prioritization/SKILL.md
+++ b/.claude/skills/roadmap-prioritization/SKILL.md
@@ -51,21 +51,22 @@ Group **open items only** by status column and present the current state:
 |--------|---------|
 | **User Requested** | Feature requests from users — needs triage into another column |
 | **Do First** | Highest priority — work on these now |
-| **In Progress** | Actively being worked on by a human or agent |
 | **Do Next** | Next up after current work completes |
 | **Later** | Backlog — not yet prioritized |
 | **Quick Wins** | Low-effort items that can ship alongside bigger work |
 | **On Hold** | Blocked or waiting on external factors |
 
+There is no "In Progress" column — detect in-flight work via open PRs and `issue-<number>-*` branches, not a board status.
+
 Flag any column imbalances:
 - "Do First" is empty → refill from "Do Next"
 - "Do First" is overloaded (5+ items) → suggest narrowing focus
-- "In Progress" has items with no recent activity → flag as potentially stale
+- In-flight work (an item with a linked open PR or `issue-<number>-*` branch) has gone quiet → flag as potentially stale
 - "User Requested" has untriaged items → flag for review
 
 ### 3. Assess Readiness
 
-For each item in "Do First", "In Progress", and "Do Next", evaluate:
+For each item in "Do First" and "Do Next", evaluate:
 
 - **Well-defined?** Has a description with clear scope, or needs decomposition
 - **Blocked?** Dependencies on other issues, external factors, or missing information
@@ -76,7 +77,7 @@ For each item in "Do First", "In Progress", and "Do Next", evaluate:
 
 Apply these prioritization heuristics in order:
 
-1. **Board order is primary signal** — "Do First" > "In Progress" > "Do Next" > "Quick Wins"
+1. **Board order is primary signal** — "Do First" > "Do Next" > "Quick Wins"
 2. **Bugs before features** — bugs degrade existing experience
 3. **Launch blockers first** — if release is approaching, these gate shipping
 4. **Quick wins pair well** — a small fix alongside a bigger feature maintains momentum
@@ -93,8 +94,7 @@ Output a structured recommendation:
 ### Board Overview
 | Column | Count | Notes |
 |--------|-------|-------|
-| Do First | 3 | All well-defined |
-| In Progress | 1 | #127 — active |
+| Do First | 3 | #127 has an open PR (in flight) |
 | Do Next | 4 | #55 needs decomposition |
 | Quick Wins | 3 | Ready to ship |
 | ... | | |

--- a/.claude/skills/roadmap-refinement/SKILL.md
+++ b/.claude/skills/roadmap-refinement/SKILL.md
@@ -47,7 +47,7 @@ For each open issue, check if it's likely completed:
 
 - **Linked merged PRs**: Issue referenced in a merged PR's body or commit messages
 - **Closed branches**: An `issue-<number>-*` branch exists but the issue is open
-- **Stale "In Progress"**: On the board as In Progress but no activity in 30+ days
+- **Stale in-flight work**: A linked open PR or `issue-<number>-*` branch exists but the issue has had no activity in 30+ days (may have been quietly merged or abandoned)
 
 Flag these as candidates for closing. Do NOT close automatically.
 
@@ -140,13 +140,12 @@ Current status options on the Prose Roadmap board:
 |--------|---------|
 | **User Requested** | Feature requests from users — needs triage |
 | **Do First** | Highest priority — work on these now |
-| **In Progress** | Actively being worked on by a human or agent |
 | **Do Next** | Next up after current work completes |
 | **Later** | Backlog — not yet prioritized |
 | **Quick Wins** | Low effort, high value — ship alongside bigger work |
 | **On Hold** | Blocked or paused |
 
-There is **no Done/terminal column** — every option above is an active-work bucket. When an issue is closed or its PR merges, archive its board item (`gh project item-archive`); do not leave it sitting in an active column, and do not delete it.
+There is **no Done/terminal column** — every option above is an active-work bucket — and **no "In Progress" column**; track in-flight work via open PRs and `issue-<number>-*` branches, not a board status. When an issue is closed or its PR merges, archive its board item (`gh project item-archive`); do not leave it sitting in an active column, and do not delete it.
 
 ## Dangerous Operations — DO NOT USE
 

--- a/.claude/skills/roadmap-refinement/SKILL.md
+++ b/.claude/skills/roadmap-refinement/SKILL.md
@@ -7,6 +7,10 @@ description: Audit open issues and project board. Flags done-but-open issues, bo
 
 Audit the backlog and project board, then present findings for approval before making changes.
 
+## Keep `docs/roadmap.md` in sync
+
+`docs/roadmap.md` is the canonical roadmap *narrative* — what we're building, the wave model, the track structure, and the A→B→C merge ladder. The [project board (#5)](https://github.com/orgs/solo-ist/projects/5/views/1) is the live *queue* (column = phase, milestone = wave). **These two must stay consistent.** Board cleanup that changes the narrative — an epic completes, a wave's scope shifts because issues were closed or superseded, track sequencing changes — must be reflected in `docs/roadmap.md` in the *same* pass, or the doc silently drifts out of date. Read the doc before auditing; propose doc edits alongside the board edits.
+
 ## Usage
 
 ```
@@ -26,6 +30,8 @@ gh issue list --repo solo-ist/prose --state open --limit 200 --json number,title
 gh pr list --repo solo-ist/prose --state all --limit 200 --json number,title,state,mergedAt,body,headRefName,closedAt
 gh project item-list 5 --owner solo-ist --format json --limit 500
 ```
+
+Also read the current `docs/roadmap.md` — it is the narrative the board should match, so you can flag where the two have drifted. If your worktree may be behind `main`, read the live version with `git show origin/main:docs/roadmap.md` after `git fetch origin`.
 
 Use `--jq` for data extraction instead of piping to external processors (e.g., `python3`, `jq`). This keeps each command as a single `gh` invocation that matches the Bash allowlist:
 
@@ -85,10 +91,16 @@ Output a structured report:
 |---|-------|---------------|----------------|
 | 30 | Old feature | 2025-10-01 | Close or re-prioritize |
 
+### Roadmap Doc Updates (`docs/roadmap.md`)
+| Section | Drift | Proposed Edit |
+|---------|-------|---------------|
+| Wave 1 / Track B | #312 shipped but still listed as in-flight | Move to "shipped" / retire from active wave |
+
 ### Summary
 - X issues ready to close
 - X board items need status updates
 - X stale issues to review
+- X `docs/roadmap.md` sections need updating to match the board
 ```
 
 ### 6. Execute on Approval
@@ -117,6 +129,8 @@ gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> --field-id <STATUS
 ```bash
 gh project item-add 5 --owner solo-ist --url <ISSUE_URL>
 ```
+
+**Updating the roadmap narrative:** When approved board changes alter the roadmap (an epic completes, a wave's scope shifts, sequencing changes), edit `docs/roadmap.md` in the same pass so the narrative and the board stay consistent. This is a normal file edit — commit it on a branch / open a PR; it is *not* a `gh project` operation. Don't archive a completed epic's board items without also retiring it from the doc's active waves.
 
 ## Board Columns
 
@@ -153,4 +167,5 @@ Safe operations are limited to:
 - **Board is source of truth for priority.** If an issue isn't on the board, it's not prioritized.
 - **Stale != irrelevant.** Flag staleness, but let the user decide disposition.
 - **Done items are archived, not deleted.** There is no Done column — archive closed/merged items off the active board with `item-archive` (reversible). Don't leave them in an active column; don't `item-delete` them.
+- **The doc and the board move together.** `docs/roadmap.md` is the narrative; board #5 is the queue. Any cleanup that changes the narrative gets reflected in the doc in the same pass — never let the doc drift behind the board.
 - **Never mutate field definitions.** Only move items between existing columns.


### PR DESCRIPTION
## Summary

Updates both roadmap skills so they treat **`docs/roadmap.md` as the canonical narrative** (waves, tracks, A→B→C merge ladder) that must stay in sync with **board #5, the live queue** — and removes references to an **"In Progress" column that doesn't exist** on the board.

## Keep the roadmap doc in sync

Board roadmapping activity (cleanup, prioritization, card moves) can silently drift the narrative doc out of date. Both skills now:

- **Read `docs/roadmap.md`** during Gather State (with a `git show origin/main:docs/roadmap.md` fallback for stale worktrees).
- **Reflect narrative-changing board edits back into the doc in the same pass** — clarified as a normal file edit on a branch, *not* a `gh project` op.
- Gained a matching **key principle** ("the doc and the board move together").
- `roadmap-refinement` also reports doc drift in its findings table + summary.
- `roadmap-prioritization` anchors its sequencing heuristic on the doc's wave/track model.

## Fix stale "In Progress" column

Board #5's Status options are **User Requested, Do First, Do Next, Later, Quick Wins, On Hold** — there is no "In Progress" column (confirmed via `gh project field-list 5`). Both skills referenced it, which would have produced wrong board maps and a never-matching staleness check. In-flight work is now tracked via **open PRs and `issue-<number>-*` branches**, not a board status. Updated the column tables, prioritization readiness scope / ordering heuristic / report example, and the refinement done-but-open signal, plus a clarifying note in each skill.

## Notes

- Skills are runtime-loaded markdown — no build/restart needed.
- Aligns with `CLAUDE.md`, which already documents the six columns and the doc/board relationship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)