### PR TITLE
docs: advance roadmap to Wave 0.5 (MAS Refresh) + release checklist

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -1,0 +1,157 @@
+# Wave 0.5 — MAS Refresh (release checklist)
+
+**Status:** Active · **Created:** 2026-06-01 · **Owner:** local HITL
+**Roadmap:** [`../roadmap.md`](../roadmap.md) (Wave 0.5 · *Do Next*) · **Board:** [#5](https://github.com/orgs/solo-ist/projects/5/views/1)
+
+The next Mac App Store release. Bundles Wave 0's shipped QoL/feature work (v1.5.0 + v1.6.0 + v1.6.1)
+with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build lands
+**fixes + new branding + free pricing together**. Per the Distribution & Monetization Model,
+**MAS is the free taste** — never the paid surface.
+
+---
+
+## Hard boundaries (read before touching build config)
+
+- **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
+  automation edge; clicking "Submit for Review" is always a human decision and action.
+- **`buildVersion` is global-monotonic.** Currently `"22"` in `electron-builder.yml`.
+  Every upload to App Store Connect must use a strictly higher integer than any prior upload —
+  **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.1`).
+- **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS
+  entitlements without re-validating against the provisioning profile.
+- The `mas` target force-disables reMarkable (credentials/OCR not App-Store-ready) and blocks
+  MCP install/uninstall/status via `IS_MAS_BUILD` — expected, don't "fix" it.
+
+---
+
+## Sequenced work
+
+Ordered by the roadmap's sequencing: unblock local QA → harden → cheap config/asset/copy bulk.
+
+### 0. Critical path — restore local MAS QA
+- [ ] **#487** — `masDev` local launch fails (Launchd 163). Local MAS-sandbox QA is broken;
+      verification otherwise falls back to the slow (~15-min) TestFlight upload loop.
+      **Debug this first.** See the investigation log below. If it proves intractable in a
+      time-box, fall back to TestFlight-only verification and note that decision here.
+
+### 1. MAS hardening (real code/config risk)
+- [ ] **#391** — Sentry CSP blocks the `sentry-ipc` protocol in the MAS build. Land crash
+      reporting on the free client. Touches CSP + Sentry init; verify Sentry stays **opt-in**.
+- [ ] **#376** — Enable asar integrity fuses in production builds. Hardens the self-distributed
+      DMG/ZIP too, not just MAS. Verify the app still launches signed after fuse flip.
+
+### 2. The cheap bulk (config / assets / copy)
+- [ ] **#615** — Drop the $0.99 price → ship free. App Store Connect pricing change +
+      any in-repo references. Low code risk.
+- [ ] **#612** — Refresh App Store screenshots + icon for the new branding.
+- [ ] **#613** — Refresh App Store description + persona copy. Current `docs/app-store-copy.md`
+      is **stale** ("First release" promo text, pre-rebrand) — rewrite it.
+
+### 3. Deprioritized (revisit only if needed)
+- [ ] **#409** — MAS universal binary (arm64 + x64). Revisit only if Intel demand shows.
+- [ ] **#317** — Agent-driven macOS UI testing via Circuit + GitHub Actions (test infra).
+
+---
+
+## #487 investigation log
+
+Symptom: `electron-builder --mac mas-dev` → dev-signed `dist/mas-dev-arm64/Prose.app`
+fails to launch with `RBSRequestErrorDomain Code=5` / `NSPOSIXErrorDomain Code=163`
+("Launchd job spawn failed") on macOS 15.3 / Darwin 25.3.
+
+Already tried (no effect): installing the dev provisioning profile, removing
+`com.apple.provenance` xattrs, copying to `/tmp/`, direct binary launch, `log show` (no AMFI/
+sandbox/launchd denial surfaced). Production `mas` target also won't launch locally (expected —
+bound to the App Store install flow).
+
+Leads to chase (from the issue): dev cert in System vs login keychain · register profile via
+Xcode "Download Manual Profiles" · exact `com.apple.security.app-group` match
+(`8PT2Y7QQ2F.ist.solo.prose`) · recent macOS/Xcode policy change for locally-launched
+MAS-sandboxed dev builds.
+
+### Root cause (corrected 2026-06-01 — provisioning/device gap, NOT a cert problem)
+
+> An earlier pass misdiagnosed this as a missing/cross-team cert. The valid Apple Development
+> cert's CN is `Apple Development: ANGEL MARINO (2Y3M2V2Q5F)`, and the parenthetical `(2Y3M2V2Q5F)`
+> was misread as the team. It isn't — in an Apple Development cert the CN parenthetical is a
+> *per-developer* identifier; **the team is the cert's `OU`.** (h/t Claude Cowork for the catch.)
+
+Verified against the keychain (`openssl x509 -subject` on the exported certs):
+
+```
+# valid — OU is the MAS team
+C=US, O=ANGEL MARINO, OU=8PT2Y7QQ2F, CN=Apple Development: ANGEL MARINO (2Y3M2V2Q5F), UID=HX2XHG7583   notAfter=2027-03-18
+# expired — parenthetical ≠ OU
+C=US, O=Angel Marino, OU=PDU38J9F73, CN=Apple Development: Angel Marino (2R28G5K25U), UID=9T728L4SV8   notAfter=2025-01-09
+```
+
+The valid Apple Development cert is **already under team `8PT2Y7QQ2F`** (good through 2027-03-18) —
+there is no cross-team cert. Error 163 is downstream of the cert: most likely a **stale or missing
+development provisioning profile** (built against the expired `2R28G5K25U`/`PDU38J9F73` cert, or not
+listing this Mac), or this Mac not being registered under `8PT2Y7QQ2F`. A dev profile can't
+authorize an unlisted device. (This is consistent with MAS *release* already working — release
+signs via the Distribution chain, never implicated here.)
+
+Environment note: machine is now **macOS 26.3 (25D125)** on **Apple M4 Pro**; Provisioning UDID
+**`00006040-0004482A0187801C`**. (Issue was filed on macOS 15.3.)
+
+### Fix — provisioning, not code (human-gated; needs the `8PT2Y7QQ2F` Apple ID)
+
+1. ~~Mint an `Apple Development` cert under `8PT2Y7QQ2F`~~ — **not needed; already exists**
+   (`OU=8PT2Y7QQ2F`, valid through 2027-03-18).
+2. **Confirm this Mac is registered under `8PT2Y7QQ2F`.** Portal → Devices → Platform macOS →
+   Provisioning UDID `00006040-0004482A0187801C` (or let Xcode auto-register on first build).
+3. **Regenerate `build/Prose_Development.provisionprofile`** for app ID `ist.solo.prose` under
+   `8PT2Y7QQ2F`, embedding the existing `8PT2Y7QQ2F` dev cert, this Mac, and the **App Groups**
+   capability (`8PT2Y7QQ2F.ist.solo.prose`).
+4. **(Optional / defensive) Pin `masDev.identity`** to the existing cert's SHA-1
+   (`5106DA8B43E1AF25E3B553CABD91400445A9E68A`). With only one *valid* Apple Development cert
+   present, bare `Apple Development` already resolves to it — hygiene, not a fix.
+5. **Rebuild + verify:** `npx electron-builder --mac mas-dev` → launch `dist/mas-dev-arm64/Prose.app`.
+   Expect a clean launch and working file-open/bookmark persistence under real sandbox enforcement.
+
+Most likely root cause: a stale or missing development provisioning profile, not the certificate.
+Fallback if blocked: TestFlight-only verification (the issue's documented workaround).
+
+---
+
+## Build & upload runbook
+
+```bash
+# 1. Bump marketing version if cutting a new one (package.json "version"); DO NOT touch buildVersion
+#    unless incrementing it for a fresh upload (electron-builder.yml "buildVersion", monotonic).
+
+# 2. Build the App Store package
+npm run build:mas            # MAS_BUILD=1 npm run build && electron-builder --mac mas
+                             # → dist/mas-arm64/Prose-<version>.pkg
+
+# 3. Build the dev target for local sandbox QA (the thing #487 currently breaks)
+npx electron-builder --mac mas-dev   # → dist/mas-dev-arm64/Prose.app
+
+# 4. Upload to App Store Connect / TestFlight (human-gated edge — automation STOPS here)
+#    NOTE: Apple has deprecated `altool` for App Store delivery — prefer the Transporter app
+#    or `xcrun iTMSTransporter`. altool still ships in Xcode (26.5 here) and works as a fallback.
+#    Supply the Key ID + Issuer UUID via env (never hardcode them); the .p8 private key
+#    lives under ~/.appstoreconnect/private_keys/.
+xcrun altool --upload-app \
+  --type macos \
+  --file dist/mas-arm64/Prose-<version>.pkg \
+  --apiKey "$ASC_KEY_ID" \
+  --apiIssuer "$ASC_ISSUER_ID"
+```
+
+The notarized DMG/ZIP for the **self-distributed** channel ship separately via `release.yml`
+on a `v*` tag (already published through **v1.6.1**, the current latest release).
+
+---
+
+## Pre-submission gate (all human-confirmed)
+
+- [ ] `buildVersion` incremented above the last App Store Connect upload.
+- [ ] reMarkable + MCP correctly gated out of the MAS build (`IS_MAS_BUILD`).
+- [ ] Sentry opt-in still defaults off; `sentry-ipc` works in MAS (#391).
+- [ ] App launches signed with asar fuses enabled (#376).
+- [ ] Pricing set to free in App Store Connect (#615).
+- [ ] New screenshots + icon + description uploaded (#612, #613).
+- [ ] TestFlight build verified on a real install (covers what #487's local loop can't).
+- [ ] **STOP** — submission for review is a human action.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Prose Roadmap
 
-**Status:** Active · **Updated:** 2026-05-26 · **Live priority:** [Project board #5](https://github.com/orgs/solo-ist/projects/5/views/1)
+**Status:** Active · **Updated:** 2026-06-01 · **Live priority:** [Project board #5](https://github.com/orgs/solo-ist/projects/5/views/1)
 
 > **Reading this cold?** Top-to-bottom this tells you the strategy, the phase we're in, what to pick up next, and how work flows — enough to resume mid-stream. This doc is the narrative + operating model; the **project board is the live queue** and the **milestones mirror the waves**. For dev/security/build conventions, see [`../CLAUDE.md`](../CLAUDE.md).
 
@@ -8,13 +8,13 @@
 
 ## You are here
 
-- **Active wave: Wave 0 — QoL & Bug Fixes** (20 issues). Runs as sequenced cloud-agent batches followed by local human-in-the-loop QA.
-- **Grab-next, fully unblocked:** the two P1 data-loss fixes — [#578](https://github.com/solo-ist/prose/issues/578) (`suggest_edit` clobbers a single-paragraph doc) and [#595](https://github.com/solo-ist/prose/issues/595) (comments dropped on tab switch). Do these as individual PRs with careful QA. Then the batched P2–P5 polish/correctness fixes.
-- **One caveat in Wave 0:** [#536](https://github.com/solo-ist/prose/issues/536) (Sentry→GitHub) splits into an agent-doable repo slice (labels + issue template) and a manual Sentry-console slice (human only) — see the note on the issue.
-- **Next:** **Wave 0.5 — MAS Refresh** (the next App Store release: QoL fixes + rebrand + drop to free), then **Wave 1 — Core Build-Out** (three parallel tracks, gated by the spikes).
+- **Active wave: Wave 0.5 — MAS Refresh** (8 issues, *Do Next*). The next App Store release — bundles Wave 0's shipped QoL/feature work with the rebrand ([#612](https://github.com/solo-ist/prose/issues/612)/[#613](https://github.com/solo-ist/prose/issues/613)), drop-to-free pricing ([#615](https://github.com/solo-ist/prose/issues/615)), and MAS hardening ([#391](https://github.com/solo-ist/prose/issues/391) Sentry CSP, [#376](https://github.com/solo-ist/prose/issues/376) asar fuses).
+- **Grab-next / critical path:** [#487](https://github.com/solo-ist/prose/issues/487) — `masDev` local launch fails (Launchd 163). Local MAS-sandbox QA is broken, so verification currently falls back to the slow TestFlight upload cycle. **Being debugged first** to restore a tight local loop before the rest of the refresh.
+- **The cheap bulk:** [#615](https://github.com/solo-ist/prose/issues/615) (free pricing — config), [#612](https://github.com/solo-ist/prose/issues/612) (screenshots + icon), [#613](https://github.com/solo-ist/prose/issues/613) (App Store description + persona copy — the current copy in [`app-store-copy.md`](app-store-copy.md) is stale). [#409](https://github.com/solo-ist/prose/issues/409) (universal binary) and [#317](https://github.com/solo-ist/prose/issues/317) (agent-driven macOS UI testing) are deprioritized.
+- **Hard boundary:** never submit for App Store review — TestFlight upload is the automation edge; submission is a human action. MAS `buildVersion` is global-monotonic — never reset it on a marketing-version bump.
+- **Wave 0 — done.** Shipped in **v1.5.0** (2026-05-28 — P1–P5 bug/QoL batch + [#641](https://github.com/solo-ist/prose/issues/641) HTML export) and **v1.6.0** (2026-06-01 — [#385](https://github.com/solo-ist/prose/issues/385) Quick Review redesign · [#386](https://github.com/solo-ist/prose/issues/386) AI edits history · [#380](https://github.com/solo-ist/prose/issues/380) Projects & Favorites first pass). **v1.6.1** (2026-06-02) is now the latest published GitHub release (DMG/ZIP, notarized), adding a follow-up batch — #645 annotation visibility, #646 reopen-closed-tab, #648 comment anchoring, plus reMarkable fixes #652/#667. MAS is still deferred to this Wave 0.5 run. Stragglers still open: [#384](https://github.com/solo-ist/prose/issues/384) Homebrew Cask (now unblocked by the notarized DMG) and [#536](https://github.com/solo-ist/prose/issues/536) Sentry→GitHub (hybrid: agent repo slice + manual Sentry-console slice). [#380](https://github.com/solo-ist/prose/issues/380) stays open pending follow-up [#654](https://github.com/solo-ist/prose/issues/654).
+- **Next:** **Wave 1 — Core Build-Out** — three concurrent tracks on the **A→B→C merge ladder**, gated by the spikes ([#601](https://github.com/solo-ist/prose/issues/601)/[#602](https://github.com/solo-ist/prose/issues/602) for Track C, [#616](https://github.com/solo-ist/prose/issues/616) for Track B).
 - **Deferred (On Hold):** Wave 2 (Generative Codebase), vision/research, and the parked Authorship Annotations cluster.
-- **No feature work is mid-flight in code right now** (no open feature PRs). The board is the queue; pick from the active columns.
-- **Recently shipped:** auto-update relaunch (#577), chat-input layout jump (#584), and this roadmap/board refresh (#614).
 
 ## How work flows (operating model)
 
@@ -62,8 +62,8 @@ The phases run roughly in order: **Wave 0 → Wave 0.5 → (Spikes) → Wave 1 �
 | [#603](https://github.com/solo-ist/prose/issues/603) | Light confirmation that generative/terminal gates cleanly out of MAS. Expect "yes." |
 | [#616](https://github.com/solo-ist/prose/issues/616) | Research the official reMarkable app + competitive landscape to validate Track B's parity scope before building it. |
 
-### Wave 0 — QoL & Bug Fixes · *active · Do First + Quick Wins*
-Sequenced cloud-agent batches + local QA. Suggested order: P1 first (individual PRs), then P2–P3 batched polish, then P4/P5 by subsystem.
+### Wave 0 — QoL & Bug Fixes · *done — shipped v1.5.0 + v1.6.0 + v1.6.1*
+Shipped as sequenced cloud-agent batches + local QA. The P1–P5 bug/QoL batch landed in v1.5.0; the three features (#385/#386/#380) in v1.6.0; a follow-up batch (#645/#646/#648/#652/#667) in v1.6.1. Stragglers still open: #384 (Homebrew) and #536 (Sentry→GitHub hybrid); #380 held for follow-up #654.
 
 | Issue | Group | Captures |
 |---|---|---|
@@ -88,8 +88,8 @@ Sequenced cloud-agent batches + local QA. Suggested order: P1 first (individual 
 | [#380](https://github.com/solo-ist/prose/issues/380) | feature | Projects & Favorites in the file explorer. |
 | [#494](https://github.com/solo-ist/prose/issues/494) | docs | Fresh CLAUDE.md / docs accuracy audit. |
 
-### Wave 0.5 — MAS Refresh · *Do Next*
-Bundles with Wave 0's QoL fixes so the **next MAS release** ships fixes + new branding + free pricing together.
+### Wave 0.5 — MAS Refresh · *active · Do Next*
+Bundles with Wave 0's shipped QoL fixes so the **next MAS release** ships fixes + new branding + free pricing together. Driven by [`launch/wave-0.5-mas-refresh.md`](launch/wave-0.5-mas-refresh.md). Sequencing: debug #487 first (restores local MAS QA), then the hardening pair (#391, #376), then the cheap config/asset/copy bulk (#615, #612, #613), with #409/#317 deprioritized.
 
 | Issue | Captures |
 |---|---|


### PR DESCRIPTION
Reconciles the roadmap with shipped state and stands up the MAS-release plan doc.

## Roadmap (`docs/roadmap.md`)
- **"You are here"** rewritten: Wave 0 is **done** (v1.5.0 bug/QoL batch + v1.6.0's #385/#386/#380); **Wave 0.5 — MAS Refresh is now active**. Critical path called out as #487. Stragglers noted (#384 Homebrew, #536 Sentry→GitHub; #380 held for #654).
- Wave 0 / Wave 0.5 section headers updated to reflect status.

## New: `docs/launch/wave-0.5-mas-refresh.md`
Release checklist driving Wave 0.5:
- Sequences all 8 MAS issues (debug #487 → harden #391/#376 → cheap config/asset/copy #615/#612/#613 → deprioritized #409/#317).
- Hard boundaries (never submit for review; `buildVersion` monotonic; sandbox flags).
- **#487 root-cause investigation log** — the team-identity gap (missing `8PT2Y7QQ2F` Apple Development cert) + the 4-step provisioning fix.
- Build/upload runbook + pre-submission gate.

Docs-only; no code changes.