### PR TITLE
fix(editor): annotation toggle requires full selection coverage (#642)

### DIFF
--- a/src/renderer/components/editor/SelectionPopover.tsx
+++ b/src/renderer/components/editor/SelectionPopover.tsx
@@ -3,8 +3,39 @@ import { Editor } from '@tiptap/react'
 import { NodeSelection } from '@tiptap/pm/state'
 import { MessageSquarePlus, Bot, Bold, Italic, Link, Code } from 'lucide-react'
 import { Button } from '../ui/button'
-import { useAnnotationStore, getAnnotationsInRange } from '../../extensions/ai-annotations'
+import { useAnnotationStore } from '../../extensions/ai-annotations'
 import { useEditorStore } from '../../stores/editorStore'
+
+/**
+ * Whether the range [from, to) is *fully* covered by AI annotation(s).
+ *
+ * The toggle reflects "is the selected text annotated?", which is a coverage
+ * question — every character of the selection must lie within an annotation.
+ * The previous check used a loose any-overlap test, so a neighbouring
+ * annotation that merely reached into the selection (e.g. a prior edit's
+ * annotation whose mapped range overlaps the selected span) lit the button up
+ * for text that wasn't itself annotated. Requiring full coverage means an
+ * un-annotated selection — even adjacent to or partially overlapping an
+ * annotation — reads as not annotated, and toggling no longer trims a
+ * neighbour's annotation across the span.
+ */
+function isRangeFullyAnnotated(
+  annotations: { from: number; to: number }[],
+  from: number,
+  to: number
+): boolean {
+  if (from >= to) return false
+  const overlapping = annotations
+    .filter((a) => a.from < to && a.to > from)
+    .sort((a, b) => a.from - b.from)
+  let cursor = from
+  for (const a of overlapping) {
+    if (a.from > cursor) return false // uncovered gap before this annotation
+    cursor = Math.max(cursor, a.to)
+    if (cursor >= to) return true
+  }
+  return cursor >= to
+}
 
 interface SelectionPopoverProps {
   editor: Editor | null
@@ -22,7 +53,7 @@ export function SelectionPopover({ editor, onAddComment, onToggleLink }: Selecti
 
   // Check if current selection has an AI annotation
   const hasAIAnnotation = selectionRange
-    ? getAnnotationsInRange(annotations, selectionRange.from, selectionRange.to).length > 0
+    ? isRangeFullyAnnotated(annotations, selectionRange.from, selectionRange.to)
     : false
 
   const updatePosition = useCallback(() => {


### PR DESCRIPTION
Found during the Wave 0 HITL-QA sweep on `release/wave-0`.

## Symptom
Selecting text that has **no** AI annotation shows the AI-annotation toggle (the Bot button in the selection popover) in the active / "annotated" state. Clicking it operates across the whole selection, and the provenance/reason surfaced belongs to a *nearby* annotation (e.g. the last AI edit in an adjacent paragraph). Toggling off trims that neighbour's annotation across the selected span.

## Root cause
`src/renderer/components/editor/SelectionPopover.tsx` computed `hasAIAnnotation` with a loose any-overlap test:

```ts
getAnnotationsInRange(annotations, from, to).length > 0   // a.from < to && a.to > from
```

AI annotations are inline decorations driven by the store's `from`/`to`. Any annotation whose range overlaps the selection by even one character — including one whose mapped range reaches into the selected span from an edit elsewhere — lit the toggle up. The remove path (`removeAnnotationsInRange`) used the same loose predicate, so toggling off trimmed the overlapping neighbour across the span.

## Status
**Pre-existing** — `SelectionPopover.tsx` and `ai-annotations/store.ts` are byte-identical to `main`, so this reproduces on `main` too. Wave 0's #572 (annotation preservation on edits) can *amplify* it by leaving more annotations whose mapped ranges overlap adjacent text, which is how it surfaced during QA.

## Fix
Make the toggle reflect "is the **selected text** annotated?" as a *coverage* question — the selection must be fully covered by annotation(s) — rather than merely touched. Scoped to `SelectionPopover.tsx`; the shared `getAnnotationsInRange` is left untouched (it backs legitimate overlap/decoration lookups elsewhere). Verified via live HMR on `release/wave-0`: the toggle now reads inactive on unannotated text and active on annotated text.

---
Verified via live HMR on release/wave-0 during the Wave 0 QA sweep (toggle reads inactive on unannotated text, active on annotated text).

Closes #642