### PR TITLE
feat(ai): harden every AI entry point when no LLM is configured (#635)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ Zustand stores in `src/renderer/stores/`:
 - `summaryStore` - AI-generated document summaries, staleness tracking
 - `commandHistoryStore` - Per-tool argument history, persisted to IndexedDB
 - `linkHoverStore` - Currently hovered link URL for tooltip
+- `notificationStore` - Bespoke in-app toasts (the app uses no toast library; rendered by `components/layout/Notifications.tsx`)
 
 ### Feature Flags
 
@@ -244,6 +245,8 @@ Client-side persistence uses IndexedDB (`src/renderer/lib/persistence.ts`). When
 **Anthropic is the only provider.** All legacy multi-provider code (OpenAI, OpenRouter, Ollama) has been removed. The `Settings` type defines `provider: 'anthropic'` only.
 
 LLM calls flow: `useChat` hook → `getApi().llmChatStream()` → IPC → main process → Anthropic SDK (with tools) or Vercel AI SDK (without)
+
+**Gating AI entry points:** any UI or background path that triggers an LLM call must gate on the single source of truth in `lib/llm.ts` — `isAIConfigured(settings)` / `aiAvailability(settings)` (consent **and** valid config), or the `useAIConfigured()` hook in components. Disable user-initiated controls with an explanation when unavailable, fire `notifyAINotConfigured()` for blocked actions whose surface may be hidden, and silently no-op auto-fired calls (e.g. summaries). Never destroy user content (comments, suggestions) on a blocked call.
 
 Tool pipeline, stream lifecycle, and tool modes: see `docs/architecture/llm-pipeline.md`.
 

--- a/src/renderer/components/CommentPopover.tsx
+++ b/src/renderer/components/CommentPopover.tsx
@@ -8,6 +8,8 @@ import { createPortal } from 'react-dom'
 import type { Editor } from '@tiptap/core'
 import { Trash2, X, Sparkles } from 'lucide-react'
 import { useChat } from '../hooks/useChat'
+import { useAIConfigured } from '../hooks/useAIConfigured'
+import { aiUnavailableMessage } from '../lib/llm'
 
 interface CommentPopoverProps {
   editor: Editor
@@ -30,6 +32,7 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
   const [adjustedPosition, setAdjustedPosition] = useState<{ x: number; y: number } | null>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const { processComment } = useChat()
+  const ai = useAIConfigured()
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
@@ -141,7 +144,11 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
       <div className="comment-label">Comment:</div>
       <div className="comment-text">{popover.commentText}</div>
       <div className="actions">
-        <button className="process-btn" onClick={handleProcess}>
+        <button
+          className="process-btn"
+          onClick={handleProcess}
+          disabled={!ai.available}
+        >
           <Sparkles size={16} />
           Process
         </button>
@@ -154,6 +161,9 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
           Close
         </button>
       </div>
+      {!ai.available && ai.reason && (
+        <div className="ai-hint">{aiUnavailableMessage(ai.reason)}</div>
+      )}
     </div>,
     document.body
   )

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -1,7 +1,11 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } from 'react'
 import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { Square, MessageSquare, ChevronRight, X, Sparkles } from 'lucide-react'
 import { useChat } from '../../hooks/useChat'
+import { useAIConfigured } from '../../hooks/useAIConfigured'
+import { aiUnavailableMessage } from '../../lib/llm'
+import { useSettingsStore } from '../../stores/settingsStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useChatStore, createMessageId } from '../../stores/chatStore'
@@ -126,6 +130,24 @@ interface ChatInputProps {
   onStop?: () => void
 }
 
+/**
+ * Wraps a (possibly disabled) control in a tooltip only when `tip` is set.
+ * The span trigger is needed because Radix tooltips don't fire hover events
+ * on disabled buttons. When `tip` is null, renders children unchanged so the
+ * normal (enabled) layout is untouched.
+ */
+function AIControl({ tip, children }: { tip: string | null; children: ReactNode }) {
+  if (!tip) return <>{children}</>
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="block w-full">{children}</span>
+      </TooltipTrigger>
+      <TooltipContent>{tip}</TooltipContent>
+    </Tooltip>
+  )
+}
+
 export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputProps) {
   const [message, setMessage] = useState('')
   const [commentCount, setCommentCount] = useState(0)
@@ -134,6 +156,8 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const { context, setContext, toolMode, processComments, getCommentCount, processSuggestionReplies, getSuggestionFeedbackCount, isInitializing } = useChat()
+  const ai = useAIConfigured()
+  const aiBlockedTip = !ai.available && ai.reason ? aiUnavailableMessage(ai.reason) : null
   const editor = useEditorInstanceStore((state) => state.editor)
   const { addArg, getRecentArgs, clearHistory } = useCommandHistoryStore()
 
@@ -733,32 +757,52 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
         </div>
       )}
 
