### PR TITLE
fix(remarkable): resilient OCR batching

### DIFF
--- a/src/main/remarkable/ocr.ts
+++ b/src/main/remarkable/ocr.ts
@@ -105,6 +105,29 @@ function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
   })
 }
 
+/**
+ * 4xx statuses that are transient and worth retrying with backoff (the rest of
+ * the 4xx range — auth, bad request — are not). 429 is the important one: the
+ * sync processes notebooks concurrently, so rate-limit responses are expected
+ * under load and must not fail a whole notebook on the first hit.
+ */
+const RETRYABLE_STATUSES = new Set([408, 425, 429])
+
+/** Upper bound on a server-suggested Retry-After so one slow hint can't stall the sync. */
+const RETRY_AFTER_CAP_MS = 10_000
+
+/**
+ * Parse a Retry-After header into milliseconds. Supports the common
+ * delta-seconds form (e.g. "5"); the HTTP-date form is ignored (returns 0) as
+ * this API uses delta-seconds. Result is capped at RETRY_AFTER_CAP_MS.
+ */
+function parseRetryAfter(value: string | null): number {
+  if (!value) return 0
+  const seconds = Number(value)
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0
+  return Math.min(seconds * 1000, RETRY_AFTER_CAP_MS)
+}
+
 export async function extractTextFromPages(
   pages: Array<{ id: string; data: Buffer }>,
   anthropicApiKey: string,
@@ -163,10 +186,19 @@ export async function extractTextFromPages(
           // Ignore JSON parse errors
         }
 
-        // Only retry on 5xx (server) errors, not 4xx (client) errors
-        if (response.status >= 500 && attempt < MAX_ATTEMPTS - 1) {
-          console.warn(`[OCR] Server error (${response.status}), retrying in ${RETRY_DELAYS[attempt]}ms (retry ${attempt + 1}/${MAX_ATTEMPTS - 1})`)
-          await abortableDelay(RETRY_DELAYS[attempt], signal)
+        // Retry on 5xx (server) errors AND on the transient 4xx statuses that
+        // mean "back off and try again": 429 (rate limited — common when the
+        // sync runs notebooks concurrently and hammers the Lambda), 408
+        // (request timeout), 425 (too early). Other 4xx (auth, bad request)
+        // are genuine client errors and are not retried.
+        const isRetryableStatus = response.status >= 500 || RETRYABLE_STATUSES.has(response.status)
+        if (isRetryableStatus && attempt < MAX_ATTEMPTS - 1) {
+          // Honor Retry-After when the server sends it (429s often do), but
+          // floor it at the exponential-backoff delay and cap it so a large
+          // server-suggested value can't stall the whole sync.
+          const delayMs = Math.max(RETRY_DELAYS[attempt], parseRetryAfter(response.headers.get('retry-after')))
+          console.warn(`[OCR] Retryable status ${response.status}, retrying in ${delayMs}ms (retry ${attempt + 1}/${MAX_ATTEMPTS - 1})`)
+          await abortableDelay(delayMs, signal)
           lastError = new Error(errorMessage)
           continue
         }
@@ -249,10 +281,43 @@ export async function extractTextBatched(
   for (let i = 0; i < pages.length; i += BATCH_SIZE) {
     if (signal?.aborted) throw new DOMException('OCR aborted', 'AbortError')
     const batch = pages.slice(i, i + BATCH_SIZE)
-    const result = await extractTextFromPages(batch, anthropicApiKey, signal)
 
-    allResults.push(...result.pages)
-    allFailed.push(...result.failedPages)
+    try {
+      const result = await extractTextFromPages(batch, anthropicApiKey, signal)
+      allResults.push(...result.pages)
+      allFailed.push(...result.failedPages)
+    } catch (error) {
+      // Cancellation must abort the whole notebook, not be swallowed as a
+      // failed batch.
+      if ((error as { name?: string })?.name === 'AbortError') throw error
+
+      // A whole-batch failure (timeout, payload size, retries exhausted) used
+      // to throw and discard the ENTIRE notebook — one oversized/dense page
+      // could take all its batch-mates down with it. Instead, fall back to
+      // OCR'ing each page in the batch on its own so only the genuinely bad
+      // page is lost. Pages that still fail are recorded in failedPages; the
+      // notebook keeps every page we can read.
+      const reason = error instanceof Error ? error.message : 'unknown error'
+      if (batch.length === 1) {
+        console.warn(`[OCR] Page ${batch[0].id.slice(0, 8)} failed: ${reason}`)
+        allFailed.push(batch[0].id)
+      } else {
+        console.warn(`[OCR] Batch of ${batch.length} failed (${reason}); retrying pages individually`)
+        for (const page of batch) {
+          if (signal?.aborted) throw new DOMException('OCR aborted', 'AbortError')
+          try {
+            const single = await extractTextFromPages([page], anthropicApiKey, signal)
+            allResults.push(...single.pages)
+            allFailed.push(...single.failedPages)
+          } catch (pageError) {
+            if ((pageError as { name?: string })?.name === 'AbortError') throw pageError
+            const pageReason = pageError instanceof Error ? pageError.message : 'unknown error'
+            console.warn(`[OCR] Page ${page.id.slice(0, 8)} failed individually: ${pageReason}`)
+            allFailed.push(page.id)
+          }
+        }
+      }
+    }
 
     onProgress?.(Math.min(i + BATCH_SIZE, pages.length), pages.length)
   }

--- a/src/main/remarkable/sync.ts
+++ b/src/main/remarkable/sync.ts
@@ -428,6 +428,11 @@ async function processNotebookWithOCR(
     // OCR only the changed/new pages
     const newCache: Record<string, PageOCRCacheEntry> = { ...cachedPages }
     let ocrResults: Array<{ id: string; markdown: string; confidence: number }> = []
+    // Pages OCR couldn't transcribe this run. extractTextBatched now degrades
+    // gracefully (a failed batch retries page-by-page), so these are the pages
+    // that failed even in isolation — marked inline so the notebook documents
+    // its own gaps instead of silently dropping content.
+    const failedPageIds = new Set<string>()
 
     if (pagesToOCR.length > 0) {
       console.log(`[OCR] Calling extractTextBatched with ${pagesToOCR.length} pages`)
@@ -439,6 +444,7 @@ async function processNotebookWithOCR(
 
       if (result.failedPages.length > 0) {
         console.log(`[OCR] Failed pages:`, result.failedPages)
+        for (const id of result.failedPages) failedPageIds.add(id)
         onProgress?.({ message: `Warning: ${result.failedPages.length} pages failed OCR`, notebookName, phase: 'ocr' })
       }
 
@@ -454,6 +460,17 @@ async function processNotebookWithOCR(
           confidence: page.confidence
         }
       }
+
+      // Total failure: we attempted pages this run, every one failed, and there
+      // is no cached content from a prior sync to fall back on. Return null so
+      // the caller stamps the OCR-failure sentinel (warning icon + Retry Sync).
+      // A PARTIAL failure (some pages succeeded) falls through and saves a
+      // usable notebook below — a notebook with one gap beats no notebook.
+      if (ocrResults.length === 0 && Object.keys(cachedPages).length === 0) {
+        console.warn(`[OCR] All ${pagesToOCR.length} pages failed for "${notebookName}" — treating as OCR failure`)
+        onProgress?.({ message: `OCR failed for all pages of "${notebookName}"`, notebookName, phase: 'ocr' })
+        return null
+      }
     }
 
     // Assemble all pages in order — merge cached and fresh results
@@ -467,10 +484,15 @@ async function processNotebookWithOCR(
 
     console.log(`[OCR] Ordered ${orderedPages.length} pages`)
 
-    // Combine all markdown with page separators
+    // Combine all markdown with page separators. Pages OCR couldn't transcribe
+    // get a visible placeholder so the gap is obvious and recoverable (Retry
+    // Sync re-attempts), rather than rendering as a silently blank page.
     const markdownParts = orderedPages.map((page, index) => {
       const pageHeader = orderedPages.length > 1 ? `<!-- Page ${index + 1} -->\n\n` : ''
-      return pageHeader + page.markdown
+      const body = failedPageIds.has(page.id)
+        ? '*[This page could not be transcribed. Use “Retry Sync” to try again.]*'
+        : page.markdown
+      return pageHeader + body
     })
 
     const combinedMarkdown = markdownParts.join('\n\n---\n\n')


### PR DESCRIPTION
## Summary

After #660 restored reMarkable cloud sync, freshly-synced notebooks intermittently showed the OCR-failure warning triangle in the file explorer. Investigation confirmed #660 **uncovered** (did not cause) a pre-existing OCR brittleness — before #660, cloud sync was fully broken so OCR never ran and no warnings were possible.

The download path from #660 is intact: the failing notebook ("Dailies Mini") extracted a complete set of 12 `.rm` files; a sibling ("Test") extracted 13 and OCR'd fine. The warning is the OCR-failure sentinel (`ocrAttempt`), and it was being stamped on the **whole notebook** whenever a single OCR batch failed.

## Root cause (`src/main/remarkable/ocr.ts`)

1. **All-or-nothing batching.** `extractTextBatched` splits pages into batches of 5. If *any* batch threw (timeout, payload size, exhausted retries), the whole call threw → `processNotebookWithOCR` returned null → the entire notebook was marked failed with a 30-min sentinel, discarding the pages that succeeded.
2. **429s weren't retried.** The retry loop only retried `status >= 500`. A `429 Too Many Requests` (4xx) threw immediately. With `CONCURRENCY = 3` notebooks hitting the Lambda on the initial full sync, rate-limit 429s are the likely original trigger — which fits the symptom (multiple notebooks flagged at first, most clearing on re-sync).

## Changes

**`ocr.ts`**
- `extractTextBatched`: on a batch failure, retry each page individually so one oversized/dense page can't sink its batch-mates. Pages that still fail are recorded in `failedPages` instead of throwing. `AbortError` still propagates (cancellation unaffected).
- `extractTextFromPages`: retry `429`/`408`/`425` with backoff, honoring `Retry-After` (floored at the backoff delay, capped at 10s). Other 4xx (auth/bad-request) still fail fast.

**`sync.ts`**
- `processNotebookWithOCR`: set the failure sentinel only on **total** failure (every attempted page failed *and* no cached content to fall back on). A partial failure saves a usable notebook.
- Unreadable pages get a visible inline placeholder so gaps are obvious and recoverable via *Retry Sync*, rather than rendering as a silently blank page.

## Verification

- `npm run build` passes the full pipeline (typechecks the main process).
- **Live re-sync of the previously-failing notebook**: warning cleared, `ocrAttempt` removed, all 12 pages transcribed (the 2 MB page included). This run succeeded cleanly — the original failure was transient — so the new fallback branch wasn't exercised at runtime here; it's covered by build + review and is defense-in-depth alongside the 429-retry fix that addresses the likely trigger.

Closes #666
Refs #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)