### PR TITLE
fix(sentry): allow sentry-ipc: scheme in CSP connect-src

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -427,7 +427,11 @@ app.whenReady().then(async () => {
     is.dev ? "script-src 'self' 'unsafe-eval'" : "script-src 'self'",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    "connect-src 'self' https://api.anthropic.com https://accounts.google.com https://www.googleapis.com https://docs.googleapis.com https://oauth2.googleapis.com https://*.ingest.sentry.io",
+    // sentry-ipc: is @sentry/electron's renderer→main transport scheme; without it
+    // the renderer SDK's envelope POSTs are refused by CSP (heavy console spam in MAS,
+    // and crash reports never reach the main process). https://*.ingest.sentry.io is
+    // the upload endpoint used by the main process itself.
+    "connect-src 'self' https://api.anthropic.com https://accounts.google.com https://www.googleapis.com https://docs.googleapis.com https://oauth2.googleapis.com https://*.ingest.sentry.io sentry-ipc:",
     // img-src https: is needed for documents with remote images (![](https://...))
     // Tightening this would require a proxy or URL allowlist
     "img-src 'self' data: https: local-file:",


### PR DESCRIPTION
Closes #391

## Problem
The MAS/TestFlight build spams the console with:
> Fetch API cannot load sentry-ipc://scope/sentry_key. Refused to connect because it violates the document's Content Security Policy.

`@sentry/electron/renderer` forwards envelopes to the main process over the custom `sentry-ipc:` scheme. Our CSP `connect-src` allowed the *upload* host (`https://*.ingest.sentry.io`) but **not** the IPC scheme — so every renderer-side envelope POST was refused, producing the spam and meaning renderer crash reports never reached the main process.

## Fix
Add `sentry-ipc:` to the `connect-src` directive in `src/main/index.ts`. The CSP is universal (not MAS-gated), so this also fixes the same refusal on desktop/dev builds.

## Verification
- Dev server builds clean; Electron launches without errors.
- Confirmed `sentry-ipc:` is present in the emitted `connect-src` of the built `out/main/index.js`.
- Local: with Error Reporting enabled, DevTools console shows no `Refused to connect ... sentry-ipc://` violations.
- Definitive "spam gone" check is the MAS/TestFlight build (local MAS launch is blocked by #487).

## Follow-up
The benign runtime-toggle init-timing warning (`Sentry SDK should be initialized before 'ready'`) is tracked separately in #655 — it touches the privacy invariant (never init unless opted in) and is out of scope here.

Part of **Wave 0.5 — MAS Refresh**.