+      {/* AI unavailable notice — ambient feedback that chat + AI actions are
+          off (the textarea stays enabled so local slash commands still work). */}
+      {aiBlockedTip && (
+        <div className="mb-2 flex items-center justify-between gap-2 rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+          <span className="min-w-0">{aiBlockedTip}</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 shrink-0 px-2 text-xs"
+            onClick={() => useSettingsStore.getState().setDialogOpen(true, 'llm')}
+          >
+            Open Settings
+          </Button>
+        </div>
+      )}
+
       {/* Process Comments button */}
       {commentCount > 0 && (
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={handleProcessComments}
-          disabled={isLoading}
-          className="mb-2 w-full justify-start gap-2"
-        >
-          <MessageSquare className="h-4 w-4" />
-          Process {commentCount} comment{commentCount !== 1 ? 's' : ''}
-        </Button>
+        <AIControl tip={aiBlockedTip}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleProcessComments}
+            disabled={isLoading || !ai.available}
+            className="mb-2 w-full justify-start gap-2"
+          >
+            <MessageSquare className="h-4 w-4" />
+            Process {commentCount} comment{commentCount !== 1 ? 's' : ''}
+          </Button>
+        </AIControl>
       )}
 
       {/* Process Suggestion Feedback button */}
       {suggestionFeedbackCount > 0 && (
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={handleProcessSuggestionFeedback}
-          disabled={isLoading}
-          className="mb-2 w-full justify-start gap-2 bg-purple-500/10 hover:bg-purple-500/20 border-purple-500/30"
-        >
-          <Sparkles className="h-4 w-4 text-purple-500" />
-          Process {suggestionFeedbackCount} suggestion feedback{suggestionFeedbackCount !== 1 ? 's' : ''}
-        </Button>
+        <AIControl tip={aiBlockedTip}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleProcessSuggestionFeedback}
+            disabled={isLoading || !ai.available}
+            className="mb-2 w-full justify-start gap-2 bg-purple-500/10 hover:bg-purple-500/20 border-purple-500/30"
+          >
+            <Sparkles className="h-4 w-4 text-purple-500" />
+            Process {suggestionFeedbackCount} suggestion feedback{suggestionFeedbackCount !== 1 ? 's' : ''}
+          </Button>
+        </AIControl>
       )}
 
       {/* Terminal-style input */}

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -14,7 +14,7 @@ import { MessageSquare, History, Plus, Trash2, Sparkles, Info, Loader2 } from 'l
 import { useChatStore } from '../../stores/chatStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
-import { useSettingsStore } from '../../stores/settingsStore'
+import { useAIConfigured } from '../../hooks/useAIConfigured'
 import { useReviewStore, useReviewMode } from '../../stores/reviewStore'
 import { useSummaryStore } from '../../stores/summaryStore'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
@@ -42,7 +42,7 @@ export function ChatPanel() {
 
   // Summary store
   const { summary, isGenerating, isStale, error, loadForDocument: loadSummary, generateSummary } = useSummaryStore()
-  const hasApiKey = useSettingsStore((s) => !!s.settings.llm.apiKey)
+  const aiAvailable = useAIConfigured().available
 
   // Reading time
   const wordCount = document.content.split(/\s+/).filter((w: string) => w.length > 0).length
@@ -58,13 +58,13 @@ export function ChatPanel() {
 
   // Auto-generate if panel is open and no summary or stale
   useEffect(() => {
-    if (!infoOpen || isGenerating || !hasApiKey) return
+    if (!infoOpen || isGenerating || !aiAvailable) return
     if (!summary || isStale) {
       const content = useEditorStore.getState().document.content
       if (!content?.trim()) return
       generateSummary(document.documentId, content)
     }
-  }, [infoOpen, summary, isStale, isGenerating, hasApiKey, document.documentId, generateSummary])
+  }, [infoOpen, summary, isStale, isGenerating, aiAvailable, document.documentId, generateSummary])
 
   // Listen for the "Switch & Run" button in request_mode_switch tool
   // results. Renderer dispatches a CustomEvent so it doesn't have to

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -17,6 +17,7 @@ import { ModelPickerDialog } from '../ModelPickerDialog'
 import { AIConsentDialog } from '../AIConsentDialog'
 import { EnableLoggingDialog } from '../EnableLoggingDialog'
 import { MigrationToast } from './MigrationToast'
