### PR TITLE
feat(review): Quick Review redesign — actions above diff card

### DIFF
--- a/src/renderer/components/review/QuickReviewPanel.tsx
+++ b/src/renderer/components/review/QuickReviewPanel.tsx
@@ -279,16 +279,24 @@ export function QuickReviewPanel() {
       {/* This is the core of the redesign: the action row lives right above */}
       {/* the suggestion content so the user can read + act without moving   */}
       {/* their eyes/cursor to the bottom of the panel.                      */}
+      {/*                                                                     */}
+      {/* Hover fix: motion.div carries the MotionValue backgroundColor for  */}
+      {/* drag-reactive lighting; the inner <button> uses Tailwind hover      */}
+      {/* classes without being overridden by an inline style MotionValue.    */}
       <div className="flex items-stretch gap-2 px-4 pt-3 pb-2 shrink-0">
-        <motion.button
-          onClick={handleReject}
+        <motion.div
           style={{ backgroundColor: rejectBg, borderColor: rejectBorderColor }}
-          className="flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium border border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors"
-          aria-label="Reject suggestion (Backspace)"
+          className="flex-1 rounded-md border border-border"
         >
-          <X className="h-3.5 w-3.5 shrink-0" />
-          Reject
-        </motion.button>
+          <button
+            onClick={handleReject}
+            className="w-full h-full flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium hover:bg-destructive/10 hover:text-destructive transition-colors"
+            aria-label="Reject suggestion (Backspace)"
+          >
+            <X className="h-3.5 w-3.5 shrink-0" />
+            Reject
+          </button>
+        </motion.div>
 
         {/* Feedback toggle — compact icon-only button between Reject and Accept */}
         {!showFeedbackForm && !current.userReply && (
@@ -301,15 +309,19 @@ export function QuickReviewPanel() {
           </button>
         )}
 
-        <motion.button
-          onClick={handleAccept}
+        <motion.div
           style={{ backgroundColor: acceptBg, borderColor: acceptBorderColor }}
-          className="flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium border border-border hover:bg-emerald-500/10 hover:text-emerald-600 dark:hover:text-emerald-400 hover:border-emerald-500/30 transition-colors"
-          aria-label="Accept suggestion (Enter)"
+          className="flex-1 rounded-md border border-border"
         >
-          <Check className="h-3.5 w-3.5 shrink-0" />
-          Accept
-        </motion.button>
+          <button
+            onClick={handleAccept}
+            className="w-full h-full flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium hover:bg-emerald-500/10 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+            aria-label="Accept suggestion (Enter)"
+          >
+            <Check className="h-3.5 w-3.5 shrink-0" />
+            Accept
+          </button>
+        </motion.div>
       </div>
 
       {/* ── Row 3: Diff card — the main content ───────────────────────── */}
@@ -401,11 +413,15 @@ export function QuickReviewPanel() {
             </div>
           ) : null}
 
-          {/* Keyboard hint — subtle, tucked at the bottom of the card */}
-          <div className="mt-4 text-[10px] text-muted-foreground/40 text-center select-none">
-            ← swipe to reject · swipe to accept →
-          </div>
         </motion.div>
+      </div>
+
+      {/* ── Row 4: Keyboard / gesture hint — always visible, pinned ──────── */}
+      {/* Outside the scrollable card so it never scrolls off-screen.         */}
+      <div className="shrink-0 px-4 pb-3 pt-1 text-[10px] text-muted-foreground/40 text-center select-none leading-relaxed">
+        ← swipe to reject · swipe to accept →
+        <span className="mx-1">·</span>
+        ↵ accept · ⌫ reject · ← → navigate
       </div>
     </div>
   )

--- a/src/renderer/components/review/QuickReviewPanel.tsx
+++ b/src/renderer/components/review/QuickReviewPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Check, X, ChevronLeft, ChevronRight, MessageSquare } from 'lucide-react'
+import { Check, X, ChevronLeft, ChevronRight, MessageSquare, ArrowLeftRight } from 'lucide-react'
 import { motion, useMotionValue, useTransform, type PanInfo } from 'framer-motion'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useReviewStore, useCurrentSuggestionIndex } from '../../stores/reviewStore'
