### PR TITLE
feat(files): Projects & Favorites first pass

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -83,7 +83,7 @@ const favoriteBookmarkStopFns = new Map<string, () => void>()
 function activateBookmark(bookmark: string | undefined, label: string): (() => void) | null {
   if (!IS_MAS_BUILD || !bookmark) return null
   try {
-    return app.startAccessingSecurityScopedResource(bookmark)
+    return app.startAccessingSecurityScopedResource(bookmark) as () => void
   } catch (err) {
     console.warn(`[settings:load] Security-scoped bookmark invalid (${label}):`, err)
     return null
@@ -586,6 +586,7 @@ export function setupIpcHandlers(): void {
       }
 
       // Restore security-scoped bookmarks for all projects (MAS only)
+      let staleBookmarksCleared = false
       if (IS_MAS_BUILD && Array.isArray(rawSettings.projects)) {
         // Stop any previously-activated project bookmark stop fns
         for (const [, stop] of projectBookmarkStopFns) {
@@ -603,6 +604,7 @@ export function setupIpcHandlers(): void {
             } else {
               // Bookmark invalid — keep the project but clear the stale bookmark
               validProjects.push({ ...project, bookmark: undefined })
+              staleBookmarksCleared = true
             }
           } else {
             validProjects.push(project)
@@ -626,13 +628,22 @@ export function setupIpcHandlers(): void {
               favoriteBookmarkStopFns.set(fav.id, stop)
               validFavorites.push(fav)
             } else {
+              // Bookmark invalid — keep the favorite but clear the stale bookmark
               validFavorites.push({ ...fav, bookmark: undefined })
+              staleBookmarksCleared = true
             }
           } else {
             validFavorites.push(fav)
           }
         }
         rawSettings.favorites = validFavorites
+      }
+
+      // Persist cleared stale bookmarks so the warning doesn't repeat on every launch
+      if (staleBookmarksCleared) {
+        try {
+          await writeFile(getSettingsPath(), JSON.stringify(rawSettings, null, 2), 'utf-8')
+        } catch { /* best effort */ }
       }
 
       return rawSettings

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -66,8 +66,29 @@ interface LLMStreamRequest extends LLMRequest {
 // Track active streams for abort support
 const activeStreams = new Map<string, AbortController>()
 
-// Security-scoped bookmark stop function (MAS sandbox)
+// Security-scoped bookmark stop function (MAS sandbox) — single bookmark for
+// the legacy `masDirectoryBookmark` / `defaultSaveDirectory` path.
 let stopAccessingBookmark: (() => void) | null = null
+
+// Stop-functions for project and favorite bookmarks, keyed by their UUID.
+// Populated in settings:load; torn down when a project/favorite is removed
+// (settings:save handles persistence; the stop fn is released on next load).
+const projectBookmarkStopFns = new Map<string, () => void>()
+const favoriteBookmarkStopFns = new Map<string, () => void>()
+
+/**
+ * Activate a security-scoped bookmark (MAS only) and return the stop function.
+ * Returns null if not a MAS build or bookmark is missing.
+ */
+function activateBookmark(bookmark: string | undefined, label: string): (() => void) | null {
+  if (!IS_MAS_BUILD || !bookmark) return null
+  try {
+    return app.startAccessingSecurityScopedResource(bookmark)
+  } catch (err) {
+    console.warn(`[settings:load] Security-scoped bookmark invalid (${label}):`, err)
+    return null
+  }
+}
 
 function getSettingsPath(): string { return join(getSettingsDir(), 'settings.json') }
 const ANTHROPIC_KEY_PATH = join(LEGACY_SETTINGS_DIR, '.remarkable-anthropic-key') // Legacy path for migration
@@ -562,6 +583,56 @@ export function setupIpcHandlers(): void {
             await writeFile(getSettingsPath(), JSON.stringify(rawSettings, null, 2), 'utf-8')
           } catch { /* best effort */ }
         }
+      }
+
+      // Restore security-scoped bookmarks for all projects (MAS only)
+      if (IS_MAS_BUILD && Array.isArray(rawSettings.projects)) {
+        // Stop any previously-activated project bookmark stop fns
+        for (const [, stop] of projectBookmarkStopFns) {
+          try { stop() } catch { /* best effort */ }
+        }
+        projectBookmarkStopFns.clear()
+
+        const validProjects = []
+        for (const project of rawSettings.projects) {
+          if (project.bookmark) {
+            const stop = activateBookmark(project.bookmark, `project:${project.id}`)
+            if (stop) {
+              projectBookmarkStopFns.set(project.id, stop)
+              validProjects.push(project)
+            } else {
+              // Bookmark invalid — keep the project but clear the stale bookmark
+              validProjects.push({ ...project, bookmark: undefined })
+            }
+          } else {
+            validProjects.push(project)
+          }
+        }
+        rawSettings.projects = validProjects
+      }
+
+      // Restore security-scoped bookmarks for all favorites (MAS only)
+      if (IS_MAS_BUILD && Array.isArray(rawSettings.favorites)) {
+        for (const [, stop] of favoriteBookmarkStopFns) {
+          try { stop() } catch { /* best effort */ }
+        }
+        favoriteBookmarkStopFns.clear()
+
+        const validFavorites = []
+        for (const fav of rawSettings.favorites) {
+          if (fav.bookmark) {
+            const stop = activateBookmark(fav.bookmark, `favorite:${fav.id}`)
+            if (stop) {
+              favoriteBookmarkStopFns.set(fav.id, stop)
+              validFavorites.push(fav)
+            } else {
+              validFavorites.push({ ...fav, bookmark: undefined })
+            }
+          } else {
+            validFavorites.push(fav)
+          }
+        }
+        rawSettings.favorites = validFavorites
       }
 
       return rawSettings

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -90,6 +90,20 @@ function activateBookmark(bookmark: string | undefined, label: string): (() => v
   }
 }
 
+/**
+ * Return a copy of settings with secrets (LLM API key, reMarkable device token)
+ * blanked, for safe persistence to plaintext settings.json. Secrets live in
+ * credentialStore; any write-back from settings:load (stale-bookmark cleanup,
+ * migrations) must strip them so they never land on disk. Mirrors settings:save.
+ */
+function stripSecretsForDisk(settings: Settings): Settings {
+  return {
+    ...settings,
+    llm: { ...settings.llm, apiKey: '' },
+    ...(settings.remarkable ? { remarkable: { ...settings.remarkable, deviceToken: '' } } : {}),
+  }
+}
+
 function getSettingsPath(): string { return join(getSettingsDir(), 'settings.json') }
 const ANTHROPIC_KEY_PATH = join(LEGACY_SETTINGS_DIR, '.remarkable-anthropic-key') // Legacy path for migration
 const REMARKABLE_CREDENTIAL_KEY = 'remarkable-anthropic-key'
