### PR TITLE
build: enable asar integrity fuses in production builds

### DIFF
--- a/build/afterPack.cjs
+++ b/build/afterPack.cjs
@@ -41,6 +41,12 @@ module.exports = async function afterPack(context) {
     [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
     // Disable --inspect and related CLI flags — prevents attaching debuggers to production builds
     [FuseV1Options.EnableNodeCliInspectArguments]: false,
+    // Validate the embedded asar at runtime against the hash electron-builder
+    // writes into Info.plist (ElectronAsarIntegrity) — launch fails if the
+    // bundled app code is tampered with on disk after signing.
+    [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+    // Refuse to load app code from loose files outside the asar archive.
+    [FuseV1Options.OnlyLoadAppFromAsar]: true,
   })
 
   console.log('[Fuses] Fuses flipped successfully')


### PR DESCRIPTION
Closes #376

## Change
Adds two integrity fuses to the existing `flipFuses` call in `build/afterPack.cjs`:
- `EnableEmbeddedAsarIntegrityValidation` — Electron validates `app.asar` at runtime against the `ElectronAsarIntegrity` hash in Info.plist; launch fails if the bundle is tampered with after signing.
- `OnlyLoadAppFromAsar` — refuse to load app code from loose files outside the asar.

Both default to `false`. Found during the v1.0.0 security audit; defense-in-depth for the **self-distributed** DMG/ZIP. MAS builds are unaffected — the afterPack hook still returns early for `mas` (the App Sandbox provides equivalent protection, and flipping fuses on the MAS binary invalidates framework signatures).

## Verification (signed `dir` build)
- `npm run build` + `electron-builder --mac dir` succeed; afterPack logs `Fuses flipped successfully`, signed with `Developer ID Application (8PT2Y7QQ2F)`.
- electron-builder injects `ElectronAsarIntegrity` (SHA256 for `Resources/app.asar`) into `Info.plist` — so the integrity fuse has a valid target.
- `@electron/fuses read` on the built app confirms `EnableEmbeddedAsarIntegrityValidation` and `OnlyLoadAppFromAsar` are **Enabled** (the three runtime fuses remain Disabled).
- The signed app **launches** to `[Main] Renderer signaled ready` — `app.asar` passes integrity validation at runtime, no crash.

`build:mas` is not exercised here (afterPack skips MAS, and the MAS provisioning profile isn't present in this worktree) — but the change cannot affect it by construction.

Part of **Wave 0.5 — MAS Refresh**.