### PR TITLE
fix(annotations): keep AI provenance highlights perceptibly visible

### DIFF
--- a/src/renderer/extensions/ai-annotations/plugin.ts
+++ b/src/renderer/extensions/ai-annotations/plugin.ts
@@ -129,7 +129,6 @@ export function createAIAnnotationsPlugin(options: AIAnnotationOptions = {}) {
             }
 
             const opacity = calculateOpacity(annotation.createdAt, opts.maxAge)
-            if (opacity < ANNOTATION_CONSTANTS.MIN_OPACITY) continue
 
             decorations.push(
               Decoration.inline(annotation.from, annotation.to, {
@@ -243,7 +242,6 @@ export function createAIAnnotationsPlugin(options: AIAnnotationOptions = {}) {
               }
 
               const opacity = calculateOpacity(annotation.createdAt, opts.maxAge)
-              if (opacity < ANNOTATION_CONSTANTS.MIN_OPACITY) continue
 
               decorations.push(
                 Decoration.inline(annotation.from, annotation.to, {

--- a/src/renderer/types/annotations.ts
+++ b/src/renderer/types/annotations.ts
@@ -124,8 +124,8 @@ export interface AnnotationDecorationMeta {
 export const ANNOTATION_CONSTANTS = {
   /** Maximum age before fully faded (7 days in ms) */
   MAX_AGE_MS: 7 * 24 * 60 * 60 * 1000,
-  /** Minimum opacity (never fully invisible for accessibility) */
-  MIN_OPACITY: 0.05,
+  /** Minimum opacity (perceptible resting floor; never fades to invisible) */
+  MIN_OPACITY: 0.3,
   /** How often to recalculate opacity (every 5 minutes) */
   REFRESH_INTERVAL_MS: 5 * 60 * 1000,
 } as const


### PR DESCRIPTION
## Summary

- Raised `MIN_OPACITY` in `ANNOTATION_CONSTANTS` from `0.05` to `0.3` — annotations now settle at a clearly perceptible resting floor instead of fading to near-invisibility after 7 days
- Removed two now-dead `if (opacity < ANNOTATION_CONSTANTS.MIN_OPACITY) continue` guards in `plugin.ts` (init path and apply rebuild path): with the floor at 0.3, `Math.max(MIN_OPACITY, opacity)` guarantees the condition can never be true, so the guards were unreachable dead code
- The gentle decay curve (`Math.pow(1 - ratio, 0.7)`), `MAX_AGE_MS` (7 days), and `REFRESH_INTERVAL_MS` are unchanged — only the floor moves

The only thing that should hide annotations is the user's explicit visibility toggle; time alone can never make them invisible.

Closes #645

## Verification

- Build: `npm run build` completes with no TypeScript or compile errors (only pre-existing `"use client"` directive warnings from node_modules)
- Manual: open a document with week-old AI annotations — they should remain visibly highlighted at ~30% opacity rather than disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)