### PR TITLE
fix(comments): anchor restored comments to the correct duplicate occurrence

### DIFF
--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -330,7 +330,7 @@ export const Comment = Mark.create<CommentOptions>({
 /**
  * Extract all comments from the editor
  */
-export function getComments(editor: { state: { doc: { descendants: (fn: (node: { marks: Array<{ type: { name: string }; attrs: { id: string; comment: string; createdAt: number } }>; nodeSize: number; textContent: string }, pos: number) => void) => void; textBetween: (from: number, to: number, blockSeparator?: string) => string } } }): CommentData[] {
+export function getComments(editor: { state: { doc: { descendants: (fn: (node: { marks: Array<{ type: { name: string }; attrs: { id: string; comment: string; createdAt: number } }>; nodeSize: number; textContent: string }, pos: number) => void) => void; textBetween: (from: number, to: number, blockSeparator?: string) => string; textContent: string } } }): CommentData[] {
   // Map to collect all text nodes for each comment ID
   const commentMap = new Map<string, {
     texts: string[]

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -142,12 +142,14 @@ export const Comment = Mark.create<CommentOptions>({
           const docText = state.doc.textContent
           const charsBefore = state.doc.textBetween(0, from, '').length
           let occurrenceIndex = 0
-          let searchOffset = 0
-          while (true) {
-            const matchIdx = docText.indexOf(markedText, searchOffset)
-            if (matchIdx === -1 || matchIdx >= charsBefore) break
-            occurrenceIndex++
-            searchOffset = matchIdx + markedText.length
+          if (markedText) {
+            let searchOffset = 0
+            while (true) {
+              const matchIdx = docText.indexOf(markedText, searchOffset)
+              if (matchIdx === -1 || matchIdx >= charsBefore) break
+              occurrenceIndex++
+              searchOffset = matchIdx + markedText.length
+            }
           }
 
           const commentData: CommentData = {
@@ -375,12 +377,14 @@ export function getComments(editor: { state: { doc: { descendants: (fn: (node: {
     // Convert to char-space via textBetween before comparing against matchIdx.
     const charsBefore = editor.state.doc.textBetween(0, data.from, '').length
     let occurrenceIndex = 0
-    let searchOffset = 0
-    while (true) {
-      const matchIdx = docText.indexOf(markedText, searchOffset)
-      if (matchIdx === -1 || matchIdx >= charsBefore) break
-      occurrenceIndex++
-      searchOffset = matchIdx + markedText.length
+    if (markedText) {
+      let searchOffset = 0
+      while (true) {
+        const matchIdx = docText.indexOf(markedText, searchOffset)
+        if (matchIdx === -1 || matchIdx >= charsBefore) break
+        occurrenceIndex++
+        searchOffset = matchIdx + markedText.length
+      }
     }
 
     comments.push({

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -236,11 +236,13 @@ export const Comment = Mark.create<CommentOptions>({
             let currentOccurrence = 0
             let searchOffset = 0
             let textIndex = -1
+            let foundTarget = false
             while (true) {
               const matchIdx = docText.indexOf(searchText, searchOffset)
               if (matchIdx === -1) break
               textIndex = matchIdx // track last found as fallback
               if (currentOccurrence === targetOccurrence) {
+                foundTarget = true
                 break
               }
               currentOccurrence++
@@ -253,7 +255,7 @@ export const Comment = Mark.create<CommentOptions>({
               })
               continue
             }
-            if (currentOccurrence !== targetOccurrence) {
+            if (!foundTarget) {
               // Fewer occurrences than expected (text changed); fell back to last found
               console.warn('[Comment] occurrenceIndex out of range, using last occurrence:', {
                 id: comment.id,

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -134,12 +134,18 @@ export const Comment = Mark.create<CommentOptions>({
           // Compute how many non-overlapping occurrences of markedText appear
           // in the document strictly before the selection start (from).
           // This is the 0-based occurrence index for this comment.
+          //
+          // IMPORTANT: `from` is a ProseMirror position (counts node-boundary
+          // tokens), while `matchIdx` is a char offset into doc.textContent.
+          // Convert `from` to char-space first via textBetween so the comparison
+          // is in the same coordinate system.
           const docText = state.doc.textContent
+          const charsBefore = state.doc.textBetween(0, from, '').length
           let occurrenceIndex = 0
           let searchOffset = 0
           while (true) {
             const matchIdx = docText.indexOf(markedText, searchOffset)
-            if (matchIdx === -1 || matchIdx >= from) break
+            if (matchIdx === -1 || matchIdx >= charsBefore) break
             occurrenceIndex++
             searchOffset = matchIdx + markedText.length
           }
@@ -362,11 +368,15 @@ export function getComments(editor: { state: { doc: { descendants: (fn: (node: {
 
     // Compute occurrenceIndex: how many non-overlapping prior occurrences of
     // markedText exist in the full document text before data.from.
+    //
+    // IMPORTANT: `data.from` is a ProseMirror position, not a char offset.
+    // Convert to char-space via textBetween before comparing against matchIdx.
+    const charsBefore = editor.state.doc.textBetween(0, data.from, '').length
     let occurrenceIndex = 0
     let searchOffset = 0
     while (true) {
       const matchIdx = docText.indexOf(markedText, searchOffset)
-      if (matchIdx === -1 || matchIdx >= data.from) break
+      if (matchIdx === -1 || matchIdx >= charsBefore) break
       occurrenceIndex++
       searchOffset = matchIdx + markedText.length
     }

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -90,6 +90,16 @@ export const Comment = Mark.create<CommentOptions>({
           return { 'data-comment-created': String(attributes.createdAt) }
         },
       },
+      occurrenceIndex: {
+        default: 0,
+        parseHTML: (element) => {
+          const val = element.getAttribute('data-comment-occurrence')
+          return val !== null ? parseInt(val, 10) : 0
+        },
+        renderHTML: (attributes) => {
+          return { 'data-comment-occurrence': String(attributes.occurrenceIndex ?? 0) }
+        },
+      },
     }
   },
 
@@ -121,11 +131,25 @@ export const Comment = Mark.create<CommentOptions>({
           // Get the selected text
           const markedText = state.doc.textBetween(from, to, ' ')
 
+          // Compute how many non-overlapping occurrences of markedText appear
+          // in the document strictly before the selection start (from).
+          // This is the 0-based occurrence index for this comment.
+          const docText = state.doc.textContent
+          let occurrenceIndex = 0
+          let searchOffset = 0
+          while (true) {
+            const matchIdx = docText.indexOf(markedText, searchOffset)
+            if (matchIdx === -1 || matchIdx >= from) break
+            occurrenceIndex++
+            searchOffset = matchIdx + markedText.length
+          }
+
           const commentData: CommentData = {
             id: attrs.id,
             markedText,
             comment: attrs.comment,
             createdAt: Date.now(),
+            occurrenceIndex,
             from,
             to,
           }
@@ -134,6 +158,7 @@ export const Comment = Mark.create<CommentOptions>({
             id: attrs.id,
             comment: attrs.comment,
             createdAt: Date.now(),
+            occurrenceIndex,
           })
 
           if (result && this.options.onCommentAdded) {
@@ -199,13 +224,36 @@ export const Comment = Mark.create<CommentOptions>({
             }
 
             const docText = doc.textContent
-            const textIndex = docText.indexOf(searchText)
+            // Walk occurrences of searchText and stop at the Nth one, where N is
+            // comment.occurrenceIndex (default 0 for backward-compat with older data).
+            const targetOccurrence = comment.occurrenceIndex ?? 0
+            let currentOccurrence = 0
+            let searchOffset = 0
+            let textIndex = -1
+            while (true) {
+              const matchIdx = docText.indexOf(searchText, searchOffset)
+              if (matchIdx === -1) break
+              textIndex = matchIdx // track last found as fallback
+              if (currentOccurrence === targetOccurrence) {
+                break
+              }
+              currentOccurrence++
+              searchOffset = matchIdx + searchText.length
+            }
             if (textIndex === -1) {
               console.warn('[Comment] Cannot find markedText in document:', {
                 id: comment.id,
                 markedText: searchText.substring(0, 50)
               })
               continue
+            }
+            if (currentOccurrence !== targetOccurrence) {
+              // Fewer occurrences than expected (text changed); fell back to last found
+              console.warn('[Comment] occurrenceIndex out of range, using last occurrence:', {
+                id: comment.id,
+                targetOccurrence,
+                usedOccurrence: currentOccurrence
+              })
             }
 
             // Walk the document to map char index → ProseMirror positions
@@ -244,6 +292,7 @@ export const Comment = Mark.create<CommentOptions>({
               id: comment.id,
               comment: comment.comment,
               createdAt: comment.createdAt,
+              occurrenceIndex: comment.occurrenceIndex ?? 0,
             })
 
             tr.addMark(foundStart, foundEnd, mark)
@@ -306,13 +355,28 @@ export function getComments(editor: { state: { doc: { descendants: (fn: (node: {
   })
 
   // Convert map to array, joining all text nodes with paragraph separator
+  const docText = editor.state.doc.textContent
   const comments: CommentData[] = []
   commentMap.forEach((data, id) => {
+    const markedText = editor.state.doc.textBetween(data.from, data.to, ' ')
+
+    // Compute occurrenceIndex: how many non-overlapping prior occurrences of
+    // markedText exist in the full document text before data.from.
+    let occurrenceIndex = 0
+    let searchOffset = 0
+    while (true) {
+      const matchIdx = docText.indexOf(markedText, searchOffset)
+      if (matchIdx === -1 || matchIdx >= data.from) break
+      occurrenceIndex++
+      searchOffset = matchIdx + markedText.length
+    }
+
     comments.push({
       id,
-      markedText: editor.state.doc.textBetween(data.from, data.to, ' '),
+      markedText,
       comment: data.comment,
       createdAt: data.createdAt,
+      occurrenceIndex,
       from: data.from,
       to: data.to,
     })

--- a/src/renderer/extensions/comments/types.ts
+++ b/src/renderer/extensions/comments/types.ts
@@ -13,6 +13,8 @@ export interface CommentData {
   markedText: string
   comment: string
   createdAt: number
+  /** 0-based index of which occurrence of markedText this comment anchors to. Missing in older data → treated as 0. */
+  occurrenceIndex?: number
   from: number
   to: number
 }


### PR DESCRIPTION
## Summary

- Adds `occurrenceIndex: number` (0-based, optional for backward compat) to `CommentData` in `types.ts` and a new `data-comment-occurrence` HTML attribute to the comment mark in `extension.ts`
- At comment creation (`setComment`) and in `getComments`, counts how many non-overlapping occurrences of the selected phrase appear strictly before the comment's start position — storing that count as the `occurrenceIndex`
- In `restoreComments`, replaces the single `indexOf` (always first occurrence) with a running-offset loop that stops at the **Nth** occurrence (N = `occurrenceIndex`, defaulting to `0` for older persisted data with no field), with a graceful fallback to the last found occurrence if the document changed

## Backward compatibility

Older `CommentData` entries without `occurrenceIndex` default to `0` (first occurrence), which was the previous behavior — no migration needed.

## Test plan

- [ ] Add two comments to the same repeated phrase (e.g. "the word" appearing twice), one on each occurrence
- [ ] Switch tabs and switch back — verify each comment re-anchors to its original occurrence, not both to the first
- [ ] Open a document with older persisted comments (no `occurrenceIndex`) — verify they restore normally to the first occurrence
- [ ] Check console: no TypeScript errors, expected `[Comment] Restored` logs

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)