### PR TITLE
feat(tabs): reopen last closed tab on Cmd+Shift+T

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -141,6 +141,13 @@ export function createMenu(mainWindow: BrowserWindow): void {
             sendMenuAction('closeTab')
           }
         },
+        {
+          label: 'Reopen Closed Tab',
+          accelerator: 'CmdOrCtrl+Shift+T',
+          click: (): void => {
+            sendMenuAction('reopenClosedTab')
+          }
+        },
         { type: 'separator' },
         {
           label: 'Save',

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -76,7 +76,7 @@ export function App() {
 
   const googleDocsEnabled = useGoogleDocsEnabled()
   const { openFile, openFileFromPath, saveFile, saveFileAs, newFile } = useEditor()
-  const { createNewTab, openFileInTab } = useTabs()
+  const { createNewTab, openFileInTab, reopenLastClosedTab } = useTabs()
   const { setDialogOpen, isShortcutsDialogOpen, setShortcutsDialogOpen, isAboutDialogOpen, setAboutDialogOpen, isModelPickerOpen, setModelPickerOpen, settings, effectiveTheme, autosaveActive, isLoaded: settingsLoaded } = useSettings()
   const [recoveryDialogOpen, setRecoveryDialogOpen] = useState(false)
   const [pendingDraft, setPendingDraft] = useState<DraftState | null>(null)
@@ -822,6 +822,9 @@ export function App() {
           // Delegate to Toolbar which handles the dirty-state confirmation dialog
           window.dispatchEvent(new CustomEvent('menu:closeTab'))
           break
+        case 'reopenClosedTab':
+          reopenLastClosedTab()
+          break
         case 'googleSync':
           if (isGoogleDocsEnabled()) handleGoogleSync()
           break
@@ -853,7 +856,7 @@ export function App() {
     })
 
     return unsubscribe
-  }, [openFileInTab, saveFile, saveFileAs, createNewTab, setDialogOpen, toggleChat, toggleFileList, isFileListOpen, setShortcutsDialogOpen, setAboutDialogOpen, editor, handleGoogleSync, handleGoogleImport])
+  }, [openFileInTab, saveFile, saveFileAs, createNewTab, setDialogOpen, toggleChat, toggleFileList, isFileListOpen, setShortcutsDialogOpen, setAboutDialogOpen, editor, handleGoogleSync, handleGoogleImport, reopenLastClosedTab])
 
   // Handle menu:new custom event (dispatched by Editor keyboard handler for Cmd+N in web mode)
   useEffect(() => {

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -693,10 +693,13 @@ export function useTabs() {
    * Close all tabs except one
    */
   const closeOtherTabs = useCallback(async (keepTabId: string) => {
-    const tabsToClose = tabs.filter(t => t.id !== keepTabId && !t.isDirty)
+    // All tabs being removed by the store action (dirty included — store removes ALL others)
+    const allTabsToRemove = tabs.filter(t => t.id !== keepTabId)
+    // Subset used only for IndexedDB cleanup of untitled docs
+    const tabsToCleanUp = allTabsToRemove.filter(t => !t.isDirty)
 
-    // Snapshot non-preview tabs onto the closed-tab stack (most-recently-seen first)
-    for (const tab of [...tabsToClose].reverse()) {
+    // Snapshot every non-preview tab that will be removed (most-recently-seen first)
+    for (const tab of [...allTabsToRemove].reverse()) {
       if (!tab.isPreview) {
         pushClosedTab({
           path: tab.path,
@@ -710,8 +713,8 @@ export function useTabs() {
       }
     }
 
-    // Close all non-dirty tabs
-    for (const tab of tabsToClose) {
+    // Clean up IndexedDB data only for non-dirty untitled tabs
+    for (const tab of tabsToCleanUp) {
       if (!tab.path) {
         await deleteConversations(tab.documentId)
         await deleteAnnotations(tab.documentId)
@@ -732,7 +735,8 @@ export function useTabs() {
    * Close all tabs
    */
   const closeAllTabs = useCallback(async () => {
-    // Snapshot non-preview tabs onto the closed-tab stack (most-recently-seen first)
+    // Snapshot every non-preview tab (dirty included — store removes ALL tabs)
+    // Push most-recently-seen first so the last tab closed is first to be reopened
     for (const tab of [...tabs].reverse()) {
       if (!tab.isPreview) {
         pushClosedTab({
@@ -747,7 +751,7 @@ export function useTabs() {
       }
     }
 
-    // Close all non-dirty tabs
+    // Clean up IndexedDB data only for non-dirty untitled tabs
     for (const tab of tabs) {
       if (!tab.isDirty && !tab.path) {
         await deleteConversations(tab.documentId)
@@ -907,8 +911,8 @@ export function useTabs() {
     // Pause annotation position updates during document loading
     useAnnotationStore.getState().setLoadingDocument(true)
 
-    // Create the new tab in the store
-    const tabId = reopenLastClosedTabStore(snapshot, documentId)
+    // Create the new tab in the store (store sets activeTabId internally)
+    reopenLastClosedTabStore(snapshot, documentId)
 
     // Load the restored content into editorStore
     setDocument({
@@ -938,6 +942,9 @@ export function useTabs() {
       useFileListStore.getState().revealAndSelectPath(snapshot.path)
     }
 
+    // Mirrors the same delay used in switchToTab/openFileInTab: gives the editor
+    // time to fully mount the restored content before re-enabling annotation
+    // position mapping (prevents the plugin from dropping marks on the new doc).
     setTimeout(() => {
       useAnnotationStore.getState().setLoadingDocument(false)
     }, 100)

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -698,8 +698,9 @@ export function useTabs() {
     // Subset used only for IndexedDB cleanup of untitled docs
     const tabsToCleanUp = allTabsToRemove.filter(t => !t.isDirty)
 
-    // Snapshot every non-preview tab that will be removed (most-recently-seen first)
-    for (const tab of [...allTabsToRemove].reverse()) {
+    // Snapshot every non-preview tab that will be removed (oldest→newest so
+    // the last push — newest tab — lands on top of the stack after prepending)
+    for (const tab of allTabsToRemove) {
       if (!tab.isPreview) {
         pushClosedTab({
           path: tab.path,

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { useTabStore, createTab, generateUntitledTitle, type Tab } from '../stores/tabStore'
+import { useTabStore, createTab, generateUntitledTitle, type Tab, type ClosedTabSnapshot } from '../stores/tabStore'
 import { useEditorStore } from '../stores/editorStore'
 import { useEditorInstanceStore } from '../stores/editorInstanceStore'
 import { useChatStore, setCurrentDocumentId } from '../stores/chatStore'
@@ -58,6 +58,8 @@ export function useTabs() {
   const getActiveTab = useTabStore((state) => state.getActiveTab)
   const getTabByPath = useTabStore((state) => state.getTabByPath)
   const getTabById = useTabStore((state) => state.getTabById)
+  const pushClosedTab = useTabStore((state) => state.pushClosedTab)
+  const reopenLastClosedTabStore = useTabStore((state) => state.reopenLastClosedTab)
 
   const document = useEditorStore((state) => state.document)
   const setDocument = useEditorStore((state) => state.setDocument)
@@ -596,6 +598,20 @@ export function useTabs() {
       return false // Signal that tab needs save confirmation
     }
 
+    // Snapshot non-preview tabs onto the closed-tab stack before removing
+    if (!tab.isPreview) {
+      const snapshot: ClosedTabSnapshot = {
+        path: tab.path,
+        title: tab.title,
+        baseTitle: tab.baseTitle,
+        isDirty: tab.isDirty,
+        content: tab.content,
+        frontmatter: tab.frontmatter,
+        cursorPosition: tab.cursorPosition
+      }
+      pushClosedTab(snapshot)
+    }
+
     // If closing the active tab, we need special handling
     const wasActive = tabId === activeTabId
 
@@ -623,7 +639,7 @@ export function useTabs() {
     }
 
     return true
-  }, [getTabById, activeTabId, removeTab, createNewTab, switchToTab])
+  }, [getTabById, activeTabId, removeTab, createNewTab, switchToTab, pushClosedTab])
 
   /**
    * Force close a tab (after save or discard confirmation)
@@ -633,6 +649,20 @@ export function useTabs() {
     if (!tab) return
 
     const wasActive = tabId === activeTabId
+
+    // Snapshot non-preview tabs onto the closed-tab stack before removing
+    if (!tab.isPreview) {
+      const snapshot: ClosedTabSnapshot = {
+        path: tab.path,
+        title: tab.title,
+        baseTitle: tab.baseTitle,
+        isDirty: tab.isDirty,
+        content: tab.content,
+        frontmatter: tab.frontmatter,
+        cursorPosition: tab.cursorPosition
+      }
+      pushClosedTab(snapshot)
+    }
 
     // Remove the tab
     removeTab(tabId)
@@ -656,7 +686,7 @@ export function useTabs() {
         await switchToTab(newActiveTabId)
       }
     }
-  }, [getTabById, activeTabId, removeTab, createNewTab, switchToTab])
+  }, [getTabById, activeTabId, removeTab, createNewTab, switchToTab, pushClosedTab])
 
   /**
    * Close all tabs except one
@@ -807,6 +837,70 @@ export function useTabs() {
     }
   }, [getTabById, updateTab, document])
 
+  /**
+   * Reopen the most recently closed tab, restoring its content (including unsaved edits).
+   * No-op if the closed-tab stack is empty.
+   */
+  const reopenLastClosedTab = useCallback(async () => {
+    const closedTabs = useTabStore.getState().closedTabs
+    if (closedTabs.length === 0) return
+
+    const snapshot = closedTabs[0]
+
+    // Derive documentId: path-backed tabs get a stable ID from path; untitled tabs get fresh ID
+    let documentId: string
+    if (snapshot.path) {
+      documentId = await generateIdFromPath(snapshot.path)
+    } else {
+      documentId = generateId()
+    }
+
+    // Save current tab state before switching
+    await saveCurrentTabState()
+
+    // Pause annotation position updates during document loading
+    useAnnotationStore.getState().setLoadingDocument(true)
+
+    // Pop snapshot from store and create tab
+    const tabId = reopenLastClosedTabStore(documentId)
+    if (!tabId) {
+      useAnnotationStore.getState().setLoadingDocument(false)
+      return
+    }
+
+    // Load the restored content into editorStore
+    setDocument({
+      documentId,
+      path: snapshot.path,
+      content: snapshot.content ?? '',
+      frontmatter: snapshot.frontmatter ?? {},
+      isDirty: snapshot.isDirty
+    })
+
+    if (snapshot.cursorPosition) {
+      setCursorPosition(snapshot.cursorPosition.line, snapshot.cursorPosition.column)
+    }
+
+    setCurrentDocumentId(documentId)
+
+    // Load persisted chat/annotations/suggestions for this document
+    await loadChatForDocument(documentId)
+    await useAnnotationStore.getState().loadAnnotations(documentId)
+    await useSuggestionStore.getState().loadSuggestions(documentId)
+    await useCommentStore.getState().loadComments(documentId)
+
+    useEditorStore.getState().setRemarkableReadOnly(false, null)
+    setEditing(true)
+
+    if (snapshot.path) {
+      useFileListStore.getState().revealAndSelectPath(snapshot.path)
+    }
+
+    setTimeout(() => {
+      useAnnotationStore.getState().setLoadingDocument(false)
+    }, 100)
+  }, [saveCurrentTabState, reopenLastClosedTabStore, setDocument, setCursorPosition, loadChatForDocument, setEditing])
+
   return {
     tabs,
     activeTabId,
@@ -820,6 +914,7 @@ export function useTabs() {
     closeAllTabs,
     saveCurrentTabState,
     renameTab,
+    reopenLastClosedTab,
     getActiveTab: useTabStore.getState().getActiveTab
   }
 }

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -59,6 +59,7 @@ export function useTabs() {
   const getTabByPath = useTabStore((state) => state.getTabByPath)
   const getTabById = useTabStore((state) => state.getTabById)
   const pushClosedTab = useTabStore((state) => state.pushClosedTab)
+  const popClosedTab = useTabStore((state) => state.popClosedTab)
   const reopenLastClosedTabStore = useTabStore((state) => state.reopenLastClosedTab)
 
   const document = useEditorStore((state) => state.document)
@@ -694,6 +695,21 @@ export function useTabs() {
   const closeOtherTabs = useCallback(async (keepTabId: string) => {
     const tabsToClose = tabs.filter(t => t.id !== keepTabId && !t.isDirty)
 
+    // Snapshot non-preview tabs onto the closed-tab stack (most-recently-seen first)
+    for (const tab of [...tabsToClose].reverse()) {
+      if (!tab.isPreview) {
+        pushClosedTab({
+          path: tab.path,
+          title: tab.title,
+          baseTitle: tab.baseTitle,
+          isDirty: tab.isDirty,
+          content: tab.content,
+          frontmatter: tab.frontmatter,
+          cursorPosition: tab.cursorPosition
+        })
+      }
+    }
+
     // Close all non-dirty tabs
     for (const tab of tabsToClose) {
       if (!tab.path) {
@@ -710,12 +726,27 @@ export function useTabs() {
     if (activeTabId !== keepTabId) {
       await switchToTab(keepTabId)
     }
-  }, [tabs, activeTabId, switchToTab])
+  }, [tabs, activeTabId, switchToTab, pushClosedTab])
 
   /**
    * Close all tabs
    */
   const closeAllTabs = useCallback(async () => {
+    // Snapshot non-preview tabs onto the closed-tab stack (most-recently-seen first)
+    for (const tab of [...tabs].reverse()) {
+      if (!tab.isPreview) {
+        pushClosedTab({
+          path: tab.path,
+          title: tab.title,
+          baseTitle: tab.baseTitle,
+          isDirty: tab.isDirty,
+          content: tab.content,
+          frontmatter: tab.frontmatter,
+          cursorPosition: tab.cursorPosition
+        })
+      }
+    }
+
     // Close all non-dirty tabs
     for (const tab of tabs) {
       if (!tab.isDirty && !tab.path) {
@@ -730,7 +761,7 @@ export function useTabs() {
 
     // Create a new blank tab
     await createNewTab()
-  }, [tabs, createNewTab])
+  }, [tabs, createNewTab, pushClosedTab])
 
   /**
    * Update the active tab when editor content changes
@@ -840,14 +871,29 @@ export function useTabs() {
   /**
    * Reopen the most recently closed tab, restoring its content (including unsaved edits).
    * No-op if the closed-tab stack is empty.
+   *
+   * Race safety: the snapshot is popped atomically first; the async documentId
+   * derivation happens after the pop, so rapid double-presses each consume a
+   * distinct snapshot rather than both racing on the same top entry.
+   *
+   * Duplicate guard: if the snapshot's path is already open in a live tab, we
+   * pop the snapshot, switch to the existing tab, and do not create a duplicate.
    */
   const reopenLastClosedTab = useCallback(async () => {
-    const closedTabs = useTabStore.getState().closedTabs
-    if (closedTabs.length === 0) return
+    // Atomically pop the top snapshot — no await before this point.
+    const snapshot = popClosedTab()
+    if (!snapshot) return
 
-    const snapshot = closedTabs[0]
+    // If a tab for this path is already open, just switch to it.
+    if (snapshot.path) {
+      const existing = getTabByPath(snapshot.path)
+      if (existing) {
+        await switchToTab(existing.id)
+        return
+      }
+    }
 
-    // Derive documentId: path-backed tabs get a stable ID from path; untitled tabs get fresh ID
+    // Derive documentId after the pop (no TOCTOU risk — snapshot already claimed).
     let documentId: string
     if (snapshot.path) {
       documentId = await generateIdFromPath(snapshot.path)
@@ -861,12 +907,8 @@ export function useTabs() {
     // Pause annotation position updates during document loading
     useAnnotationStore.getState().setLoadingDocument(true)
 
-    // Pop snapshot from store and create tab
-    const tabId = reopenLastClosedTabStore(documentId)
-    if (!tabId) {
-      useAnnotationStore.getState().setLoadingDocument(false)
-      return
-    }
+    // Create the new tab in the store
+    const tabId = reopenLastClosedTabStore(snapshot, documentId)
 
     // Load the restored content into editorStore
     setDocument({
@@ -899,7 +941,7 @@ export function useTabs() {
     setTimeout(() => {
       useAnnotationStore.getState().setLoadingDocument(false)
     }, 100)
-  }, [saveCurrentTabState, reopenLastClosedTabStore, setDocument, setCursorPosition, loadChatForDocument, setEditing])
+  }, [popClosedTab, getTabByPath, switchToTab, saveCurrentTabState, reopenLastClosedTabStore, setDocument, setCursorPosition, loadChatForDocument, setEditing])
 
   return {
     tabs,

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -735,9 +735,11 @@ export function useTabs() {
    * Close all tabs
    */
   const closeAllTabs = useCallback(async () => {
-    // Snapshot every non-preview tab (dirty included — store removes ALL tabs)
-    // Push most-recently-seen first so the last tab closed is first to be reopened
-    for (const tab of [...tabs].reverse()) {
+    // Snapshot every non-preview tab (dirty included — store removes ALL tabs).
+    // Push oldest→newest: pushClosedTab prepends, so the last push (newest tab)
+    // lands on top of the stack. When >10 tabs are closed, slice(0, CLOSED_TABS_MAX)
+    // drops the tail (oldest), keeping the most-recently-open 10 reopenable.
+    for (const tab of tabs) {
       if (!tab.isPreview) {
         pushClosedTab({
           path: tab.path,

--- a/src/renderer/stores/tabStore.ts
+++ b/src/renderer/stores/tabStore.ts
@@ -49,7 +49,8 @@ interface TabState {
 
   // Closed-tab history
   pushClosedTab: (snapshot: ClosedTabSnapshot) => void
-  reopenLastClosedTab: (documentId: string) => string | null
+  popClosedTab: () => ClosedTabSnapshot | null
+  reopenLastClosedTab: (snapshot: ClosedTabSnapshot, documentId: string) => string
 
   // Utility
   getNextUntitledNumber: () => number
@@ -75,11 +76,15 @@ export const useTabStore = create<TabState>()(
       })
     },
 
-    reopenLastClosedTab: (documentId) => {
+    popClosedTab: () => {
       const state = get()
       if (state.closedTabs.length === 0) return null
-
       const [snapshot, ...rest] = state.closedTabs
+      set({ closedTabs: rest })
+      return snapshot
+    },
+
+    reopenLastClosedTab: (snapshot, documentId) => {
       const tab: Tab = {
         id: generateId(),
         documentId,
@@ -94,8 +99,7 @@ export const useTabStore = create<TabState>()(
 
       set((state) => ({
         tabs: [...state.tabs, tab],
-        activeTabId: tab.id,
-        closedTabs: rest
+        activeTabId: tab.id
       }))
 
       return tab.id

--- a/src/renderer/stores/tabStore.ts
+++ b/src/renderer/stores/tabStore.ts
@@ -18,9 +18,23 @@ export interface Tab {
   cursorPosition?: { line: number; column: number }
 }
 
+/** Snapshot of a closed tab for session-only reopen history (max 10) */
+export interface ClosedTabSnapshot {
+  path: string | null
+  title: string
+  baseTitle?: string
+  isDirty: boolean
+  content?: string
+  frontmatter?: Record<string, unknown>
+  cursorPosition?: { line: number; column: number }
+}
+
+const CLOSED_TABS_MAX = 10
+
 interface TabState {
   tabs: Tab[]
   activeTabId: string | null
+  closedTabs: ClosedTabSnapshot[]
 
   // Tab actions
   addTab: (tab: Omit<Tab, 'id'> & { id?: string }) => string
@@ -32,6 +46,10 @@ interface TabState {
   getTabById: (tabId: string) => Tab | null
   getPreviewTab: () => Tab | null
   promotePreviewTab: (tabId: string) => void
+
+  // Closed-tab history
+  pushClosedTab: (snapshot: ClosedTabSnapshot) => void
+  reopenLastClosedTab: (documentId: string) => string | null
 
   // Utility
   getNextUntitledNumber: () => number
@@ -48,6 +66,40 @@ export const useTabStore = create<TabState>()(
   subscribeWithSelector((set, get) => ({
     tabs: [],
     activeTabId: null,
+    closedTabs: [],
+
+    pushClosedTab: (snapshot) => {
+      set((state) => {
+        const next = [snapshot, ...state.closedTabs]
+        return { closedTabs: next.length > CLOSED_TABS_MAX ? next.slice(0, CLOSED_TABS_MAX) : next }
+      })
+    },
+
+    reopenLastClosedTab: (documentId) => {
+      const state = get()
+      if (state.closedTabs.length === 0) return null
+
+      const [snapshot, ...rest] = state.closedTabs
+      const tab: Tab = {
+        id: generateId(),
+        documentId,
+        path: snapshot.path,
+        title: snapshot.title,
+        baseTitle: snapshot.baseTitle,
+        isDirty: snapshot.isDirty,
+        content: snapshot.content,
+        frontmatter: snapshot.frontmatter,
+        cursorPosition: snapshot.cursorPosition
+      }
+
+      set((state) => ({
+        tabs: [...state.tabs, tab],
+        activeTabId: tab.id,
+        closedTabs: rest
+      }))
+
+      return tab.id
+    },
 
     addTab: (tabData) => {
       const id = tabData.id ?? generateId()


### PR DESCRIPTION
## Summary

- **Session-only in-memory stack (cap 10):** `tabStore` gains a `closedTabs: ClosedTabSnapshot[]` field (never persisted to IndexedDB — no DB_VERSION bump). `pushClosedTab` prepends and trims to 10; `reopenLastClosedTab` pops the top entry and adds a new tab from the snapshot.
- **Snapshots captured on every non-preview close:** Both `closeTab` (clean close) and `forceCloseTab` (after save/discard dialog) snapshot the full tab state before calling `removeTab`. Preview tabs (`isPreview: true`) are skipped.
- **Unsaved-content restore:** The reopen path restores `content`, `frontmatter`, `cursorPosition`, and `isDirty` directly from the snapshot — no disk re-read. Works even if the file was deleted from disk after closing.
- **Stable document IDs:** File-backed tabs derive their `documentId` via `generateIdFromPath` so existing chat history, annotations, suggestions, and comment marks rejoin automatically. Untitled tabs get a fresh `generateId()`.
- **Menu wiring:** "Reopen Closed Tab" added to the File menu after "Close Tab" with the `CmdOrCtrl+Shift+T` accelerator (free since convert actions moved to `CmdOrCtrl+Alt+T/M`). `reopenClosedTab` action dispatched via `sendMenuAction`, handled in `App.tsx` `onMenuAction` switch.

## Test plan

- [ ] Open two or three tabs (mix of files and untitled docs with content)
- [ ] Close one tab with Cmd+W — it should disappear
- [ ] Press Cmd+Shift+T — the closed tab should reappear with its content intact
- [ ] For a dirty untitled tab: close with discard — press Cmd+Shift+T — content should restore (isDirty=true)
- [ ] Press Cmd+Shift+T repeatedly — each press should restore the next-most-recent closed tab, up to 10
- [ ] After 10 reopens (stack exhausted), a further Cmd+Shift+T should be a no-op
- [ ] Preview tabs (single-click in file explorer) should NOT enter the history

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)