### PR TITLE
fix(remarkable): upgrade rmapi-js 9→10 to fix cloud sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "lucide-react": "^0.468.0",
         "marked": "^17.0.1",
         "react-resizable-panels": "^2.1.7",
-        "rmapi-js": "^9.0.3",
+        "rmapi-js": "^10.0.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "tiptap-markdown": "^0.8.10",
@@ -11576,9 +11576,9 @@
       }
     },
     "node_modules/rmapi-js": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/rmapi-js/-/rmapi-js-9.0.3.tgz",
-      "integrity": "sha512-6eTi4+3TUWqhn2MUGoo/JWJfwjBBlw2Lom2x5Fla9cWJf+Ih5yx3EmIpLyeFyeQcCAnvweZQyka86e0MzbsZbQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rmapi-js/-/rmapi-js-10.0.1.tgz",
+      "integrity": "sha512-ztpFOJt+GKBLaItJLZehFhLWc+UR6ZFbyWSQathLRAc8C+FRMy7CCCCbs/vzd+radoNFZoWqRGujgTKG8hSYYA==",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.49.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lucide-react": "^0.468.0",
     "marked": "^17.0.1",
     "react-resizable-panels": "^2.1.7",
-    "rmapi-js": "^9.0.3",
+    "rmapi-js": "^10.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "tiptap-markdown": "^0.8.10",

--- a/src/main/remarkable/client.ts
+++ b/src/main/remarkable/client.ts
@@ -1,7 +1,7 @@
 /**
  * reMarkable Cloud API client wrapper using rmapi-js
  */
-import { register as rmapiRegister, remarkable, type RemarkableApi, type Entry, type DocumentType } from 'rmapi-js'
+import { register as rmapiRegister, remarkable, type RemarkableApi, type Entry, type CollectionEntry, type DocumentType } from 'rmapi-js'
 
 export interface RemarkableNotebook {
   id: string
@@ -122,29 +122,46 @@ export function disconnect(): void {
 function createClient(api: RemarkableApi): RemarkableClient {
   return {
     async listNotebooks(): Promise<RemarkableNotebook[]> {
-      const items = await api.listItems(true)
+      // v10: listItems() uses the low-level API (no rm-filename header issues)
+      const items = await api.listItems()
 
-      return items.map((item: Entry): RemarkableNotebook => {
-        const isDocument = item.type === 'DocumentType'
-        const doc = item as DocumentType
+      return items
+        .filter((item: Entry): item is DocumentType | CollectionEntry => {
+          // Exclude TemplateType entries (new in v10) — we only care about
+          // user documents and folders
+          return item.type === 'DocumentType' || item.type === 'CollectionType'
+        })
+        .map((item): RemarkableNotebook => {
+          const isDocument = item.type === 'DocumentType'
+          const doc = item as DocumentType
 
-        return {
-          id: item.id,
-          hash: item.hash,
-          name: item.visibleName,
-          parent: item.parent === '' ? null : item.parent === 'trash' ? 'trash' : item.parent,
-          type: item.type === 'CollectionType' ? 'folder' : 'notebook',
-          fileType: isDocument ? doc.fileType : undefined,
-          lastModified: item.lastModified,
-          lastOpened: isDocument ? doc.lastOpened : undefined,
-          pinned: item.pinned
-        }
-      }).filter(item => item.parent !== 'trash') // Exclude trashed items
+          // v10: `parent` is optional (undefined means root, same as empty string in v9)
+          const rawParent = item.parent
+          const parent =
+            rawParent === undefined || rawParent === ''
+              ? null
+              : rawParent === 'trash'
+                ? 'trash'
+                : rawParent
+
+          return {
+            id: item.id,
+            hash: item.hash,
+            name: item.visibleName,
+            parent,
+            type: item.type === 'CollectionType' ? 'folder' : 'notebook',
+            fileType: isDocument ? doc.fileType : undefined,
+            lastModified: item.lastModified,
+            lastOpened: isDocument ? doc.lastOpened : undefined,
+            pinned: item.pinned
+          }
+        })
+        .filter(item => item.parent !== 'trash') // Exclude trashed items
     },
 
     async downloadNotebook(id: string, hash: string): Promise<Uint8Array> {
-      // getDocument returns a zip containing all notebook files
-      return await api.getDocument(hash)
+      // v10: getDocument now requires both id and hash (was hash-only in v9)
+      return await api.getDocument(id, hash)
     },
 
     async moveNotebook(hash: string, newParentId: string): Promise<string> {


### PR DESCRIPTION
## Summary

- Bumps `rmapi-js` from `^9.0.3` to `^10.0.0` (resolved to `10.0.1`) to fix the reMarkable cloud sync failure where listing notebooks errored with `{"message":"unexpected 'rm-filename' http header"}`
- Migrates all v10 breaking API changes in `src/main/remarkable/client.ts` (the only file that imports `rmapi-js` directly)
- Build passes with zero TypeScript/compile errors

## v10 Breaking Changes Migrated (`client.ts`)

| Change | v9 | v10 |
|--------|-----|-----|
| `getDocument` signature | `getDocument(hash)` | `getDocument(id, hash)` — now requires both `id` and `hash` |
| `listItems` call | `api.listItems(true)` | `api.listItems()` — refresh still accepted but no longer causes a bad `rm-filename` header |
| `Entry` union type | `CollectionEntry \| DocumentType` | `CollectionEntry \| DocumentType \| TemplateType` — `TemplateType` is new; filter added to exclude it |
| `CollectionEntry` import | not needed separately | added to imports for the type-predicate filter |
| `parent` field | always `string` | `string \| undefined` in `EntryCommon` — `undefined` treated as root (same as `""`) |

**Root cause of the `rm-filename` error:** In v9, `rmapi-js` was sending raw HTTP requests that included an `rm-filename` header incorrectly (either malformed or sent where not expected). v10 rewrites the low-level transport layer (see `RawRemarkableApi.getHash(fileName, hash)`) to properly scope the `rm-filename` header only to requests that require it, per the current reMarkable cloud API contract.

## Files Changed

- `package.json` — version bump `rmapi-js ^9.0.3 → ^10.0.0`
- `package-lock.json` — lock file updated to `rmapi-js@10.0.1`
- `src/main/remarkable/client.ts` — API migration (all usages of `rmapi-js` are in this one file)

`sync.ts` and `ocr.ts` are unchanged — they go through the `RemarkableClient` wrapper interface which remained stable.

## Testing

**Build:** `npm run build` completes with zero errors (all three stages: main, preload, renderer).

**Runtime QA required:** End-to-end verification (device registration → list notebooks → sync → OCR) must be performed by the user against a real reMarkable device before release. There is no automated test coverage for the reMarkable path.

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)