+import { Notifications } from './Notifications'
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -990,6 +991,7 @@ export function App() {
         <AIConsentDialog />
         <EnableLoggingDialog />
         <MigrationToast />
+        <Notifications />
 
         {/* Google Docs Import Dialog */}
         <AlertDialog open={googleDocsEnabled && importDialogOpen} onOpenChange={(open) => {

--- a/src/renderer/components/layout/Notifications.tsx
+++ b/src/renderer/components/layout/Notifications.tsx
@@ -10,13 +10,15 @@ import { useNotificationStore, type AppNotification } from '../../stores/notific
  */
 function Toast({ notification }: { notification: AppNotification }) {
   const dismiss = useNotificationStore((s) => s.dismiss)
-  const { id, message, actionLabel, onAction, durationMs } = notification
+  const { id, message, actionLabel, onAction, durationMs, triggeredAt } = notification
 
+  // `triggeredAt` changes when an existing toast (same id) is re-triggered, so
+  // the timer restarts from the latest trigger instead of the first.
   useEffect(() => {
     if (!durationMs) return
     const timer = setTimeout(() => dismiss(id), durationMs)
     return () => clearTimeout(timer)
-  }, [id, durationMs, dismiss])
+  }, [id, durationMs, triggeredAt, dismiss])
 
   return (
     <div

--- a/src/renderer/components/layout/Notifications.tsx
+++ b/src/renderer/components/layout/Notifications.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from 'react'
+import { X } from 'lucide-react'
+import { Button } from '../ui/button'
+import { useNotificationStore, type AppNotification } from '../../stores/notificationStore'
+
+/**
+ * Renders the bespoke toast stack (see notificationStore). Mounted once near
+ * the app root. Matches MigrationToast's visual language; auto-dismiss timers
+ * live here so they tie to the mounted toast and clean up on unmount.
+ */
+function Toast({ notification }: { notification: AppNotification }) {
+  const dismiss = useNotificationStore((s) => s.dismiss)
+  const { id, message, actionLabel, onAction, durationMs } = notification
+
+  useEffect(() => {
+    if (!durationMs) return
+    const timer = setTimeout(() => dismiss(id), durationMs)
+    return () => clearTimeout(timer)
+  }, [id, durationMs, dismiss])
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-auto relative w-80 rounded-lg border border-border bg-popover text-popover-foreground shadow-lg p-4 animate-in fade-in slide-in-from-bottom-2"
+    >
+      <button
+        onClick={() => dismiss(id)}
+        aria-label="Dismiss"
+        className="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      <p className="text-sm leading-relaxed pr-5">{message}</p>
+      {actionLabel && (
+        <div className="mt-3 flex justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={() => dismiss(id)}>
+            Dismiss
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => {
+              onAction?.()
+              dismiss(id)
+            }}
+          >
+            {actionLabel}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function Notifications() {
+  const notifications = useNotificationStore((s) => s.notifications)
+  if (notifications.length === 0) return null
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      {notifications.map((notification) => (
+        <Toast key={notification.id} notification={notification} />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/hooks/useAIConfigured.ts
+++ b/src/renderer/hooks/useAIConfigured.ts
@@ -1,0 +1,19 @@
+import { useSettingsStore } from '../stores/settingsStore'
+import { validateConfig, type AIAvailability } from '../lib/llm'
+
+/**
+ * Reactive AI availability for components. Re-renders only when consent or
+ * LLM config validity actually changes (selects primitives, not a derived
+ * object, so it doesn't churn on unrelated settings updates). Use to
+ * disable/annotate AI controls and to choose the right "not available"
+ * message. For callbacks/stores outside React, call `aiAvailability(settings)`
+ * / `isAIConfigured(settings)` directly.
+ */
+export function useAIConfigured(): AIAvailability {
+  const consented = useSettingsStore((s) => Boolean(s.settings.aiConsent?.consented))
+  const configError = useSettingsStore((s) => validateConfig(s.settings.llm))
+
+  if (!consented) return { available: false, reason: 'no-consent' }
+  if (configError !== null) return { available: false, reason: 'no-config' }
+  return { available: true, reason: null }
+}

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -3,7 +3,8 @@ import { useChatStore, createMessageId, type ToolMode } from '../stores/chatStor
 import { useSettingsStore } from '../stores/settingsStore'
 import { useEditorStore } from '../stores/editorStore'
 import { useEditorInstanceStore } from '../stores/editorInstanceStore'
-import { validateConfig } from '../lib/llm'
+import { aiAvailability, aiUnavailableMessage } from '../lib/llm'
+import { notifyAINotConfigured } from '../lib/notifyAI'
 import { buildSystemPrompt, buildCommentsPrompt, buildSuggestionRepliesPrompt } from '../lib/prompts'
 import { getApi } from '../lib/browserApi'
 import { getComments } from '../extensions/comments'
@@ -522,33 +523,24 @@ export function useChat() {
         addConversation(document.documentId)
       }
 
-      // Check AI consent before making any API calls
-      if (!settings.aiConsent?.consented) {
-        const consentMsgId = createMessageId()
+      // Gate every AI request on the single availability check (consent +
+      // valid config). On a blocked path, record the reason in the chat AND
+      // fire a visible toast — the chat panel may be closed when this is
+      // triggered from a comment/suggestion action, which is the #631 gap
+      // where the user saw no feedback at all. Returning false lets callers
+      // (processComment/processComments/processSuggestionReplies) preserve the
+      // user's content instead of deleting it.
+      const availability = aiAvailability(settings)
+      if (!availability.available && availability.reason) {
         addMessage({
-          id: consentMsgId,
+          id: createMessageId(),
           role: 'assistant',
-          content: 'AI features are not enabled. Enable them in Settings → LLM to use the assistant.',
+          content: aiUnavailableMessage(availability.reason),
           timestamp: new Date()
         })
+        notifyAINotConfigured()
         return false
       }
-
-      // Validate config first
-      console.log('[useChat] Validating config:', settings.llm?.provider, settings.llm?.model)
-      const configError = validateConfig(settings.llm)
-      if (configError) {
-        console.log('[useChat] Config error:', configError)
-        const errorMsgId = createMessageId()
-        addMessage({
-          id: errorMsgId,
-          role: 'assistant',
-          content: `${configError}. Please configure your API settings (Cmd+,).`,
-          timestamp: new Date()
-        })
-        return false
-      }
-      console.log('[useChat] Config validated successfully')
 
       // Get context from store and clear it
       const messageContext = context

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -909,6 +909,25 @@
   background: hsl(var(--ai-action-hover));
 }
 
+.comment-popover .process-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Keep the disabled Process button from brightening on hover. */
+.comment-popover .process-btn:disabled:hover {
+  background: hsl(var(--ai-action));
+}
+
+/* "AI not configured" explainer shown in the popover when Process is disabled. */
+.comment-popover .ai-hint {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: hsl(var(--foreground));
+  opacity: 0.7;
+}
+
 .comment-popover .remove-btn {
   background: hsl(var(--comment-remove-btn));
   color: white;

--- a/src/renderer/lib/llm.ts
+++ b/src/renderer/lib/llm.ts
@@ -76,6 +76,44 @@ export function validateConfig(config: Settings['llm']): string | null {
   return null
 }
 
+/** Why AI can't be used right now, or `null` when it can. */
+export type AIUnavailableReason = 'no-consent' | 'no-config'
+
+export interface AIAvailability {
+  available: boolean
+  reason: AIUnavailableReason | null
+}
+
+/**
+ * Single source of truth for "can the app make an AI request right now."
+ * AI is available only when the user has consented to AI data disclosure
+ * AND the LLM config validates (model + API key present). Every AI entry
+ * point — chat send, comment/suggestion processing, auto-summaries — should
+ * gate on this instead of ad-hoc `!!apiKey` / `validateConfig` checks so they
+ * all agree on the same answer (and so the user gets one consistent message).
+ *
+ * Consent is requested by a launch-time modal independent of these controls,
+ * so gating on it here never traps a user: declining consent disables AI
+ * controls, and re-enabling lives in Settings.
+ */
+export function aiAvailability(settings: Settings): AIAvailability {
+  if (!settings.aiConsent?.consented) return { available: false, reason: 'no-consent' }
+  if (validateConfig(settings.llm) !== null) return { available: false, reason: 'no-config' }
+  return { available: true, reason: null }
+}
+
+/** Boolean convenience wrapper around {@link aiAvailability}. */
+export function isAIConfigured(settings: Settings): boolean {
+  return aiAvailability(settings).available
+}
+
+/** User-facing copy for why AI is unavailable. Used by tooltips and toasts. */
+export function aiUnavailableMessage(reason: AIUnavailableReason): string {
+  return reason === 'no-consent'
+    ? 'AI features are turned off. Enable them in Settings (⌘,) to use the assistant.'
+    : 'AI isn’t configured. Add an API key in Settings (⌘,) to use the assistant.'
+}
+
 /**
  * Comprehensive configuration validation with warnings.
  */

--- a/src/renderer/lib/notifyAI.ts
+++ b/src/renderer/lib/notifyAI.ts
@@ -1,0 +1,33 @@
+import { useNotificationStore } from '../stores/notificationStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { useChatStore } from '../stores/chatStore'
+import { aiAvailability, aiUnavailableMessage } from './llm'
+
+/** Fixed id so repeated triggers refresh one toast rather than stacking. */
+const AI_NOTIFICATION_ID = 'ai-not-configured'
+
+/**
+ * Fire a visible toast explaining why AI can't be used, with an action that
+ * opens Settings to the LLM tab. Call from any blocked user-initiated AI
+ * action so feedback shows regardless of chat-panel visibility (the original
+ * #631 gap — the only error landed in a panel that may be closed).
+ *
+ * No-ops when AI is actually available, so it's safe to call defensively.
+ */
+export function notifyAINotConfigured(): void {
+  const { settings } = useSettingsStore.getState()
+  const { available, reason } = aiAvailability(settings)
+  if (available || !reason) return
+
+  // When the chat panel is open, the inline notice + the assistant message
+  // already make this visible — a toast would be a redundant third copy. The
+  // toast is for the panel-closed case (the #631 "errors might've errored" gap).
+  if (useChatStore.getState().isPanelOpen) return
+
+  useNotificationStore.getState().notify({
+    id: AI_NOTIFICATION_ID,
+    message: aiUnavailableMessage(reason),
+    actionLabel: 'Open Settings',
+    onAction: () => useSettingsStore.getState().setDialogOpen(true, 'llm')
+  })
+}

--- a/src/renderer/stores/notificationStore.ts
+++ b/src/renderer/stores/notificationStore.ts
@@ -9,13 +9,16 @@ export interface AppNotification {
   onAction?: () => void
   /** ms before auto-dismiss. 0 / undefined keeps it until dismissed. */
   durationMs?: number
+  /** Stamp set on every show/refresh so the renderer can reset its dismiss
+   *  timer when an existing toast (same id) is re-triggered. Set internally. */
+  triggeredAt: number
 }
 
 interface NotificationState {
   notifications: AppNotification[]
   /** Show a toast. Returns its id. Passing an existing id refreshes that toast
-   *  in place instead of stacking a duplicate. */
-  notify: (n: Omit<AppNotification, 'id'> & { id?: string }) => string
+   *  in place (and resets its timer) instead of stacking a duplicate. */
+  notify: (n: Omit<AppNotification, 'id' | 'triggeredAt'> & { id?: string }) => string
   dismiss: (id: string) => void
 }
 
@@ -31,7 +34,12 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   notifications: [],
   notify: ({ id, durationMs, ...rest }) => {
     const notifId = id ?? `notif-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    const next: AppNotification = { id: notifId, durationMs: durationMs ?? DEFAULT_DURATION_MS, ...rest }
+    const next: AppNotification = {
+      id: notifId,
+      durationMs: durationMs ?? DEFAULT_DURATION_MS,
+      triggeredAt: Date.now(),
+      ...rest
+    }
     const exists = get().notifications.some((n) => n.id === notifId)
     set((s) => ({
       notifications: exists

--- a/src/renderer/stores/notificationStore.ts
+++ b/src/renderer/stores/notificationStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand'
+
+export interface AppNotification {
+  id: string
+  message: string
+  /** Optional action button label (e.g. "Open Settings"). */
+  actionLabel?: string
+  /** Invoked when the action button is clicked. The toast dismisses after. */
+  onAction?: () => void
+  /** ms before auto-dismiss. 0 / undefined keeps it until dismissed. */
+  durationMs?: number
+}
+
+interface NotificationState {
+  notifications: AppNotification[]
+  /** Show a toast. Returns its id. Passing an existing id refreshes that toast
+   *  in place instead of stacking a duplicate. */
+  notify: (n: Omit<AppNotification, 'id'> & { id?: string }) => string
+  dismiss: (id: string) => void
+}
+
+const DEFAULT_DURATION_MS = 6000
+
+/**
+ * Minimal in-app toast store. The app intentionally has no toast library
+ * (see MigrationToast); this is the bespoke equivalent for recurring,
+ * programmatic notifications — e.g. "AI not configured" feedback fired from
+ * any entry point regardless of chat-panel visibility.
+ */
+export const useNotificationStore = create<NotificationState>((set, get) => ({
+  notifications: [],
+  notify: ({ id, durationMs, ...rest }) => {
+    const notifId = id ?? `notif-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const next: AppNotification = { id: notifId, durationMs: durationMs ?? DEFAULT_DURATION_MS, ...rest }
+    const exists = get().notifications.some((n) => n.id === notifId)
+    set((s) => ({
+      notifications: exists
+        ? s.notifications.map((n) => (n.id === notifId ? next : n))
+        : [...s.notifications, next]
+    }))
+    return notifId
+  },
+  dismiss: (id) => set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) }))
+}))

--- a/src/renderer/stores/summaryStore.ts
+++ b/src/renderer/stores/summaryStore.ts
@@ -7,6 +7,7 @@ import {
 } from '../lib/persistence'
 import { useSettingsStore } from './settingsStore'
 import { getApi } from '../lib/browserApi'
+import { isAIConfigured } from '../lib/llm'
 
 interface SummaryState {
   summary: string | null
@@ -56,8 +57,11 @@ export const useSummaryStore = create<SummaryState>()((set, get) => ({
     if (!content || content.trim().length === 0) return
     if (get().isGenerating) return
 
+    // Auto-fired on doc open from many call sites — silently no-op when AI
+    // isn't usable (no consent or no valid config) instead of firing a
+    // doomed request. Shared check so this agrees with every other entry point.
     const { settings } = useSettingsStore.getState()
-    if (!settings.llm.apiKey) return
+    if (!isAIConfigured(settings)) return
 
     set({ isGenerating: true, error: null, generatingForDocumentId: documentId })
 


### PR DESCRIPTION
## Summary

Completes the **original #631 ask** — a full audit so nothing breaks, and the user always sees feedback, when no LLM is configured. #632/#633 fixed only the comment-deletion symptom; the lone error message landed in the chat panel, invisible when the panel is closed (@robbylucia: *"errors might've errored"*).

## What changed

**Single source of truth** (`lib/llm.ts`): `aiAvailability(settings)` / `isAIConfigured(settings)` / `aiUnavailableMessage(reason)` — gate on consent **and** valid config. `useAIConfigured()` hook for components. Replaces three inconsistent ad-hoc checks (`validateConfig`, `!!apiKey`, `hasApiKey`).

**Disabled controls + explanation:**
- Comment **Process** (popover) — disabled with an inline hint.
- **Process all comments** / **process suggestion replies** buttons — disabled with a tooltip.

**Visible feedback regardless of surface:**
- Inline notice + **Open Settings** in the chat input when AI is off.
- A bespoke notification/toast store (the app has no toast lib — see `MigrationToast`) fires on a blocked send **when the chat panel is closed** (the #631 gap). Suppressed while the panel is open to avoid a triple message (assistant message + inline notice + toast).

**No data loss:** comments/suggestions preserved on blocked sends (baseline from #633, now standardized).

**Auto-fired calls** (`summaryStore.generateSummary`, fired on doc open) now no-op via the shared check — previously keyed on `apiKey` alone, ignoring consent.

## QA

Verified against an **isolated profile** (`--user-data-dir`, fresh = no key/no consent) so no real settings were touched:
- ✅ Comment popover: Process disabled + hint shown; Remove/Close still work.
- ✅ Chat panel: inline "AI isn't configured… Open Settings" notice; "Process N comment" button disabled.
- ✅ Blocked send with panel closed → toast bottom-right; with panel open → no toast (just notice + assistant message).
- ✅ Comment preserved after a blocked process attempt.

Type-checked (changed files) and full `npm run build` green.

## Verification steps (configured path / regression)

1. `npm run dev` (running locally) with your API key configured.
2. Open the chat, send a message → works as before; no inline notice, no toast.
3. Add a comment (⌘⇧A) and click **Process** → processes normally.

Closes #635
Refs #631