@@ -534,7 +548,7 @@ export function setupIpcHandlers(): void {
         try {
           await credentialStore.set(LLM_API_KEY, rawSettings.llm.apiKey)
           rawSettings.llm = { ...rawSettings.llm, apiKey: '' }
-          await writeFile(getSettingsPath(), JSON.stringify(rawSettings, null, 2), 'utf-8')
+          await writeFile(getSettingsPath(), JSON.stringify(stripSecretsForDisk(rawSettings), null, 2), 'utf-8')
           console.log('[settings:load] Migrated plaintext API key to secure storage')
         } catch (err) {
           console.error('[settings:load] Migration failed:', err)
@@ -546,7 +560,7 @@ export function setupIpcHandlers(): void {
         try {
           await credentialStore.set(REMARKABLE_DEVICE_TOKEN, rawSettings.remarkable.deviceToken)
           rawSettings.remarkable = { ...rawSettings.remarkable, deviceToken: '' }
-          await writeFile(getSettingsPath(), JSON.stringify(rawSettings, null, 2), 'utf-8')
+          await writeFile(getSettingsPath(), JSON.stringify(stripSecretsForDisk(rawSettings), null, 2), 'utf-8')
           console.log('[settings:load] Migrated plaintext reMarkable device token to secure storage')
         } catch (err) {
           console.error('[settings:load] reMarkable token migration failed:', err)
@@ -580,7 +594,7 @@ export function setupIpcHandlers(): void {
           rawSettings.masDirectoryBookmark = undefined
           rawSettings.defaultSaveDirectory = undefined
           try {
-            await writeFile(getSettingsPath(), JSON.stringify(rawSettings, null, 2), 'utf-8')
+            await writeFile(getSettingsPath(), JSON.stringify(stripSecretsForDisk(rawSettings), null, 2), 'utf-8')
           } catch { /* best effort */ }
         }
       }
@@ -642,7 +656,7 @@ export function setupIpcHandlers(): void {
       // Persist cleared stale bookmarks so the warning doesn't repeat on every launch
       if (staleBookmarksCleared) {
         try {
-          await writeFile(getSettingsPath(), JSON.stringify(rawSettings, null, 2), 'utf-8')
+          await writeFile(getSettingsPath(), JSON.stringify(stripSecretsForDisk(rawSettings), null, 2), 'utf-8')
         } catch { /* best effort */ }
       }
 

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -90,14 +90,60 @@ export function FileListPanel() {
   const googleConnected = useSettingsStore((state) => googleDocsFlag && !!state.settings.google)
   const googleSyncDirectory = useSettingsStore((state) => state.settings.google?.syncDirectory)
   const projects = useProjects()
-  const { switchToProject, exitToRoot } = useProjectsStore()
+  const { exitToRoot } = useProjectsStore()
   const defaultSaveDirectory = useSettingsStore((s) => s.settings.defaultSaveDirectory)
   // The project whose folder contains the current view root (handles drill-down
   // into project subfolders). Base root and projects are separate, peer locations.
   const currentProject = projects.find(
     (p) => !!rootPath && (rootPath === p.path || rootPath.startsWith(p.path + '/'))
   ) ?? null
-  const baseFolderName = defaultSaveDirectory?.split('/').pop() || 'Home'
+
+  // Return from an open project to the Projects list (stay in the Projects panel).
+  const backToProjectsList = () => {
+    useSettingsStore.getState().setActiveProject(null)
+    setRootPath(defaultSaveDirectory ?? null)
+    setViewMode('projects')
+  }
+
+  // Responsive header: measure the (stable) header width and spill overflowing
+  // view-toggles into a ··· menu when there isn't room for all of them inline.
+  const headerRef = useRef<HTMLDivElement>(null)
+  const [headerWidth, setHeaderWidth] = useState(0)
+  useEffect(() => {
+    const el = headerRef.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setHeaderWidth(e.contentRect.width)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  // View toggles in priority order (earliest stay inline longest).
+  const viewToggles = [
+    {
+      key: 'folder', Icon: Folder, label: 'Files', active: viewMode === 'folder',
+      onClick: () => {
+        if (currentProject) exitToRoot()
+        else if (viewMode === 'folder') loadFiles()
+        else setViewMode('folder')
+      },
+    },
+    { key: 'projects', Icon: Boxes, label: 'Projects', active: viewMode === 'projects', onClick: () => setViewMode('projects') },
+    { key: 'favorites', Icon: Star, label: 'Favorites', active: viewMode === 'favorites', onClick: () => setViewMode('favorites') },
+    { key: 'recent', Icon: History, label: 'Recent files', active: viewMode === 'recent', onClick: () => setViewMode('recent') },
+    ...(googleConnected ? [{ key: 'googledocs', Icon: Globe, label: 'Google Docs', active: viewMode === 'googledocs', onClick: () => setViewMode('googledocs') }] : []),
+    ...(remarkableEnabled ? [{ key: 'notebooks', Icon: BookOpen, label: 'reMarkable notebooks', active: viewMode === 'notebooks', onClick: () => setViewMode('notebooks') }] : []),
+  ]
+  const TOGGLE_PX = 36 // 32px button + 4px gap
+  // Title gets a real min-width: shown at >=120px, otherwise hidden entirely
+  // (rather than shrinking to a sliver) so the toggles collapse into ··· sooner.
+  const showHeaderTitle = headerWidth === 0 || headerWidth >= 192
+  const toggleBudget = headerWidth > 0 ? headerWidth - (showHeaderTitle ? 120 : 0) : Infinity
+  const maxInlineToggles = Math.max(1, Math.floor(toggleBudget / TOGGLE_PX))
+  const togglesOverflow = viewToggles.length > maxInlineToggles
+  const inlineToggles = togglesOverflow ? viewToggles.slice(0, maxInlineToggles - 1) : viewToggles
+  const overflowToggles = togglesOverflow ? viewToggles.slice(maxInlineToggles - 1) : []
 
   // Switch away from notebooks view if reMarkable becomes disconnected
   useEffect(() => {
@@ -945,56 +991,25 @@ export function FileListPanel() {
   return (
     <div ref={containerRef} className="flex h-full flex-col bg-muted/20" data-testid="file-list-panel" tabIndex={-1}>
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <div className="flex items-center gap-2">
-          {viewMode === 'folder' && projects.length > 0 ? (
+      <div ref={headerRef} className="flex items-center gap-2 border-b border-border px-4 py-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          {showHeaderTitle && (viewMode === 'projects' && currentProject ? (
             <div className="flex min-w-0 items-center gap-1">
-              {currentProject && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 shrink-0"
-                      onClick={() => exitToRoot()}
-                      aria-label="Back to root folder"
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Back to root folder</TooltipContent>
-                </Tooltip>
-              )}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    className="flex min-w-0 items-center gap-1 rounded px-1 py-0.5 hover:bg-muted/50"
-                    title={currentProject?.path ?? rootPath ?? undefined}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 shrink-0"
+                    onClick={backToProjectsList}
+                    aria-label="Back to projects"
                   >
-                    <span className="truncate text-sm font-medium">{currentProject ? currentProject.name : folderName}</span>
-                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start">
-                  <DropdownMenuItem
-                    className={cn(!currentProject && "bg-muted")}
-                    onClick={() => exitToRoot()}
-                  >
-                    <Folder className="h-4 w-4 mr-2 shrink-0" />
-                    <span className="truncate">{baseFolderName}</span>
-                  </DropdownMenuItem>
-                  {projects.map((p) => (
-                    <DropdownMenuItem
-                      key={p.id}
-                      className={cn(p.id === currentProject?.id && "bg-muted")}
-                      onClick={() => switchToProject(p.id)}
-                    >
-                      <Boxes className="h-4 w-4 mr-2 shrink-0" />
-                      <span className="truncate">{p.name}</span>
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Back to projects</TooltipContent>
+              </Tooltip>
+              <span className="truncate text-sm font-medium" title={currentProject.path}>{currentProject.name}</span>
             </div>
           ) : (
             <h2 className="text-sm font-medium truncate" title={viewMode === 'folder' ? rootPath || undefined : undefined}>
@@ -1005,7 +1020,7 @@ export function FileListPanel() {
                 : viewMode === 'favorites' ? 'Favorites'
                 : folderName}
             </h2>
-          )}
+          ))}
           {viewMode === 'notebooks' && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -1056,108 +1071,50 @@ export function FileListPanel() {
             </Tooltip>
           )}
         </div>
-        <div className="flex items-center gap-1">
-          {/* View toggle buttons */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn("h-8 w-8", viewMode === 'recent' && "bg-muted")}
-                onClick={() => setViewMode('recent')}
-                aria-label="Recent files"
-              >
-                <History className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Recent files</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn("h-8 w-8", viewMode === 'folder' && "bg-muted")}
-                onClick={() => {
-                  if (currentProject) {
-                    exitToRoot()
-                  } else if (viewMode === 'folder') {
-                    loadFiles()
-                  } else {
-                    setViewMode('folder')
-                  }
-                }}
-                aria-label="Files"
-              >
-                <Folder className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Files</TooltipContent>
-          </Tooltip>
-          {(googleConnected || remarkableEnabled) && (
+        <div className="flex shrink-0 items-center gap-1">
+          {/* View toggles — responsive: overflow into a ··· menu when narrow */}
+          {inlineToggles.map((t) => (
+            <Tooltip key={t.key}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={cn("h-8 w-8", t.active && "bg-muted")}
+                  onClick={t.onClick}
+                  aria-label={t.label}
+                >
+                  <t.Icon className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t.label}</TooltipContent>
+            </Tooltip>
+          ))}
+          {overflowToggles.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={cn("h-8 w-8", (viewMode === 'googledocs' || viewMode === 'notebooks') && "bg-muted")}
-                  aria-label="More sources"
+                  className={cn("h-8 w-8", overflowToggles.some((t) => t.active) && "bg-muted")}
+                  aria-label="More views"
                 >
                   <MoreHorizontal className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {googleConnected && (
+                {overflowToggles.map((t) => (
                   <DropdownMenuItem
-                    className={cn(viewMode === 'googledocs' && "bg-muted")}
-                    onClick={() => setViewMode('googledocs')}
+                    key={t.key}
+                    className={cn(t.active && "bg-muted")}
+                    onClick={t.onClick}
                   >
-                    <Globe className="h-4 w-4 mr-2" />
-                    Google Docs
+                    <t.Icon className="h-4 w-4 mr-2" />
+                    {t.label}
                   </DropdownMenuItem>
-                )}
-                {remarkableEnabled && (
-                  <DropdownMenuItem
-                    className={cn(viewMode === 'notebooks' && "bg-muted")}
-                    onClick={() => setViewMode('notebooks')}
-                  >
-                    <BookOpen className="h-4 w-4 mr-2" />
-                    reMarkable notebooks
-                  </DropdownMenuItem>
-                )}
+                ))}
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          {/* Projects view */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn("h-8 w-8", viewMode === 'projects' && "bg-muted")}
-                onClick={() => setViewMode('projects')}
-                aria-label="Projects"
-              >
-                <Boxes className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Projects</TooltipContent>
-          </Tooltip>
-          {/* Favorites view */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn("h-8 w-8", viewMode === 'favorites' && "bg-muted")}
-                onClick={() => setViewMode('favorites')}
-                aria-label="Favorites"
-              >
-                <Star className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Favorites</TooltipContent>
-          </Tooltip>
         </div>
       </div>
 
@@ -1193,7 +1150,7 @@ export function FileListPanel() {
 
       {/* Content */}
       <ScrollArea className="flex-1">
-        {viewMode === 'projects' ? (
+        {viewMode === 'projects' && !currentProject ? (
           <ProjectsPanel mode="projects" />
         ) : viewMode === 'favorites' ? (
           <ProjectsPanel mode="favorites" />

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -102,7 +102,10 @@ export function FileListPanel() {
     (p) => !!rootPath && (rootPath === p.path || rootPath.startsWith(p.path + '/'))
   ) ?? null
 
-  // Return from an open project to the Projects list (stay in the Projects panel).
+  // Return from an open project to the Projects list — deliberately stays in the
+  // 'projects' panel (unlike projectsStore.exitToRoot, which clears the active
+  // project AND drops to the 'folder' base-root navigator). Both clear the active
+  // project; the difference is which panel you land in.
   const backToProjectsList = () => {
     useSettingsStore.getState().setActiveProject(null)
     setRootPath(defaultSaveDirectory ?? null)

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -25,6 +25,12 @@ import {
   ContextMenuTrigger
 } from '../ui/context-menu'
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -34,14 +40,14 @@ import {
 } from '../ui/dialog'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug, Boxes, Star } from 'lucide-react'
+import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronLeft, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug, Boxes, Star, MoreHorizontal } from 'lucide-react'
 import { useSettings } from '../../hooks/useSettings'
 import { cn } from '../../lib/utils'
 import { getApi } from '../../lib/browserApi'
 import { requestBugReport } from '../EnableLoggingDialog'
 import type { RemarkableNotebookMetadata, RemarkableCloudNotebook, GoogleDocEntry } from '../../types'
 import { ProjectsPanel } from './ProjectsPanel'
-import { useActiveProject } from '../../stores/projectsStore'
+import { useProjects, useProjectsStore } from '../../stores/projectsStore'
 
 export function FileListPanel() {
   const {
@@ -83,7 +89,15 @@ export function FileListPanel() {
   const remarkableEnabled = useSettingsStore((state) => remarkableFlag && state.settings.remarkable?.enabled && !!state.settings.remarkable?.deviceToken)
   const googleConnected = useSettingsStore((state) => googleDocsFlag && !!state.settings.google)
   const googleSyncDirectory = useSettingsStore((state) => state.settings.google?.syncDirectory)
-  const activeProject = useActiveProject()
+  const projects = useProjects()
+  const { switchToProject, exitToRoot } = useProjectsStore()
+  const defaultSaveDirectory = useSettingsStore((s) => s.settings.defaultSaveDirectory)
+  // The project whose folder contains the current view root (handles drill-down
+  // into project subfolders). Base root and projects are separate, peer locations.
+  const currentProject = projects.find(
+    (p) => !!rootPath && (rootPath === p.path || rootPath.startsWith(p.path + '/'))
+  ) ?? null
+  const baseFolderName = defaultSaveDirectory?.split('/').pop() || 'Home'
 
   // Switch away from notebooks view if reMarkable becomes disconnected
   useEffect(() => {
@@ -248,6 +262,33 @@ export function FileListPanel() {
     setOperationError(null)
     setNewFileDialogOpen(true)
   }
+
+  // Add a path to the persisted pointer list (folders → projects/favorites,
+  // files → favorites). Idempotent: dedup by path so re-adding is a no-op.
+  const addPathAsProject = useCallback((path: string) => {
+    const existing = useSettingsStore.getState().settings.projects ?? []
+    if (existing.some((p) => p.path === path)) return
+    const name = path.split('/').pop() || path
+    useSettingsStore.getState().addProject({
+      id: self.crypto.randomUUID(),
+      name,
+      path,
+      createdAt: new Date().toISOString(),
+    })
+  }, [])
+
+  const addPathAsFavorite = useCallback((path: string, isDirectory: boolean) => {
+    const existing = useSettingsStore.getState().settings.favorites ?? []
+    if (existing.some((f) => f.path === path)) return
+    const name = path.split('/').pop() || path
+    useSettingsStore.getState().addFavorite({
+      id: self.crypto.randomUUID(),
+      name,
+      path,
+      isDirectory,
+      addedAt: new Date().toISOString(),
+    })
+  }, [])
 
   const handleCreateNewFile = async () => {
     const targetDir = newFileTargetDir || rootPath
@@ -906,15 +947,65 @@ export function FileListPanel() {
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-2">
-          <h2 className="text-sm font-medium truncate" title={viewMode === 'folder' ? rootPath || undefined : undefined}>
-            {viewMode === 'recent' ? 'Recent'
-              : viewMode === 'notebooks' ? 'Notebooks'
-              : viewMode === 'googledocs' ? 'Google Docs'
-              : viewMode === 'projects' ? 'Projects'
-              : viewMode === 'favorites' ? 'Favorites'
-              : viewMode === 'folder' && activeProject ? activeProject.name
-              : folderName}
-          </h2>
+          {viewMode === 'folder' && projects.length > 0 ? (
+            <div className="flex min-w-0 items-center gap-1">
+              {currentProject && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 shrink-0"
+                      onClick={() => exitToRoot()}
+                      aria-label="Back to root folder"
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Back to root folder</TooltipContent>
+                </Tooltip>
+              )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className="flex min-w-0 items-center gap-1 rounded px-1 py-0.5 hover:bg-muted/50"
+                    title={currentProject?.path ?? rootPath ?? undefined}
+                  >
+                    <span className="truncate text-sm font-medium">{currentProject ? currentProject.name : folderName}</span>
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem
+                    className={cn(!currentProject && "bg-muted")}
+                    onClick={() => exitToRoot()}
+                  >
+                    <Folder className="h-4 w-4 mr-2 shrink-0" />
+                    <span className="truncate">{baseFolderName}</span>
+                  </DropdownMenuItem>
+                  {projects.map((p) => (
+                    <DropdownMenuItem
+                      key={p.id}
+                      className={cn(p.id === currentProject?.id && "bg-muted")}
+                      onClick={() => switchToProject(p.id)}
+                    >
+                      <Boxes className="h-4 w-4 mr-2 shrink-0" />
+                      <span className="truncate">{p.name}</span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          ) : (
+            <h2 className="text-sm font-medium truncate" title={viewMode === 'folder' ? rootPath || undefined : undefined}>
+              {viewMode === 'recent' ? 'Recent'
+                : viewMode === 'notebooks' ? 'Notebooks'
+                : viewMode === 'googledocs' ? 'Google Docs'
+                : viewMode === 'projects' ? 'Projects'
+                : viewMode === 'favorites' ? 'Favorites'
+                : folderName}
+            </h2>
+          )}
           {viewMode === 'notebooks' && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -988,7 +1079,9 @@ export function FileListPanel() {
                 size="icon"
                 className={cn("h-8 w-8", viewMode === 'folder' && "bg-muted")}
                 onClick={() => {
-                  if (viewMode === 'folder') {
+                  if (currentProject) {
+                    exitToRoot()
+                  } else if (viewMode === 'folder') {
                     loadFiles()
                   } else {
                     setViewMode('folder')
@@ -1001,54 +1094,39 @@ export function FileListPanel() {
             </TooltipTrigger>
             <TooltipContent>Files</TooltipContent>
           </Tooltip>
-          {googleConnected && (
-            <Tooltip>
-              <TooltipTrigger asChild>
+          {(googleConnected || remarkableEnabled) && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={cn("h-8 w-8", viewMode === 'googledocs' && "bg-muted")}
-                  onClick={() => {
-                    if (viewMode === 'googledocs') {
-                      googleSync().catch((err) => {
-                        console.error('[FileListPanel] Manual Google sync failed:', err)
-                      })
-                    } else {
-                      setViewMode('googledocs')
-                    }
-                  }}
-                  aria-label="Google Docs"
+                  className={cn("h-8 w-8", (viewMode === 'googledocs' || viewMode === 'notebooks') && "bg-muted")}
+                  aria-label="More sources"
                 >
-                  <Globe className="h-4 w-4" />
+                  <MoreHorizontal className="h-4 w-4" />
                 </Button>
-              </TooltipTrigger>
-              <TooltipContent>Google Docs</TooltipContent>
-            </Tooltip>
-          )}
-          {remarkableEnabled && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className={cn("h-8 w-8", viewMode === 'notebooks' && "bg-muted")}
-                  onClick={() => {
-                    console.log('[FileListPanel] notebooks button clicked, current viewMode:', viewMode)
-                    if (viewMode === 'notebooks') {
-                      sync().catch((err) => {
-                        console.error('[FileListPanel] Manual sync failed:', err)
-                      })
-                    } else {
-                      setViewMode('notebooks')
-                    }
-                  }}
-                  aria-label="reMarkable notebooks"
-                >
-                  <BookOpen className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>reMarkable notebooks</TooltipContent>
-            </Tooltip>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {googleConnected && (
+                  <DropdownMenuItem
+                    className={cn(viewMode === 'googledocs' && "bg-muted")}
+                    onClick={() => setViewMode('googledocs')}
+                  >
+                    <Globe className="h-4 w-4 mr-2" />
+                    Google Docs
+                  </DropdownMenuItem>
+                )}
+                {remarkableEnabled && (
+                  <DropdownMenuItem
+                    className={cn(viewMode === 'notebooks' && "bg-muted")}
+                    onClick={() => setViewMode('notebooks')}
+                  >
+                    <BookOpen className="h-4 w-4 mr-2" />
+                    reMarkable notebooks
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           {/* Projects view */}
           <Tooltip>
@@ -1057,7 +1135,7 @@ export function FileListPanel() {
                 variant="ghost"
                 size="icon"
                 className={cn("h-8 w-8", viewMode === 'projects' && "bg-muted")}
-                onClick={() => setViewMode(viewMode === 'projects' ? 'folder' : 'projects')}
+                onClick={() => setViewMode('projects')}
                 aria-label="Projects"
               >
                 <Boxes className="h-4 w-4" />
@@ -1072,7 +1150,7 @@ export function FileListPanel() {
                 variant="ghost"
                 size="icon"
                 className={cn("h-8 w-8", viewMode === 'favorites' && "bg-muted")}
-                onClick={() => setViewMode(viewMode === 'favorites' ? 'folder' : 'favorites')}
+                onClick={() => setViewMode('favorites')}
                 aria-label="Favorites"
               >
                 <Star className="h-4 w-4" />
@@ -1352,15 +1430,18 @@ export function FileListPanel() {
                     if (sourcePath && rootPath) handleFileDrop(sourcePath, rootPath)
                   }}
                 >
-                  {/* Parent directory navigation */}
-                  <button
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50 text-muted-foreground mb-1"
-                    onClick={navigateToParent}
-                    title="Go to parent folder"
-                  >
-                    <ChevronUp className="h-4 w-4 shrink-0" />
-                    <span className="truncate">..</span>
-                  </button>
+                  {/* Parent directory navigation — hidden at a project's root,
+                      which is the upward-traversal ceiling while in a project. */}
+                  {!(currentProject && rootPath === currentProject.path) && (
+                    <button
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50 text-muted-foreground mb-1"
+                      onClick={navigateToParent}
+                      title="Go to parent folder"
+                    >
+                      <ChevronUp className="h-4 w-4 shrink-0" />
+                      <span className="truncate">..</span>
+                    </button>
+                  )}
                   {/* New untitled document */}
                   <button
                     className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50 text-muted-foreground mb-1"
@@ -1398,6 +1479,8 @@ export function FileListPanel() {
                       onRenameComplete={handleRenameComplete}
                       onRenameCancel={handleRenameCancel}
                       onNewFile={handleNewFileInDir}
+                      onAddProject={addPathAsProject}
+                      onAddFavorite={addPathAsFavorite}
                       onFileDrop={handleFileDrop}
                     />
                   )}
@@ -1416,40 +1499,14 @@ export function FileListPanel() {
                 </ContextMenuItem>
                 <ContextMenuSeparator />
                 <ContextMenuItem
-                  onClick={async () => {
-                    const { useProjectsStore: ps } = await import('../../stores/projectsStore')
-                    // Add current root as a project without switching (already here)
-                    if (!rootPath) return
-                    const { useSettingsStore: ss } = await import('../../stores/settingsStore')
-                    const existing = ss.getState().settings.projects ?? []
-                    if (existing.some((p) => p.path === rootPath)) return
-                    const name = rootPath.split('/').pop() || rootPath
-                    ss.getState().addProject({
-                      id: self.crypto.randomUUID(),
-                      name,
-                      path: rootPath,
-                      createdAt: new Date().toISOString(),
-                    })
-                  }}
+                  onClick={() => rootPath && addPathAsProject(rootPath)}
                   disabled={!rootPath}
                 >
                   <Boxes className="h-4 w-4 mr-2" />
                   Add as Project
                 </ContextMenuItem>
                 <ContextMenuItem
-                  onClick={async () => {
-                    if (!rootPath) return
-                    const { useSettingsStore: ss } = await import('../../stores/settingsStore')
-                    const existing = ss.getState().settings.favorites ?? []
-                    if (existing.some((f) => f.path === rootPath)) return
-                    const name = rootPath.split('/').pop() || rootPath
-                    ss.getState().addFavorite({
-                      id: self.crypto.randomUUID(),
-                      name,
-                      path: rootPath,
-                      addedAt: new Date().toISOString(),
-                    })
-                  }}
+                  onClick={() => rootPath && addPathAsFavorite(rootPath, true)}
                   disabled={!rootPath}
                 >
                   <Star className="h-4 w-4 mr-2" />

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -34,12 +34,14 @@ import {
 } from '../ui/dialog'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug } from 'lucide-react'
+import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug, Boxes, Star } from 'lucide-react'
 import { useSettings } from '../../hooks/useSettings'
 import { cn } from '../../lib/utils'
 import { getApi } from '../../lib/browserApi'
 import { requestBugReport } from '../EnableLoggingDialog'
 import type { RemarkableNotebookMetadata, RemarkableCloudNotebook, GoogleDocEntry } from '../../types'
+import { ProjectsPanel } from './ProjectsPanel'
+import { useActiveProject } from '../../stores/projectsStore'
 
 export function FileListPanel() {
   const {
@@ -81,6 +83,7 @@ export function FileListPanel() {
   const remarkableEnabled = useSettingsStore((state) => remarkableFlag && state.settings.remarkable?.enabled && !!state.settings.remarkable?.deviceToken)
   const googleConnected = useSettingsStore((state) => googleDocsFlag && !!state.settings.google)
   const googleSyncDirectory = useSettingsStore((state) => state.settings.google?.syncDirectory)
+  const activeProject = useActiveProject()
 
   // Switch away from notebooks view if reMarkable becomes disconnected
   useEffect(() => {
@@ -904,7 +907,13 @@ export function FileListPanel() {
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-2">
           <h2 className="text-sm font-medium truncate" title={viewMode === 'folder' ? rootPath || undefined : undefined}>
-            {viewMode === 'recent' ? 'Recent' : viewMode === 'notebooks' ? 'Notebooks' : viewMode === 'googledocs' ? 'Google Docs' : folderName}
+            {viewMode === 'recent' ? 'Recent'
+              : viewMode === 'notebooks' ? 'Notebooks'
+              : viewMode === 'googledocs' ? 'Google Docs'
+              : viewMode === 'projects' ? 'Projects'
+              : viewMode === 'favorites' ? 'Favorites'
+              : viewMode === 'folder' && activeProject ? activeProject.name
+              : folderName}
           </h2>
           {viewMode === 'notebooks' && (
             <Tooltip>
@@ -1041,6 +1050,36 @@ export function FileListPanel() {
               <TooltipContent>reMarkable notebooks</TooltipContent>
             </Tooltip>
           )}
+          {/* Projects view */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn("h-8 w-8", viewMode === 'projects' && "bg-muted")}
+                onClick={() => setViewMode(viewMode === 'projects' ? 'folder' : 'projects')}
+                aria-label="Projects"
+              >
+                <Boxes className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Projects</TooltipContent>
+          </Tooltip>
+          {/* Favorites view */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn("h-8 w-8", viewMode === 'favorites' && "bg-muted")}
+                onClick={() => setViewMode(viewMode === 'favorites' ? 'folder' : 'favorites')}
+                aria-label="Favorites"
+              >
+                <Star className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Favorites</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -1076,7 +1115,11 @@ export function FileListPanel() {
 
       {/* Content */}
       <ScrollArea className="flex-1">
-        {viewMode === 'recent' ? (
+        {viewMode === 'projects' ? (
+          <ProjectsPanel mode="projects" />
+        ) : viewMode === 'favorites' ? (
+          <ProjectsPanel mode="favorites" />
+        ) : viewMode === 'recent' ? (
           // Recent files view
           recentFiles.length === 0 ? (
             <div className="p-4 text-sm text-muted-foreground">
@@ -1370,6 +1413,47 @@ export function FileListPanel() {
                   <ClipboardPaste className="h-4 w-4 mr-2" />
                   Paste
                   <ContextMenuShortcut>⌘V</ContextMenuShortcut>
+                </ContextMenuItem>
+                <ContextMenuSeparator />
+                <ContextMenuItem
+                  onClick={async () => {
+                    const { useProjectsStore: ps } = await import('../../stores/projectsStore')
+                    // Add current root as a project without switching (already here)
+                    if (!rootPath) return
+                    const { useSettingsStore: ss } = await import('../../stores/settingsStore')
+                    const existing = ss.getState().settings.projects ?? []
+                    if (existing.some((p) => p.path === rootPath)) return
+                    const name = rootPath.split('/').pop() || rootPath
+                    ss.getState().addProject({
+                      id: self.crypto.randomUUID(),
+                      name,
+                      path: rootPath,
+                      createdAt: new Date().toISOString(),
+                    })
+                  }}
+                  disabled={!rootPath}
+                >
+                  <Boxes className="h-4 w-4 mr-2" />
+                  Add as Project
+                </ContextMenuItem>
+                <ContextMenuItem
+                  onClick={async () => {
+                    if (!rootPath) return
+                    const { useSettingsStore: ss } = await import('../../stores/settingsStore')
+                    const existing = ss.getState().settings.favorites ?? []
+                    if (existing.some((f) => f.path === rootPath)) return
+                    const name = rootPath.split('/').pop() || rootPath
+                    ss.getState().addFavorite({
+                      id: self.crypto.randomUUID(),
+                      name,
+                      path: rootPath,
+                      addedAt: new Date().toISOString(),
+                    })
+                  }}
+                  disabled={!rootPath}
+                >
+                  <Star className="h-4 w-4 mr-2" />
+                  Add to Favorites
                 </ContextMenuItem>
               </ContextMenuContent>
             </ContextMenu>

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -98,9 +98,11 @@ export function FileListPanel() {
   const defaultSaveDirectory = useSettingsStore((s) => s.settings.defaultSaveDirectory)
   // The project whose folder contains the current view root (handles drill-down
   // into project subfolders). Base root and projects are separate, peer locations.
-  const currentProject = projects.find(
-    (p) => !!rootPath && (rootPath === p.path || rootPath.startsWith(p.path + '/'))
-  ) ?? null
+  // Match the longest path prefix so nested projects (e.g. /docs and /docs/work)
+  // resolve to the most specific one, not whichever appears first in the array.
+  const currentProject = projects
+    .filter((p) => !!rootPath && (rootPath === p.path || rootPath.startsWith(p.path + '/')))
+    .sort((a, b) => b.path.length - a.path.length)[0] ?? null
 
   // Return from an open project to the Projects list — deliberately stays in the
   // 'projects' panel (unlike projectsStore.exitToRoot, which clears the active

--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import type { FileItem } from '../../types'
-import { ChevronRight, ChevronDown, FileText, FileType, Folder, FolderOpen, Loader2, Trash2, Edit3, ExternalLink, Copy, Scissors, ClipboardPaste, FilePlus } from 'lucide-react'
+import { ChevronRight, ChevronDown, FileText, FileType, Folder, FolderOpen, Loader2, Trash2, Edit3, ExternalLink, Copy, Scissors, ClipboardPaste, FilePlus, Boxes, Star } from 'lucide-react'
 import { cn } from '../../lib/utils'
+import { useFavorites } from '../../stores/projectsStore'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -35,6 +36,8 @@ interface FileTreeProps {
   onRenameComplete?: (oldPath: string, newName: string) => void
   onRenameCancel?: () => void
   onNewFile?: (dirPath: string) => void
+  onAddProject?: (path: string) => void
+  onAddFavorite?: (path: string, isDirectory: boolean) => void
   onFileDrop?: (sourcePath: string, targetDirPath: string) => void
   depth?: number
 }
@@ -63,6 +66,8 @@ export function FileTree({
   onRenameComplete,
   onRenameCancel,
   onNewFile,
+  onAddProject,
+  onAddFavorite,
   onFileDrop,
   depth = 0
 }: FileTreeProps) {
@@ -94,6 +99,8 @@ export function FileTree({
           onRenameComplete={onRenameComplete}
           onRenameCancel={onRenameCancel}
           onNewFile={onNewFile}
+          onAddProject={onAddProject}
+          onAddFavorite={onAddFavorite}
           onFileDrop={onFileDrop}
           depth={depth}
         />
@@ -126,6 +133,8 @@ interface FileTreeItemProps {
   onRenameComplete?: (oldPath: string, newName: string) => void
   onRenameCancel?: () => void
   onNewFile?: (dirPath: string) => void
+  onAddProject?: (path: string) => void
+  onAddFavorite?: (path: string, isDirectory: boolean) => void
   onFileDrop?: (sourcePath: string, targetDirPath: string) => void
   depth: number
 }
@@ -154,6 +163,8 @@ function FileTreeItem({
   onRenameComplete,
   onRenameCancel,
   onNewFile,
+  onAddProject,
+  onAddFavorite,
   onFileDrop,
   depth
 }: FileTreeItemProps) {
@@ -162,6 +173,9 @@ function FileTreeItem({
   const isLoading = loadingFolders?.has(item.path) ?? false
   const isRenaming = renamingPath === item.path
   const isCut = clipboardOperation === 'cut' && clipboardPath === item.path
+  // Denote favorite files in the tree (folders keep their folder icon).
+  const favorites = useFavorites()
+  const isFavorite = !item.isDirectory && favorites.some((f) => f.path === item.path)
 
   // Inline rename state
   const [renameValue, setRenameValue] = useState('')
@@ -348,7 +362,9 @@ function FileTreeItem({
         ) : (
           <>
             <span className="w-3.5" />
-            {item.name.endsWith('.txt') ? (
+            {isFavorite ? (
+              <Star className="h-4 w-4 shrink-0 fill-amber-400 text-amber-400" />
+            ) : item.name.endsWith('.txt') ? (
               <FileType className="h-4 w-4 shrink-0 text-muted-foreground" />
             ) : (
               <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -429,6 +445,15 @@ function FileTreeItem({
           </ContextMenuItem>
         </>
       )}
+      {onAddFavorite && (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem onClick={() => onAddFavorite(item.path, false)}>
+            <Star className="h-4 w-4 mr-2" />
+            Add to Favorites
+          </ContextMenuItem>
+        </>
+      )}
       {(onFileTrash || onFileDelete) && (
         <>
           <ContextMenuSeparator />
@@ -469,6 +494,19 @@ function FileTreeItem({
             Show in Finder
           </ContextMenuItem>
         </>
+      )}
+      {(onAddProject || onAddFavorite) && <ContextMenuSeparator />}
+      {onAddProject && (
+        <ContextMenuItem onClick={() => onAddProject(item.path)}>
+          <Boxes className="h-4 w-4 mr-2" />
+          Add as Project
+        </ContextMenuItem>
+      )}
+      {onAddFavorite && (
+        <ContextMenuItem onClick={() => onAddFavorite(item.path, true)}>
+          <Star className="h-4 w-4 mr-2" />
+          Add to Favorites
+        </ContextMenuItem>
       )}
     </ContextMenuContent>
   )
@@ -512,6 +550,8 @@ function FileTreeItem({
           onRenameComplete={onRenameComplete}
           onRenameCancel={onRenameCancel}
           onNewFile={onNewFile}
+          onAddProject={onAddProject}
+          onAddFavorite={onAddFavorite}
           onFileDrop={onFileDrop}
           depth={depth + 1}
         />

--- a/src/renderer/components/files/ProjectsPanel.tsx
+++ b/src/renderer/components/files/ProjectsPanel.tsx
@@ -6,7 +6,7 @@
  * the header toggle buttons can stay consistent with the rest of FileListPanel.
  */
 import { useState } from 'react'
-import { FolderOpen, Plus, Trash2, Star, Folder, ChevronRight } from 'lucide-react'
+import { FolderOpen, Plus, Trash2, Star, Folder, ChevronRight, Boxes } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import {
@@ -34,6 +34,7 @@ import {
   useActiveProject,
 } from '../../stores/projectsStore'
 import { useSettingsStore } from '../../stores/settingsStore'
+import { useTabs } from '../../hooks/useTabs'
 
 // ---- sub-types -------------------------------------------------------
 
@@ -60,11 +61,7 @@ function ProjectItem({ id, name, path, isActive, onSwitch, onRename, onRemove }:
           onClick={() => onSwitch(id)}
           title={path}
         >
-          {isActive ? (
-            <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-          ) : (
-            <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-          )}
+          <Boxes className="h-4 w-4 shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">
             <div className="truncate font-medium">{name}</div>
             {name !== folderName && (
@@ -166,6 +163,7 @@ export function ProjectsPanel({ mode }: ProjectsPanelProps) {
     operationError,
     setOperationError,
   } = useProjectsStore()
+  const { openFileInTab } = useTabs()
 
   // Rename dialog state
   const [renameTarget, setRenameTarget] = useState<{
@@ -213,7 +211,7 @@ export function ProjectsPanel({ mode }: ProjectsPanelProps) {
   if (mode === 'projects') {
     return (
       <div className="flex h-full flex-col">
-        <ScrollArea className="flex-1">
+        <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]>div]:!block">
           {projects.length === 0 ? (
             <div className="flex flex-col items-center justify-center p-6 text-center">
               <FolderOpen className="h-8 w-8 text-muted-foreground/50 mb-3" />
@@ -339,7 +337,7 @@ export function ProjectsPanel({ mode }: ProjectsPanelProps) {
   // Favorites mode
   return (
     <div className="flex h-full flex-col">
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 [&>[data-radix-scroll-area-viewport]>div]:!block">
         {favorites.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-6 text-center">
             <Star className="h-8 w-8 text-muted-foreground/50 mb-3" />
@@ -367,7 +365,14 @@ export function ProjectsPanel({ mode }: ProjectsPanelProps) {
                   id={fav.id}
                   name={fav.name}
                   path={fav.path}
-                  onNavigate={(id) => navigateToFavorite(id)}
+                  onNavigate={(id) => {
+                    const f = favorites.find((x) => x.id === id)
+                    if (f && f.isDirectory === false) {
+                      void openFileInTab(f.path)
+                    } else {
+                      void navigateToFavorite(id)
+                    }
+                  }}
                   onRename={(id, name) => handleRenameOpen('favorite', id, name)}
                   onRemove={(id) => {
                     const f = favorites.find((x) => x.id === id)

--- a/src/renderer/components/files/ProjectsPanel.tsx
+++ b/src/renderer/components/files/ProjectsPanel.tsx
@@ -1,0 +1,450 @@
+/**
+ * ProjectsPanel — displays the list of Projects and Favorites when the user
+ * activates the 'projects' or 'favorites' view mode in the file explorer.
+ *
+ * Design: both lists live in the same component (controlled by a tab), so
+ * the header toggle buttons can stay consistent with the rest of FileListPanel.
+ */
+import { useState } from 'react'
+import { FolderOpen, Plus, Trash2, Star, Folder, ChevronRight } from 'lucide-react'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '../ui/context-menu'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { ScrollArea } from '../ui/scroll-area'
+import { cn } from '../../lib/utils'
+import {
+  useProjectsStore,
+  useProjects,
+  useFavorites,
+  useActiveProject,
+} from '../../stores/projectsStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+
+// ---- sub-types -------------------------------------------------------
+
+interface ProjectItemProps {
+  id: string
+  name: string
+  path: string
+  isActive: boolean
+  onSwitch: (id: string) => void
+  onRename: (id: string, name: string) => void
+  onRemove: (id: string) => void
+}
+
+function ProjectItem({ id, name, path, isActive, onSwitch, onRename, onRemove }: ProjectItemProps) {
+  const folderName = path.split('/').pop() || path
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          className={cn(
+            'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50',
+            isActive && 'bg-muted'
+          )}
+          onClick={() => onSwitch(id)}
+          title={path}
+        >
+          {isActive ? (
+            <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-medium">{name}</div>
+            {name !== folderName && (
+              <div className="truncate text-xs text-muted-foreground">{folderName}</div>
+            )}
+          </div>
+          {isActive && (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100" />
+          )}
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => onSwitch(id)}>
+          <FolderOpen className="h-4 w-4 mr-2" />
+          Open
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => onRename(id, name)}>
+          <Folder className="h-4 w-4 mr-2" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuItem
+          className="text-destructive focus:text-destructive"
+          onClick={() => onRemove(id)}
+        >
+          <Trash2 className="h-4 w-4 mr-2" />
+          Remove
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+interface FavoriteItemProps {
+  id: string
+  name: string
+  path: string
+  onNavigate: (id: string) => void
+  onRename: (id: string, name: string) => void
+  onRemove: (id: string) => void
+}
+
+function FavoriteItem({ id, name, path, onNavigate, onRename, onRemove }: FavoriteItemProps) {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50"
+          onClick={() => onNavigate(id)}
+          title={path}
+        >
+          <Star className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate">{name}</div>
+          </div>
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => onNavigate(id)}>
+          <FolderOpen className="h-4 w-4 mr-2" />
+          Open
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => onRename(id, name)}>
+          <Folder className="h-4 w-4 mr-2" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuItem
+          className="text-destructive focus:text-destructive"
+          onClick={() => onRemove(id)}
+        >
+          <Trash2 className="h-4 w-4 mr-2" />
+          Remove
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+// ---- main component --------------------------------------------------
+
+export type ProjectsPanelMode = 'projects' | 'favorites'
+
+interface ProjectsPanelProps {
+  mode: ProjectsPanelMode
+}
+
+export function ProjectsPanel({ mode }: ProjectsPanelProps) {
+  const projects = useProjects()
+  const favorites = useFavorites()
+  const activeProject = useActiveProject()
+  const {
+    addProjectFromPicker,
+    addFavoriteFromPicker,
+    switchToProject,
+    navigateToFavorite,
+    removeProject,
+    removeFavorite,
+    isAddingProject,
+    isAddingFavorite,
+    operationError,
+    setOperationError,
+  } = useProjectsStore()
+
+  // Rename dialog state
+  const [renameTarget, setRenameTarget] = useState<{
+    type: 'project' | 'favorite'
+    id: string
+    name: string
+  } | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+
+  const handleRenameOpen = (type: 'project' | 'favorite', id: string, name: string) => {
+    setRenameTarget({ type, id, name })
+    setRenameValue(name)
+    setOperationError(null)
+  }
+
+  const handleRenameConfirm = () => {
+    if (!renameTarget || !renameValue.trim()) return
+    const settingsStore = useSettingsStore.getState()
+    if (renameTarget.type === 'project') {
+      settingsStore.updateProject(renameTarget.id, { name: renameValue.trim() })
+    } else {
+      settingsStore.updateFavorite(renameTarget.id, { name: renameValue.trim() })
+    }
+    setRenameTarget(null)
+    setRenameValue('')
+  }
+
+  // Remove confirmation dialog state
+  const [removeTarget, setRemoveTarget] = useState<{
+    type: 'project' | 'favorite'
+    id: string
+    name: string
+  } | null>(null)
+
+  const handleRemoveConfirm = () => {
+    if (!removeTarget) return
+    if (removeTarget.type === 'project') {
+      removeProject(removeTarget.id)
+    } else {
+      removeFavorite(removeTarget.id)
+    }
+    setRemoveTarget(null)
+  }
+
+  if (mode === 'projects') {
+    return (
+      <div className="flex h-full flex-col">
+        <ScrollArea className="flex-1">
+          {projects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center p-6 text-center">
+              <FolderOpen className="h-8 w-8 text-muted-foreground/50 mb-3" />
+              <p className="text-sm text-muted-foreground mb-1">No projects yet.</p>
+              <p className="text-xs text-muted-foreground/70 mb-4">
+                Projects are root folders with their own context — like Obsidian vaults.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => addProjectFromPicker(true)}
+                disabled={isAddingProject}
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                {isAddingProject ? 'Choosing...' : 'Add Project'}
+              </Button>
+            </div>
+          ) : (
+            <div className="p-2 space-y-0.5">
+              {[...projects]
+                .sort((a, b) => {
+                  // Sort by lastOpenedAt desc, then createdAt desc
+                  const aTime = a.lastOpenedAt ?? a.createdAt
+                  const bTime = b.lastOpenedAt ?? b.createdAt
+                  return bTime.localeCompare(aTime)
+                })
+                .map((project) => (
+                  <ProjectItem
+                    key={project.id}
+                    id={project.id}
+                    name={project.name}
+                    path={project.path}
+                    isActive={activeProject?.id === project.id}
+                    onSwitch={(id) => switchToProject(id)}
+                    onRename={(id, name) => handleRenameOpen('project', id, name)}
+                    onRemove={(id) => {
+                      const p = projects.find((x) => x.id === id)
+                      if (p) setRemoveTarget({ type: 'project', id, name: p.name })
+                    }}
+                  />
+                ))}
+            </div>
+          )}
+        </ScrollArea>
+
+        {/* Add button at the bottom when there are existing projects */}
+        {projects.length > 0 && (
+          <div className="border-t border-border p-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full text-muted-foreground hover:text-foreground"
+                  onClick={() => addProjectFromPicker(true)}
+                  disabled={isAddingProject}
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  {isAddingProject ? 'Choosing...' : 'Add Project'}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Add a folder as a new project</TooltipContent>
+            </Tooltip>
+          </div>
+        )}
+
+        {operationError && (
+          <div className="px-3 py-2 text-xs text-destructive border-t border-border">
+            {operationError}
+          </div>
+        )}
+
+        {/* Rename dialog */}
+        <Dialog open={!!renameTarget} onOpenChange={(open) => !open && setRenameTarget(null)}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Rename {renameTarget?.type === 'project' ? 'Project' : 'Favorite'}</DialogTitle>
+              <DialogDescription>
+                Enter a new display name.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="rename-value">Name</Label>
+                <Input
+                  id="rename-value"
+                  value={renameValue}
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleRenameConfirm()
+                  }}
+                  autoFocus
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setRenameTarget(null)}>Cancel</Button>
+              <Button onClick={handleRenameConfirm} disabled={!renameValue.trim()}>Rename</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Remove confirmation dialog */}
+        <Dialog open={!!removeTarget} onOpenChange={(open) => !open && setRemoveTarget(null)}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Remove Project?</DialogTitle>
+              <DialogDescription>
+                This removes <strong>{removeTarget?.name}</strong> from your projects list.
+                The folder and its files are not deleted.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setRemoveTarget(null)}>Cancel</Button>
+              <Button variant="destructive" onClick={handleRemoveConfirm}>Remove</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    )
+  }
+
+  // Favorites mode
+  return (
+    <div className="flex h-full flex-col">
+      <ScrollArea className="flex-1">
+        {favorites.length === 0 ? (
+          <div className="flex flex-col items-center justify-center p-6 text-center">
+            <Star className="h-8 w-8 text-muted-foreground/50 mb-3" />
+            <p className="text-sm text-muted-foreground mb-1">No favorites yet.</p>
+            <p className="text-xs text-muted-foreground/70 mb-4">
+              Star folders for quick navigation across all projects.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => addFavoriteFromPicker()}
+              disabled={isAddingFavorite}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              {isAddingFavorite ? 'Choosing...' : 'Add Favorite'}
+            </Button>
+          </div>
+        ) : (
+          <div className="p-2 space-y-0.5">
+            {[...favorites]
+              .sort((a, b) => b.addedAt.localeCompare(a.addedAt))
+              .map((fav) => (
+                <FavoriteItem
+                  key={fav.id}
+                  id={fav.id}
+                  name={fav.name}
+                  path={fav.path}
+                  onNavigate={(id) => navigateToFavorite(id)}
+                  onRename={(id, name) => handleRenameOpen('favorite', id, name)}
+                  onRemove={(id) => {
+                    const f = favorites.find((x) => x.id === id)
+                    if (f) setRemoveTarget({ type: 'favorite', id, name: f.name })
+                  }}
+                />
+              ))}
+          </div>
+        )}
+      </ScrollArea>
+
+      {/* Add button at the bottom */}
+      {favorites.length > 0 && (
+        <div className="border-t border-border p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full text-muted-foreground hover:text-foreground"
+            onClick={() => addFavoriteFromPicker()}
+            disabled={isAddingFavorite}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            {isAddingFavorite ? 'Choosing...' : 'Add Favorite'}
+          </Button>
+        </div>
+      )}
+
+      {operationError && (
+        <div className="px-3 py-2 text-xs text-destructive border-t border-border">
+          {operationError}
+        </div>
+      )}
+
+      {/* Rename dialog (shared between modes; only one dialog open at a time) */}
+      <Dialog open={!!renameTarget} onOpenChange={(open) => !open && setRenameTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename Favorite</DialogTitle>
+            <DialogDescription>Enter a new display name.</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="rename-value-fav">Name</Label>
+              <Input
+                id="rename-value-fav"
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleRenameConfirm()
+                }}
+                autoFocus
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRenameTarget(null)}>Cancel</Button>
+            <Button onClick={handleRenameConfirm} disabled={!renameValue.trim()}>Rename</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove confirmation */}
+      <Dialog open={!!removeTarget} onOpenChange={(open) => !open && setRemoveTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Favorite?</DialogTitle>
+            <DialogDescription>
+              This removes <strong>{removeTarget?.name}</strong> from your favorites.
+              The folder and its files are not deleted.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRemoveTarget(null)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleRemoveConfirm}>Remove</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -11,7 +11,9 @@ export interface SyncProgress {
   phase: RemarkableSyncPhase
 }
 
-type ViewMode = 'recent' | 'folder' | 'notebooks' | 'googledocs'
+type ViewMode = 'recent' | 'folder' | 'notebooks' | 'googledocs' | 'projects' | 'favorites'
+
+export type { ViewMode }
 
 /**
  * Walk `newFiles` and re-attach `children` arrays from `oldFiles` for any

--- a/src/renderer/stores/projectsStore.ts
+++ b/src/renderer/stores/projectsStore.ts
@@ -171,6 +171,7 @@ export const useProjectsStore = create<ProjectsState>()(
           path: result.path,
           bookmark: result.bookmark ?? undefined,
           addedAt: new Date().toISOString(),
+          isDirectory: true, // the picker is folder-only — be explicit rather than relying on undefined
         }
 
         useSettingsStore.getState().addFavorite(favorite)
@@ -220,6 +221,8 @@ export const useProjectsStore = create<ProjectsState>()(
       if (baseRoot) {
         fileList.setRootPath(baseRoot)
       }
+      // Drop to the base-root Files navigator (contrast: FileListPanel.backToProjectsList
+      // clears the active project but stays in the 'projects' panel).
       fileList.setViewMode('folder')
     },
 
@@ -235,10 +238,18 @@ export const useProjectsStore = create<ProjectsState>()(
     },
 
     removeProject: (projectId: string): void => {
+      const wasActive = useSettingsStore.getState().settings.activeProjectId === projectId
       useSettingsStore.getState().removeProject(projectId)
-      // If we removed the active project, fall back to the first remaining project
-      // or null (single-folder mode). The file explorer root is NOT changed here —
-      // caller is responsible for navigating away if needed.
+      // If the removed project was the active one, the explorer would otherwise keep
+      // showing its folder with no project header. Navigate back to the base root
+      // (defaultSaveDirectory) so the view matches the now-removed state.
+      if (wasActive) {
+        const baseRoot = useSettingsStore.getState().settings.defaultSaveDirectory
+        void getFileListStore().then((fileList) => {
+          if (baseRoot) fileList.setRootPath(baseRoot)
+          fileList.setViewMode('folder')
+        })
+      }
     },
 
     removeFavorite: (favoriteId: string): void => {

--- a/src/renderer/stores/projectsStore.ts
+++ b/src/renderer/stores/projectsStore.ts
@@ -1,0 +1,234 @@
+/**
+ * projectsStore — runtime UI state for the Projects & Favorites feature.
+ *
+ * Persisted data (projects[], favorites[], activeProjectId) lives in
+ * settingsStore/settings.json. This store owns ephemeral runtime state:
+ * which sidebar panel is visible, loading/error states, etc.
+ *
+ * Design decision: keep persisted data in settings.json (not IndexedDB) because
+ * 1. Each project/favorite carries a MAS security-scoped bookmark that must be
+ *    activated at startup — the settings:load handler already does that for
+ *    masDirectoryBookmark; extending it to arrays is natural.
+ * 2. Projects/Favorites are small (<100 entries), stable data — no need for
+ *    the schema-versioning overhead of IndexedDB.
+ * 3. Consistent with how defaultSaveDirectory + masDirectoryBookmark work today.
+ */
+import { create } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
+import type { Favorite, Project } from '../types'
+import { getApi } from '../lib/browserApi'
+import { useSettingsStore } from './settingsStore'
+
+export type ProjectsPanelTab = 'projects' | 'favorites'
+
+interface ProjectsState {
+  /** Which tab is currently active in the sidebar panel */
+  activeTab: ProjectsPanelTab
+  /** Whether the "add project" flow is in progress */
+  isAddingProject: boolean
+  /** Whether the "add favorite" flow is in progress */
+  isAddingFavorite: boolean
+  /** Error message for the most recent operation, if any */
+  operationError: string | null
+
+  setActiveTab: (tab: ProjectsPanelTab) => void
+  setOperationError: (error: string | null) => void
+
+  /**
+   * Open the system folder picker, create a new Project from the result,
+   * persist it, and (optionally) switch to it immediately.
+   */
+  addProjectFromPicker: (switchToProject?: boolean) => Promise<Project | null>
+
+  /**
+   * Open the system folder picker, create a new Favorite from the result,
+   * and persist it.
+   */
+  addFavoriteFromPicker: () => Promise<Favorite | null>
+
+  /**
+   * Switch the active project. Updates lastOpenedAt and navigates the file
+   * explorer to the project root.
+   */
+  switchToProject: (projectId: string) => Promise<void>
+
+  /**
+   * Navigate the file explorer to a favorite folder.
+   * Does NOT change the active project.
+   */
+  navigateToFavorite: (favoriteId: string) => Promise<void>
+
+  /**
+   * Remove a project and optionally clean up MAS resources.
+   */
+  removeProject: (projectId: string) => void
+
+  /**
+   * Remove a favorite.
+   */
+  removeFavorite: (favoriteId: string) => void
+}
+
+// Lazy import to avoid circular dependency — fileListStore imports nothing
+// from projectsStore, but we need to call setRootPath on it.
+async function getFileListStore() {
+  const { useFileListStore } = await import('./fileListStore')
+  return useFileListStore.getState()
+}
+
+export const useProjectsStore = create<ProjectsState>()(
+  subscribeWithSelector((set, get) => ({
+    activeTab: 'projects',
+    isAddingProject: false,
+    isAddingFavorite: false,
+    operationError: null,
+
+    setActiveTab: (tab) => set({ activeTab: tab }),
+
+    setOperationError: (error) => set({ operationError: error }),
+
+    addProjectFromPicker: async (switchToProject = true): Promise<Project | null> => {
+      set({ isAddingProject: true, operationError: null })
+      try {
+        const api = getApi()
+        const result = await api.selectFolder(
+          undefined,
+          'Choose a folder to add as a project. Prose needs permission to access this folder.'
+        )
+        if (!result) {
+          set({ isAddingProject: false })
+          return null
+        }
+
+        const name = result.path.split('/').pop() || result.path
+        const now = new Date().toISOString()
+        const project: Project = {
+          id: self.crypto.randomUUID(),
+          name,
+          path: result.path,
+          bookmark: result.bookmark ?? undefined,
+          createdAt: now,
+          lastOpenedAt: switchToProject ? now : undefined,
+        }
+
+        useSettingsStore.getState().addProject(project)
+
+        if (switchToProject) {
+          // Also update the file explorer root
+          const fileList = await getFileListStore()
+          fileList.setRootPath(project.path)
+          useSettingsStore.getState().setActiveProject(project.id)
+          useSettingsStore.getState().setDefaultSaveDirectory(project.path)
+          // Persist bookmark in the legacy single-bookmark slot too so the
+          // existing settings:load bookmark restoration still works.
+          if (project.bookmark) {
+            useSettingsStore.setState((state) => ({
+              settings: { ...state.settings, masDirectoryBookmark: project.bookmark }
+            }))
+          }
+          useSettingsStore.getState().saveSettings()
+        }
+
+        set({ isAddingProject: false })
+        return project
+      } catch (err) {
+        console.error('[projectsStore] addProjectFromPicker failed:', err)
+        set({ isAddingProject: false, operationError: 'Failed to add project. Please try again.' })
+        return null
+      }
+    },
+
+    addFavoriteFromPicker: async (): Promise<Favorite | null> => {
+      set({ isAddingFavorite: true, operationError: null })
+      try {
+        const api = getApi()
+        const result = await api.selectFolder(
+          undefined,
+          'Choose a folder to add to Favorites. Prose needs permission to access this folder.'
+        )
+        if (!result) {
+          set({ isAddingFavorite: false })
+          return null
+        }
+
+        const name = result.path.split('/').pop() || result.path
+        const favorite: Favorite = {
+          id: self.crypto.randomUUID(),
+          name,
+          path: result.path,
+          bookmark: result.bookmark ?? undefined,
+          addedAt: new Date().toISOString(),
+        }
+
+        useSettingsStore.getState().addFavorite(favorite)
+        set({ isAddingFavorite: false })
+        return favorite
+      } catch (err) {
+        console.error('[projectsStore] addFavoriteFromPicker failed:', err)
+        set({ isAddingFavorite: false, operationError: 'Failed to add favorite. Please try again.' })
+        return null
+      }
+    },
+
+    switchToProject: async (projectId: string): Promise<void> => {
+      set({ operationError: null })
+      const { settings } = useSettingsStore.getState()
+      const project = (settings.projects ?? []).find((p) => p.id === projectId)
+      if (!project) return
+
+      useSettingsStore.getState().setActiveProject(projectId)
+      useSettingsStore.getState().setDefaultSaveDirectory(project.path)
+
+      // Sync the legacy single-bookmark slot so the existing startAccessingSecurityScopedResource
+      // call in settings:load still works on the next launch.
+      if (project.bookmark) {
+        useSettingsStore.setState((state) => ({
+          settings: { ...state.settings, masDirectoryBookmark: project.bookmark }
+        }))
+      }
+      useSettingsStore.getState().saveSettings()
+
+      const fileList = await getFileListStore()
+      fileList.setRootPath(project.path)
+      fileList.setViewMode('folder')
+    },
+
+    navigateToFavorite: async (favoriteId: string): Promise<void> => {
+      set({ operationError: null })
+      const { settings } = useSettingsStore.getState()
+      const favorite = (settings.favorites ?? []).find((f) => f.id === favoriteId)
+      if (!favorite) return
+
+      const fileList = await getFileListStore()
+      fileList.setRootPath(favorite.path)
+      fileList.setViewMode('folder')
+    },
+
+    removeProject: (projectId: string): void => {
+      useSettingsStore.getState().removeProject(projectId)
+      // If we removed the active project, fall back to the first remaining project
+      // or null (single-folder mode). The file explorer root is NOT changed here —
+      // caller is responsible for navigating away if needed.
+    },
+
+    removeFavorite: (favoriteId: string): void => {
+      useSettingsStore.getState().removeFavorite(favoriteId)
+    },
+  }))
+)
+
+// Convenience selector hooks
+export function useProjects(): Project[] {
+  return useSettingsStore((s) => s.settings.projects ?? [])
+}
+
+export function useFavorites(): Favorite[] {
+  return useSettingsStore((s) => s.settings.favorites ?? [])
+}
+
+export function useActiveProject(): Project | null {
+  const projects = useSettingsStore((s) => s.settings.projects ?? [])
+  const activeId = useSettingsStore((s) => s.settings.activeProjectId)
+  if (!activeId) return null
+  return projects.find((p) => p.id === activeId) ?? null
+}

--- a/src/renderer/stores/projectsStore.ts
+++ b/src/renderer/stores/projectsStore.ts
@@ -19,6 +19,13 @@ import type { Favorite, Project } from '../types'
 import { getApi } from '../lib/browserApi'
 import { useSettingsStore } from './settingsStore'
 
+// Stable empty-array references for the selector hooks below. Returning a fresh
+// `[]` from a Zustand selector on every call makes useSyncExternalStore treat the
+// snapshot as changed each render → infinite re-render ("Maximum update depth
+// exceeded"). These constants keep the reference stable when the field is unset.
+const EMPTY_PROJECTS: Project[] = []
+const EMPTY_FAVORITES: Favorite[] = []
+
 export type ProjectsPanelTab = 'projects' | 'favorites'
 
 interface ProjectsState {
@@ -51,6 +58,12 @@ interface ProjectsState {
    * explorer to the project root.
    */
   switchToProject: (projectId: string) => Promise<void>
+  /**
+   * Exit the active project back to the selected root folder (the stable
+   * defaultSaveDirectory). Clears the active project. Projects are additive
+   * pointers, so the selected root is preserved across project navigation.
+   */
+  exitToRoot: () => Promise<void>
 
   /**
    * Navigate the file explorer to a favorite folder.
@@ -177,7 +190,9 @@ export const useProjectsStore = create<ProjectsState>()(
       if (!project) return
 
       useSettingsStore.getState().setActiveProject(projectId)
-      useSettingsStore.getState().setDefaultSaveDirectory(project.path)
+      // Note: the selected root (defaultSaveDirectory) is intentionally NOT
+      // changed here — it stays stable as the base the Back button returns to.
+      // Projects are additive pointers layered over the selected root.
 
       // Sync the legacy single-bookmark slot so the existing startAccessingSecurityScopedResource
       // call in settings:load still works on the next launch.
@@ -190,6 +205,19 @@ export const useProjectsStore = create<ProjectsState>()(
 
       const fileList = await getFileListStore()
       fileList.setRootPath(project.path)
+      fileList.setViewMode('folder')
+    },
+
+    exitToRoot: async (): Promise<void> => {
+      set({ operationError: null })
+      const baseRoot = useSettingsStore.getState().settings.defaultSaveDirectory
+      useSettingsStore.getState().setActiveProject(null)
+      useSettingsStore.getState().saveSettings()
+
+      const fileList = await getFileListStore()
+      if (baseRoot) {
+        fileList.setRootPath(baseRoot)
+      }
       fileList.setViewMode('folder')
     },
 
@@ -219,15 +247,15 @@ export const useProjectsStore = create<ProjectsState>()(
 
 // Convenience selector hooks
 export function useProjects(): Project[] {
-  return useSettingsStore((s) => s.settings.projects ?? [])
+  return useSettingsStore((s) => s.settings.projects ?? EMPTY_PROJECTS)
 }
 
 export function useFavorites(): Favorite[] {
-  return useSettingsStore((s) => s.settings.favorites ?? [])
+  return useSettingsStore((s) => s.settings.favorites ?? EMPTY_FAVORITES)
 }
 
 export function useActiveProject(): Project | null {
-  const projects = useSettingsStore((s) => s.settings.projects ?? [])
+  const projects = useSettingsStore((s) => s.settings.projects ?? EMPTY_PROJECTS)
   const activeId = useSettingsStore((s) => s.settings.activeProjectId)
   if (!activeId) return null
   return projects.find((p) => p.id === activeId) ?? null

--- a/src/renderer/stores/projectsStore.ts
+++ b/src/renderer/stores/projectsStore.ts
@@ -205,7 +205,9 @@ export const useProjectsStore = create<ProjectsState>()(
 
       const fileList = await getFileListStore()
       fileList.setRootPath(project.path)
-      fileList.setViewMode('folder')
+      // Stay in the Projects panel — opening a project browses its files in
+      // place; the Files panel remains the separate base-root navigator.
+      fileList.setViewMode('projects')
     },
 
     exitToRoot: async (): Promise<void> => {

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
-import type { Appearance, LegacyTheme, Settings, SettingsOnDisk } from '../types'
+import type { Appearance, Favorite, LegacyTheme, Project, Settings, SettingsOnDisk } from '../types'
 import { initRendererSentry, setRendererSentryEnabled } from '../lib/sentry'
 import { getDefaultModel } from '../../shared/llm/models'
 import type { ModelInfo } from '../../shared/llm/models'
@@ -97,6 +97,15 @@ interface SettingsState {
   isAIConsentDialogOpen: boolean
   setAIConsentDialogOpen: (open: boolean) => void
   setPersistedToolMode: (mode: ToolMode) => void
+  // Projects
+  addProject: (project: Project) => void
+  updateProject: (id: string, patch: Partial<Omit<Project, 'id'>>) => void
+  removeProject: (id: string) => void
+  setActiveProject: (id: string | null) => void
+  // Favorites
+  addFavorite: (favorite: Favorite) => void
+  removeFavorite: (id: string) => void
+  updateFavorite: (id: string, patch: Partial<Omit<Favorite, 'id'>>) => void
 }
 
 const defaultSettings: Settings = {
@@ -485,6 +494,100 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
   setPersistedToolMode: (mode) => {
     set((state) => ({
       settings: { ...state.settings, toolMode: mode }
+    }))
+    get().saveSettings()
+  },
+
+  // -------------------------------------------------------------------------
+  // Projects
+  // -------------------------------------------------------------------------
+
+  addProject: (project) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        projects: [...(state.settings.projects ?? []), project]
+      }
+    }))
+    get().saveSettings()
+  },
+
+  updateProject: (id, patch) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        projects: (state.settings.projects ?? []).map((p) =>
+          p.id === id ? { ...p, ...patch } : p
+        )
+      }
+    }))
+    get().saveSettings()
+  },
+
+  removeProject: (id) => {
+    set((state) => {
+      const updated = (state.settings.projects ?? []).filter((p) => p.id !== id)
+      const activeId = state.settings.activeProjectId
+      return {
+        settings: {
+          ...state.settings,
+          projects: updated,
+          // Clear active project if the removed project was active
+          activeProjectId: activeId === id ? null : activeId
+        }
+      }
+    })
+    get().saveSettings()
+  },
+
+  setActiveProject: (id) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        activeProjectId: id,
+        // Update lastOpenedAt on the project when switching to it
+        projects: id === null
+          ? state.settings.projects
+          : (state.settings.projects ?? []).map((p) =>
+              p.id === id ? { ...p, lastOpenedAt: new Date().toISOString() } : p
+            )
+      }
+    }))
+    get().saveSettings()
+  },
+
+  // -------------------------------------------------------------------------
+  // Favorites
+  // -------------------------------------------------------------------------
+
+  addFavorite: (favorite) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        favorites: [...(state.settings.favorites ?? []), favorite]
+      }
+    }))
+    get().saveSettings()
+  },
+
+  removeFavorite: (id) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        favorites: (state.settings.favorites ?? []).filter((f) => f.id !== id)
+      }
+    }))
+    get().saveSettings()
+  },
+
+  updateFavorite: (id, patch) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        favorites: (state.settings.favorites ?? []).map((f) =>
+          f.id === id ? { ...f, ...patch } : f
+        )
+      }
     }))
     get().saveSettings()
   }

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,5 +1,31 @@
 import type { ToolResult } from '../../shared/tools/types'
 
+/**
+ * A named project — a root-folder workspace. Think Obsidian vaults or
+ * VS Code workspaces. Each project optionally carries a MAS security-scoped
+ * bookmark so the sandbox can re-open the directory without re-prompting.
+ */
+export interface Project {
+  id: string            // UUID
+  name: string          // User-visible label (defaults to folder basename)
+  path: string          // Absolute path to the root folder
+  bookmark?: string     // MAS security-scoped bookmark (base64), null on non-MAS
+  createdAt: string     // ISO timestamp
+  lastOpenedAt?: string // ISO timestamp — updated on switch
+}
+
+/**
+ * A favorited folder for quick navigation. Favorites are global (not tied to
+ * a specific project) and persist across project switches.
+ */
+export interface Favorite {
+  id: string            // UUID
+  name: string          // User-visible label (defaults to folder basename)
+  path: string          // Absolute path to the folder
+  bookmark?: string     // MAS security-scoped bookmark (base64), null on non-MAS
+  addedAt: string       // ISO timestamp
+}
+
 // v1.2 Appearance — see issue #499. The flat legacy `theme` field is replaced
 // with a structured `appearance` object. The on-disk shape may still contain
 // the legacy `theme` field; the renderer's loadSettings migrates it.
@@ -90,6 +116,21 @@ interface SettingsBase {
    * Defaults to 'editor' on first launch.
    */
   toolMode?: 'chat' | 'editor' | 'create'
+  /**
+   * Named workspace projects. Ordered by most-recently-opened first.
+   * Each project carries its own security-scoped bookmark for MAS sandbox access.
+   */
+  projects?: Project[]
+  /**
+   * The ID of the currently-active project. Null/undefined = no project
+   * selected (legacy single-folder mode — `defaultSaveDirectory` is used).
+   */
+  activeProjectId?: string | null
+  /**
+   * Globally-favorited folders for quick-navigation. Favorites are not
+   * tied to a specific project; they appear in every project's file explorer.
+   */
+  favorites?: Favorite[]
 }
 
 /**

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -20,8 +20,9 @@ export interface Project {
  */
 export interface Favorite {
   id: string            // UUID
-  name: string          // User-visible label (defaults to folder basename)
-  path: string          // Absolute path to the folder
+  name: string          // User-visible label (defaults to basename)
+  path: string          // Absolute path to the folder or file
+  isDirectory?: boolean // true = folder (navigate), false = file (open in tab); undefined = legacy folder
   bookmark?: string     // MAS security-scoped bookmark (base64), null on non-MAS
   addedAt: string       // ISO timestamp
 }


### PR DESCRIPTION
Refs #380

## Summary

First-pass implementation of Projects & Favorites in the file explorer sidebar, as specified in issue #380.

### What's in this PR

- **Types** — `Project` and `Favorite` interfaces added to `src/renderer/types/index.ts`; `projects[]`, `activeProjectId`, and `favorites[]` fields added to `SettingsBase` (therefore both `SettingsOnDisk` and `Settings`)
- **settingsStore** — CRUD actions: `addProject`, `updateProject`, `removeProject`, `setActiveProject`, `addFavorite`, `removeFavorite`, `updateFavorite`; all auto-save via the existing `saveSettings()` pattern
- **projectsStore** (new) — runtime UI state + async actions: `addProjectFromPicker` (folder picker → Project), `addFavoriteFromPicker`, `switchToProject` (updates `activeProjectId`, `defaultSaveDirectory`, file explorer root), `navigateToFavorite` (opens folder without changing project). Also exports convenience hooks `useProjects`, `useFavorites`, `useActiveProject`
- **ProjectsPanel** (new component) — renders either the projects list or the favorites list. Each item has a context menu with Open / Rename / Remove. Empty-state CTAs. Rename and Remove confirmation dialogs
- **fileListStore** — `ViewMode` type extended to include `'projects' | 'favorites'`
- **FileListPanel** — two new header toggle buttons (Boxes icon for Projects, Star for Favorites); content area routes new modes to `ProjectsPanel`; folder-view context menu gains "Add as Project" and "Add to Favorites" shortcuts; header title shows active project name in folder view
- **ipc.ts** — `settings:load` now activates MAS security-scoped bookmarks for all entries in `projects[]` and `favorites[]` arrays (mirrors existing single-bookmark logic for `masDirectoryBookmark`)

## Design decisions

**Why settings.json (not IndexedDB)?**
- Security-scoped bookmarks must be activated at startup (`app.startAccessingSecurityScopedResource`). The `settings:load` handler is the established hook for this. Extending it to arrays of bookmarks is natural and keeps all bookmark lifecycle management in one place.
- Projects/Favorites are small, stable data (typically <20 entries) — the schema-versioning overhead of IndexedDB is not worth it.
- Consistent with how `defaultSaveDirectory` + `masDirectoryBookmark` already work.

**Backward compatibility:** All new fields are optional (`?`) on `SettingsBase`. Existing users see no change until they add their first project/favorite.

**Single-bookmark legacy slot:** When switching to a project, `defaultSaveDirectory` and `masDirectoryBookmark` are updated to the new project's path/bookmark. This keeps the existing settings:load MAS bookmark restoration working for the most-recently-used project even before this PR's new array-based bookmark code is fully hardened.

## Done

- [x] `Project` and `Favorite` types
- [x] settingsStore CRUD actions
- [x] projectsStore with picker/switch/navigate actions
- [x] ProjectsPanel component (projects and favorites modes)
- [x] FileListPanel integration (header buttons, content routing, context menus)
- [x] MAS bookmark array activation in settings:load
- [x] Build passes (all three: main, preload, renderer)

## TODOs / open questions for morning review

- [ ] **Quick switcher** — issue spec mentions "quick switcher between projects"; not implemented yet. Would need a Cmd+K style modal. Defer to follow-up?
- [ ] **Project-specific settings** — issue mentions "default save location, sync preferences" per project. This PR stores only `path` + `name` + `bookmark`. Should the `Project` type grow a `settings?: Partial<SettingsBase>` bag? Needs design discussion.
- [ ] **Reactivating bookmarks at runtime** (not just at startup) — when user switches projects mid-session, the new project's `startAccessingSecurityScopedResource` call currently happens only via `switchToProject` updating `defaultSaveDirectory`+`masDirectoryBookmark` and relying on the NEXT launch. For MAS sandbox correctness within the same session, we may need to call `startAccessingSecurityScopedResource` directly at switch time via a new IPC channel (e.g. `file:activateBookmark`). Flagged as a TODO.
- [ ] **Duplicate detection** — the context-menu "Add as Project / Add to Favorites" shortcuts silently no-ops if the path already exists. Should there be user feedback?
- [ ] **Reorder** — no drag-to-reorder yet. Alphabetical or by lastOpenedAt is the current sort.
- [ ] **`useSettingsStore` unused import** in `ProjectsPanel.tsx` — imported but the rename logic calls `useSettingsStore.getState()` directly. TypeScript doesn't flag it but it's slightly inconsistent with the pattern elsewhere where store is destructured from the hook. Minor cleanup.
- [ ] **`setViewMode` in projectsStore** calls `fileList.setViewMode('folder')` — this is fine but might want to be `'projects'` so the toggle button stays lit when switching projects. UX question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)