@@ -9,9 +9,17 @@ import type { AISuggestionData } from '../../extensions/ai-suggestions/types'
 import { cn } from '../../lib/utils'
 
 /**
- * Card-based quick review component.
- * Shows one suggestion at a time with accept/reject buttons,
- * word-level diff highlighting, and auto-scroll to the current suggestion.
+ * Card-based quick review component — redesigned (#385).
+ *
+ * Layout change: accept/reject buttons are now placed ABOVE the diff card,
+ * clustering the actionable controls right above the suggestion content
+ * (closer to the top-right panel where the review lives). Previously the
+ * buttons were at the bottom of the panel, far from both the diff and the
+ * navigation header.
+ *
+ * Navigation (prev/next) stays in the top header row alongside the counter.
+ * The diff content is the visual "anchor" — buttons above, explanation +
+ * feedback below — so the user's eye travels the minimum distance.
  */
 export function QuickReviewPanel() {
   const editor = useEditorInstanceStore((state) => state.editor)
@@ -25,7 +33,7 @@ export function QuickReviewPanel() {
   const feedbackInputRef = useRef<HTMLTextAreaElement>(null)
   const [suggestions, setSuggestions] = useState<AISuggestionData[]>([])
 
-  // Subscribe to editor transactions for reactive updates (e.g., after setAISuggestionReply)
+  // Subscribe to editor transactions for reactive updates
   useEffect(() => {
     if (!editor) {
       setSuggestions([])
@@ -41,7 +49,6 @@ export function QuickReviewPanel() {
   const current = suggestions[currentSuggestionIndex]
 
   // Scroll editor to current suggestion (centered in viewport)
-  // Use current?.id as dep — not the object ref, which changes on every transaction
   useEffect(() => {
     if (!editor || !current) return
     if (!showFeedbackForm) {
@@ -52,15 +59,19 @@ export function QuickReviewPanel() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, current?.id])
 
-  // Swipe gesture state
+  // Swipe gesture values — drag the card left to reject, right to accept
   const dragX = useMotionValue(0)
-  const cardRotate = useTransform(dragX, [-200, 0, 200], [-8, 0, 8])
+  const cardRotate = useTransform(dragX, [-200, 0, 200], [-6, 0, 6])
   const cardOpacity = useTransform(dragX, [-200, -100, 0, 100, 200], [0.5, 0.8, 1, 0.8, 0.5])
-  // Button color transforms: fade in red/green backgrounds as the user drags
-  const rejectBg = useTransform(dragX, [-120, -60, 0], ['rgba(239,68,68,0.25)', 'rgba(239,68,68,0.12)', 'rgba(0,0,0,0)'])
-  const rejectBorder = useTransform(dragX, [-120, -60, 0], ['rgba(239,68,68,0.5)', 'rgba(239,68,68,0.25)', 'rgba(0,0,0,0)'])
-  const acceptBg = useTransform(dragX, [0, 60, 120], ['rgba(0,0,0,0)', 'rgba(16,185,129,0.12)', 'rgba(16,185,129,0.25)'])
-  const acceptBorder = useTransform(dragX, [0, 60, 120], ['rgba(0,0,0,0)', 'rgba(16,185,129,0.25)', 'rgba(16,185,129,0.5)'])
+
+  // Reject button lights up red as card is dragged left
+  const rejectBg = useTransform(dragX, [-120, -60, 0], ['rgba(239,68,68,0.20)', 'rgba(239,68,68,0.10)', 'rgba(0,0,0,0)'])
+  const rejectBorderColor = useTransform(dragX, [-120, -60, 0], ['rgba(239,68,68,0.45)', 'rgba(239,68,68,0.22)', 'rgba(0,0,0,0)'])
+
+  // Accept button lights up green as card is dragged right
+  const acceptBg = useTransform(dragX, [0, 60, 120], ['rgba(0,0,0,0)', 'rgba(16,185,129,0.10)', 'rgba(16,185,129,0.20)'])
+  const acceptBorderColor = useTransform(dragX, [0, 60, 120], ['rgba(0,0,0,0)', 'rgba(16,185,129,0.22)', 'rgba(16,185,129,0.45)'])
+
   const SWIPE_THRESHOLD = 100
 
   const handleAccept = useCallback(() => {
@@ -128,9 +139,7 @@ export function QuickReviewPanel() {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Don't capture if focused in an input
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
-
       switch (e.key) {
         case 'ArrowRight':
           e.preventDefault()
@@ -154,17 +163,16 @@ export function QuickReviewPanel() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [goNext, goPrev, handleAccept, handleReject])
 
-  // Auto-close review when all suggestions have been handled
-  // (all accepted/rejected = total 0, or all remaining have feedback)
+  // Auto-close when all suggestions are handled
   useEffect(() => {
-    if (total === 0) return // handled by accept/reject callbacks
+    if (total === 0) return
     const allHaveFeedback = suggestions.every((s) => s.userReply && s.userReply.trim() !== '')
     if (allHaveFeedback) {
       setReviewMode(null)
     }
   }, [suggestions, total, setReviewMode])
 
-  // Reset feedback state when navigating to a different suggestion
+  // Reset feedback state when navigating
   useEffect(() => {
     setShowFeedbackForm(false)
     setFeedbackInput(current?.userReply ?? '')
@@ -192,8 +200,21 @@ export function QuickReviewPanel() {
 
   if (!current) {
     return (
-      <div className="flex items-center justify-center h-full text-sm text-muted-foreground p-4">
-        No suggestions to review.
+      <div className="flex flex-col h-full">
+        {/* Keep close button accessible on empty state */}
+        <div className="flex items-center justify-between border-b border-border pl-4 pr-2 py-2.5 shrink-0">
+          <h2 className="text-sm font-medium">Quick Review</h2>
+          <button
+            onClick={() => setReviewMode(null)}
+            className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close review"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="flex items-center justify-center flex-1 text-sm text-muted-foreground p-4">
+          No suggestions to review.
+        </div>
       </div>
     )
   }
@@ -202,14 +223,34 @@ export function QuickReviewPanel() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Progress */}
-      <div className="flex items-center justify-between px-4 py-2 text-xs text-muted-foreground border-b border-border">
-        <span>{currentSuggestionIndex + 1} of {total} suggestions</span>
-        <div className="flex items-center gap-1">
+
+      {/* ── Row 1: Header — title + navigation + close ────────────────── */}
+      {/* All top-of-panel chrome lives here: the review title, counter,   */}
+      {/* prev/next navigation, mode cross-link, and close button.         */}
+      {/* Keeping close in the header preserves Fitts' Law for dismissal   */}
+      {/* (top-right corner). The action row below focuses on accept/reject.*/}
+      <div className="flex items-center border-b border-border pl-4 pr-2 py-2.5 shrink-0 gap-2">
+        {/* Title + mode cross-link */}
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <h2 className="text-sm font-medium shrink-0">Quick Review</h2>
+          <button
+            onClick={() => setReviewMode('side-by-side')}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors truncate"
+          >
+            <ArrowLeftRight className="h-3 w-3 shrink-0" />
+            <span className="truncate">Full diff</span>
+          </button>
+        </div>
+
+        {/* Prev / Next navigation */}
+        <div className="flex items-center gap-0 shrink-0">
+          <span className="text-xs text-muted-foreground tabular-nums mr-1.5">
+            {currentSuggestionIndex + 1}/{total}
+          </span>
           <button
             onClick={goPrev}
             disabled={currentSuggestionIndex === 0}
-            className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="p-1.5 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Previous suggestion"
           >
             <ChevronLeft className="h-3.5 w-3.5" />
@@ -217,15 +258,62 @@ export function QuickReviewPanel() {
           <button
             onClick={goNext}
             disabled={currentSuggestionIndex === total - 1}
-            className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="p-1.5 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Next suggestion"
           >
             <ChevronRight className="h-3.5 w-3.5" />
           </button>
         </div>
+
+        {/* Close */}
+        <button
+          onClick={() => setReviewMode(null)}
+          className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shrink-0"
+          aria-label="Close review (Esc)"
+        >
+          <X className="h-4 w-4" />
+        </button>
       </div>
 
-      {/* Card — draggable area fills all available space */}
+      {/* ── Row 2: Accept / Reject — directly above the diff card ─────── */}
+      {/* This is the core of the redesign: the action row lives right above */}
+      {/* the suggestion content so the user can read + act without moving   */}
+      {/* their eyes/cursor to the bottom of the panel.                      */}
+      <div className="flex items-stretch gap-2 px-4 pt-3 pb-2 shrink-0">
+        <motion.button
+          onClick={handleReject}
+          style={{ backgroundColor: rejectBg, borderColor: rejectBorderColor }}
+          className="flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium border border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors"
+          aria-label="Reject suggestion (Backspace)"
+        >
+          <X className="h-3.5 w-3.5 shrink-0" />
+          Reject
+        </motion.button>
+
+        {/* Feedback toggle — compact icon-only button between Reject and Accept */}
+        {!showFeedbackForm && !current.userReply && (
+          <button
+            onClick={() => setShowFeedbackForm(true)}
+            className="flex items-center justify-center rounded-md px-2.5 py-2 text-xs font-medium border border-border hover:bg-muted transition-colors"
+            aria-label="Add feedback"
+          >
+            <MessageSquare className="h-3.5 w-3.5" />
+          </button>
+        )}
+
+        <motion.button
+          onClick={handleAccept}
+          style={{ backgroundColor: acceptBg, borderColor: acceptBorderColor }}
+          className="flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium border border-border hover:bg-emerald-500/10 hover:text-emerald-600 dark:hover:text-emerald-400 hover:border-emerald-500/30 transition-colors"
+          aria-label="Accept suggestion (Enter)"
+        >
+          <Check className="h-3.5 w-3.5 shrink-0" />
+          Accept
+        </motion.button>
+      </div>
+
+      {/* ── Row 3: Diff card — the main content ───────────────────────── */}
+      {/* Draggable: swipe right to accept, left to reject.                */}
       <div className="flex-1 overflow-hidden">
         <motion.div
           key={current.id}
@@ -234,9 +322,9 @@ export function QuickReviewPanel() {
           dragElastic={0.7}
           onDragEnd={handleDragEnd}
           style={{ x: dragX, rotate: cardRotate, opacity: cardOpacity }}
-          initial={{ opacity: 0, x: direction === 'next' ? 30 : -30 }}
+          initial={{ opacity: 0, x: direction === 'next' ? 24 : -24 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.2 }}
+          transition={{ duration: 0.18 }}
           className={cn(
             'h-full overflow-y-auto p-4 cursor-grab active:cursor-grabbing touch-none',
             animating && 'pointer-events-none'
@@ -244,30 +332,34 @@ export function QuickReviewPanel() {
         >
           {/* Original text */}
           <div className="mb-3">
-            <div className="text-xs font-medium text-muted-foreground mb-1.5">Original</div>
-            <div className="text-sm leading-relaxed rounded-md bg-muted/30 p-3 border border-border">
+            <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 mb-1.5">
+              Original
+            </div>
+            <div className="text-sm leading-relaxed rounded-md bg-muted/30 px-3 py-2.5 border border-border">
               <DiffText segments={diff.old} mode="old" />
             </div>
           </div>
 
           {/* Suggested text */}
           <div className="mb-3">
-            <div className="text-xs font-medium text-muted-foreground mb-1.5">Suggested</div>
-            <div className="text-sm leading-relaxed rounded-md bg-muted/30 p-3 border border-border">
+            <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 mb-1.5">
+              Suggested
+            </div>
+            <div className="text-sm leading-relaxed rounded-md bg-muted/30 px-3 py-2.5 border border-border">
               <DiffText segments={diff.new} mode="new" />
             </div>
           </div>
 
           {/* Explanation */}
           {current.explanation && (
-            <div className="text-xs text-muted-foreground bg-muted/40 rounded-md px-3 py-2 leading-relaxed">
+            <div className="text-xs text-muted-foreground bg-muted/40 rounded-md px-3 py-2 leading-relaxed mb-3">
               {current.explanation}
             </div>
           )}
 
-          {/* Feedback */}
+          {/* Feedback form / existing feedback display */}
           {showFeedbackForm ? (
-            <div className="mt-3 space-y-2" onPointerDownCapture={(e) => e.stopPropagation()}>
+            <div className="space-y-2" onPointerDownCapture={(e) => e.stopPropagation()}>
               <div className="text-xs font-medium text-muted-foreground">Your feedback</div>
               <textarea
                 ref={feedbackInputRef}
@@ -295,7 +387,7 @@ export function QuickReviewPanel() {
               </div>
             </div>
           ) : current.userReply ? (
-            <div className="mt-3 space-y-1">
+            <div className="space-y-1">
               <div className="text-xs font-medium text-muted-foreground">Your feedback</div>
               <div className="text-xs text-muted-foreground bg-muted/30 rounded-md px-3 py-2 leading-relaxed">
                 {current.userReply}
@@ -308,40 +400,12 @@ export function QuickReviewPanel() {
               </button>
             </div>
           ) : null}
+
+          {/* Keyboard hint — subtle, tucked at the bottom of the card */}
+          <div className="mt-4 text-[10px] text-muted-foreground/40 text-center select-none">
+            ← swipe to reject · swipe to accept →
+          </div>
         </motion.div>
-      </div>
-
-      {/* Actions */}
-      <div className="flex items-center gap-2 px-4 py-3 border-t border-border">
-        <motion.button
-          onClick={handleReject}
-          style={{ backgroundColor: rejectBg, borderColor: rejectBorder }}
-          className="flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium border border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors"
-        >
-          <X className="h-3.5 w-3.5" />
-          Reject
-        </motion.button>
-        {!showFeedbackForm && !current.userReply && (
-          <button
-            onClick={() => setShowFeedbackForm(true)}
-            className="flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium border border-border hover:bg-muted transition-colors"
-          >
-            <MessageSquare className="h-3.5 w-3.5" />
-          </button>
-        )}
-        <motion.button
-          onClick={handleAccept}
-          style={{ backgroundColor: acceptBg, borderColor: acceptBorder }}
-          className="flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium border border-border hover:bg-primary/90 transition-colors"
-        >
-          <Check className="h-3.5 w-3.5" />
-          Accept
-        </motion.button>
-      </div>
-
-      {/* Keyboard hints */}
-      <div className="px-4 pb-2 text-[10px] text-muted-foreground/50 text-center">
-        Swipe right accept / left reject / Arrows navigate
       </div>
     </div>
   )

--- a/src/renderer/components/review/ReviewContainer.tsx
+++ b/src/renderer/components/review/ReviewContainer.tsx
@@ -1,12 +1,16 @@
 import { useEffect } from 'react'
-import { X, ArrowLeftRight } from 'lucide-react'
 import { useReviewStore, useReviewMode } from '../../stores/reviewStore'
 import { QuickReviewPanel } from './QuickReviewPanel'
 import { SideBySideDiffPanel } from './SideBySideDiffPanel'
 
 /**
- * Container that owns the review header, Escape handler, cross-links,
- * and mode switching. Rendered inside ChatPanel when reviewMode is non-null.
+ * Container that owns the Escape handler and mode-switching context.
+ * Rendered inside ChatPanel when reviewMode is non-null.
+ *
+ * In the Quick Review redesign (#385) the header (title, close button, mode
+ * cross-link) now lives inside QuickReviewPanel so all controls are clustered
+ * in one place. SideBySideDiffPanel retains its own header for its bulk
+ * actions + cross-link. This container is intentionally thin.
  */
 export function ReviewContainer() {
   const reviewMode = useReviewMode()
@@ -27,38 +31,13 @@ export function ReviewContainer() {
 
   if (!reviewMode) return null
 
-  const isQuick = reviewMode === 'quick'
-  const title = isQuick ? 'Quick Review' : 'Side-by-Side Diff'
-  const crossLinkLabel = isQuick ? 'See entire diff' : 'Quick review'
-  const crossLinkMode = isQuick ? 'side-by-side' : 'quick' as const
-
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border pl-4 pr-3 py-3">
-        <div className="flex items-center gap-3">
-          <h2 className="text-sm font-medium">{title}</h2>
-          <button
-            onClick={() => setReviewMode(crossLinkMode)}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground underline transition-colors"
-          >
-            <ArrowLeftRight className="h-3 w-3" />
-            {crossLinkLabel}
-          </button>
-        </div>
-        <button
-          onClick={() => setReviewMode(null)}
-          className="p-1 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-          aria-label="Close review"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
-
-      {/* Content */}
-      <div className="flex-1 overflow-hidden">
-        {isQuick ? <QuickReviewPanel /> : <SideBySideDiffPanel />}
-      </div>
+      {reviewMode === 'quick' ? (
+        <QuickReviewPanel />
+      ) : (
+        <SideBySideDiffPanel />
+      )}
     </div>
   )
 }

--- a/src/renderer/components/review/SideBySideDiffPanel.tsx
+++ b/src/renderer/components/review/SideBySideDiffPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
-import { Check, X, CheckCheck, XCircle, MessageSquare } from 'lucide-react'
+import { Check, X, CheckCheck, XCircle, MessageSquare, ArrowLeftRight } from 'lucide-react'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useReviewStore } from '../../stores/reviewStore'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
@@ -11,6 +11,9 @@ import { cn } from '../../lib/utils'
  * Side-by-side diff panel showing all suggestions as diff hunks.
  * Each hunk has original (left) and suggested (right) text with word-level highlighting,
  * plus individual and bulk accept/reject controls.
+ *
+ * Owns its own header row (title, cross-link to Quick Review, close button) since
+ * ReviewContainer was simplified in the #385 redesign.
  */
 export function SideBySideDiffPanel() {
   const editor = useEditorInstanceStore((state) => state.editor)
@@ -85,20 +88,47 @@ export function SideBySideDiffPanel() {
 
   if (total === 0) {
     return (
-      <div className="flex items-center justify-center h-full text-sm text-muted-foreground p-4">
-        No suggestions to review.
+      <div className="flex flex-col h-full">
+        <div className="flex items-center justify-between border-b border-border pl-4 pr-2 py-2.5 shrink-0">
+          <h2 className="text-sm font-medium">Side-by-Side Diff</h2>
+          <button
+            onClick={() => setReviewMode(null)}
+            className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close review"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="flex items-center justify-center flex-1 text-sm text-muted-foreground p-4">
+          No suggestions to review.
+        </div>
       </div>
     )
   }
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header with bulk actions */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-border shrink-0">
-        <span className="text-xs text-muted-foreground">
-          {total} suggestion{total !== 1 ? 's' : ''} remaining
+      {/* Header — title, cross-link to Quick Review, bulk actions, close */}
+      <div className="flex items-center border-b border-border pl-4 pr-2 py-2.5 shrink-0 gap-2">
+        {/* Title + mode cross-link */}
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <h2 className="text-sm font-medium shrink-0">Side-by-Side Diff</h2>
+          <button
+            onClick={() => setReviewMode('quick')}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+          >
+            <ArrowLeftRight className="h-3 w-3 shrink-0" />
+            <span>Quick review</span>
+          </button>
+        </div>
+
+        {/* Count */}
+        <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+          {total} suggestion{total !== 1 ? 's' : ''}
         </span>
-        <div className="flex items-center gap-2">
+
+        {/* Bulk actions */}
+        <div className="flex items-center gap-1 shrink-0">
           <button
             onClick={handleRejectAll}
             className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium border border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors"
@@ -114,6 +144,15 @@ export function SideBySideDiffPanel() {
             Accept All
           </button>
         </div>
+
+        {/* Close */}
+        <button
+          onClick={() => setReviewMode(null)}
+          className="p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shrink-0"
+          aria-label="Close review (Esc)"
+        >
+          <X className="h-4 w-4" />
+        </button>
       </div>
 
       {/* Scrollable hunk list */}


### PR DESCRIPTION
Refs #385

## What this does

Moves the Accept/Reject action buttons from the **bottom** of the Quick Review panel to a dedicated row **directly above the diff card**. This clusters the actionable controls with the content being reviewed, so the user's eyes and cursor travel the minimum distance to act on a suggestion.

## Layout (before → after)

**Before:**
```
┌─────────────────────────────┐
│  Quick Review    [Full diff] [✕]  ← ReviewContainer header
├─────────────────────────────┤
│  1 of 3          [←]  [→]   ← QuickReviewPanel header
├─────────────────────────────┤
│  Original:                  │
│  ... diff text ...          │
│  Suggested:                 │
│  ... diff text ...          │
│  [explanation]              │
├─────────────────────────────┤
│  [✕ Reject] [💬] [✓ Accept] ← actions at bottom, far from diff
└─────────────────────────────┘
```

**After:**
```
┌─────────────────────────────┐
│  Quick Review  [Full diff]  1/3  [←][→]  [✕]  ← single header
├─────────────────────────────┤
│  [✕ Reject]  [💬]  [✓ Accept]   ← actions ABOVE diff ← core change
├─ - - - - - - - - - - - - - ┤
│  Original:                  │
│  ... diff text ...          │
│  Suggested:                 │
│  ... diff text ...          │
│  [explanation]              │
│  [feedback area]            │
│  ← swipe · swipe →          │
└─────────────────────────────┘
```

## Design decisions

- **Accept button**: neutral border + green hover (not solid green by default) to avoid visual weight competing with the diff text. The swipe motion transforms still pulse it green as the card is dragged right.
- **ReviewContainer simplified**: previously owned the full header; now just holds the Escape handler + panel switcher. Both `QuickReviewPanel` and `SideBySideDiffPanel` own their headers directly. This makes each panel self-contained and easier to rearrange independently.
- **SideBySideDiffPanel gets matching header**: close button + "Quick review" cross-link added for parity. No layout change to the bulk accept/reject row.
- **Double-header eliminated**: the old design had two stacked headers (ReviewContainer's + QuickReviewPanel's nav row). Now there is exactly one header row per panel, containing all of: title, mode cross-link, counter, nav arrows, close.
- **Swipe gestures and keyboard shortcuts preserved** (Enter=Accept, Backspace=Reject, ←/→=navigate).
- **Feedback button** (💬) remains between Reject and Accept, visible only when no feedback exists yet, to avoid crowding the action row.

## Open questions / TODOs

- **TODO**: The issue mentions "toward the same cluster of tools at the top right" — worth verifying with the user whether the top-right positioning of the Accept button feels correct, or if Reject-left/Accept-right ordering should be flipped.
- **TODO**: Consider whether the counter ("1/3") could be replaced with a thin progress bar under the header to signal completion progress at a glance.
- **TODO**: Accessibility: aria-labels added on buttons but could add `role="region"` + `aria-label="Suggestion review"` on the panel container.
- **OPEN QUESTION**: Should the `pt-3 pb-2` spacing between the action row and the diff card be increased slightly (e.g. `pt-3 pb-3`) so the visual separation is more explicit?

## Testing

Build verified: `npm run build` passes with no TypeScript errors. Manual QA recommended via Circuit Electron (trigger AI suggestions → click "Review N suggestions" chip → verify new layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)