### PR TITLE
fix(projects): stop clobbering the explorer base root when adding a project

### DIFF
--- a/e2e/electron.projects.spec.ts
+++ b/e2e/electron.projects.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Electron Projects navigation tests — regression coverage for the v1.6.x
+ * base-root clobber: addProjectFromPicker used to set defaultSaveDirectory
+ * (the stable root that back-navigation returns to) to the new project's
+ * path, trapping the explorer inside that project (TestFlight v1.6.1 report).
+ *
+ * Launches with PROSE_USER_DATA_DIR pointing at a temp profile so the crafted
+ * settings.json (and anything the app writes back) never touches the
+ * developer's real profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  ensureFileListOpen,
+  selectors,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaProjectDir: string
+
+const PROJECT_NAME = 'qa-back-nav-project'
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+
+  // Isolated profile + project fixture
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaProjectDir = join(mkdtempSync(join(tmpdir(), 'prose-qa-fixtures-')), PROJECT_NAME)
+  mkdirSync(qaProjectDir)
+  writeFileSync(join(qaProjectDir, 'project-doc.md'), '# QA project doc\n')
+
+  // Seed the exact on-disk state the clobber bug produced: a project whose
+  // path is ALSO the defaultSaveDirectory (base root).
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        projects: [
+          {
+            id: 'qa-back-nav',
+            name: PROJECT_NAME,
+            path: qaProjectDir,
+            createdAt: '2026-06-04T00:00:00.000Z',
+            lastOpenedAt: '2026-06-04T00:00:00.000Z',
+          },
+        ],
+        activeProjectId: 'qa-back-nav',
+        defaultSaveDirectory: qaProjectDir,
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(join(qaProjectDir, '..'), { recursive: true, force: true })
+})
+
+test.describe('Electron — Projects navigation', () => {
+  test('boot heals a base root clobbered to a project path', async () => {
+    // settingsStore.loadSettings clears defaultSaveDirectory when it equals a
+    // project path and persists the healed shape back to disk.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async () => {
+            const s = await (window as any).api.loadSettings()
+            return s.defaultSaveDirectory ?? null
+          }),
+        { timeout: 10_000 },
+      )
+      .toBeNull()
+
+    // The heal must only clear the base root — the project itself survives.
+    const projects = await page.evaluate(async () => {
+      const s = await (window as any).api.loadSettings()
+      return (s.projects ?? []).map((p: { id: string }) => p.id)
+    })
+    expect(projects).toContain('qa-back-nav')
+  })
+
+  test('back button returns from an open project to the Projects index', async () => {
+    await ensureFileListOpen(page)
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Open the Projects view and enter the project
+    await page.click('[aria-label="Projects"]')
+    await panel.getByText(PROJECT_NAME).first().click()
+
+    // Inside the project: back chevron + project contents visible
+    const backButton = page.locator('[aria-label="Back to projects"]')
+    await expect(backButton).toBeVisible({ timeout: 5_000 })
+    // The file tree strips markdown extensions for display
+    await expect(panel.getByText('project-doc')).toBeVisible({ timeout: 5_000 })
+
+    // Back must land on the Projects index (pre-fix: resolved straight back
+    // into the project because the base root pointed at it)
+    await backButton.click()
+    await expect(backButton).not.toBeVisible({ timeout: 5_000 })
+    await expect(panel.getByText(PROJECT_NAME)).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('Files toggle exits the project instead of re-rendering its contents', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Re-enter the project
+    await panel.getByText(PROJECT_NAME).first().click()
+    const backButton = page.locator('[aria-label="Back to projects"]')
+    await expect(backButton).toBeVisible({ timeout: 5_000 })
+
+    // The Files toggle calls exitToRoot. With no base root configured (the
+    // heal cleared it), the folder view must fall back to the folder-picker
+    // empty state — not keep showing the project's files.
+    await page.click(selectors.filesButton)
+    await expect(backButton).not.toBeVisible({ timeout: 5_000 })
+    await expect(panel.getByText('Choose a folder to browse your documents.')).toBeVisible({
+      timeout: 5_000,
+    })
+    await expect(panel.getByText('project-doc')).not.toBeVisible()
+  })
+})

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -25,8 +25,16 @@ export * from './shared'
  * In CI, launches from the built output (requires `npm run build` first).
  * Locally, can optionally launch from source via electron-vite dev.
  */
-export async function launchApp(): Promise<{ app: ElectronApplication; page: Page }> {
+export async function launchApp(
+  options?: { env?: Record<string, string> },
+): Promise<{ app: ElectronApplication; page: Page }> {
   const projectRoot = resolve(__dirname, '..')
+  // Merge env overrides over the inherited environment — Playwright's `env`
+  // replaces the child process environment wholesale, so the spread keeps
+  // PATH etc. intact. Used by tests that need an isolated HOME (userData).
+  const env = options?.env
+    ? { ...(process.env as Record<string, string>), ...options.env }
+    : undefined
 
   // Try to find a packaged build first (electron-builder output)
   let appPath: string
@@ -54,10 +62,12 @@ export async function launchApp(): Promise<{ app: ElectronApplication; page: Pag
     app = await electron.launch({
       executablePath: appInfo.executable,
       args: [appInfo.main],
+      ...(env ? { env } : {}),
     })
   } else {
     app = await electron.launch({
       args: [appPath],
+      ...(env ? { env } : {}),
     })
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,9 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 // directory so e2e/QA harnesses never touch the real profile. Mirrors the
 // PROSE_USER_DATA_DIR override in paths.ts (which covers the pre-ready Sentry
 // read above). No-op unless the harness sets the env var.
+// Ordering invariant: hoisted imports (ipc.ts, menu.ts, ...) load before this
+// statement runs, so none of them may call app.getPath('userData') at module
+// top level — only inside handlers/functions that run after this override.
 if (process.env.PROSE_USER_DATA_DIR) {
   app.setPath('userData', process.env.PROSE_USER_DATA_DIR)
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,14 @@ try {
 
 import { app, shell, BrowserWindow, session, protocol } from 'electron'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+
+// Test seam: redirect userData (settings, IndexedDB, caches) to an isolated
+// directory so e2e/QA harnesses never touch the real profile. Mirrors the
+// PROSE_USER_DATA_DIR override in paths.ts (which covers the pre-ready Sentry
+// read above). No-op unless the harness sets the env var.
+if (process.env.PROSE_USER_DATA_DIR) {
+  app.setPath('userData', process.env.PROSE_USER_DATA_DIR)
+}
 import { setupIpcHandlers } from './ipc'
 import { createMenu } from './menu'
 import { getMcpHttpServer, getMcpBridge, getMcpSocketServer } from './mcp'

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -21,6 +21,11 @@ export const LEGACY_SETTINGS_DIR = join(homedir(), '.prose')
  * Use this ONLY for code that runs before app.whenReady() (e.g., early Sentry init).
  */
 export function getUserDataPath(): string {
+  // Test seam: e2e/QA harnesses set PROSE_USER_DATA_DIR to isolate the
+  // profile (settings, IndexedDB, caches) from the developer's real one.
+  // index.ts applies the same override to app.getPath('userData') via
+  // app.setPath, keeping both resolution paths consistent.
+  if (process.env.PROSE_USER_DATA_DIR) return process.env.PROSE_USER_DATA_DIR
   switch (process.platform) {
     case 'darwin':
       return join(homedir(), 'Library', 'Application Support', 'prose')

--- a/src/renderer/stores/projectsStore.ts
+++ b/src/renderer/stores/projectsStore.ts
@@ -131,7 +131,12 @@ export const useProjectsStore = create<ProjectsState>()(
           const fileList = await getFileListStore()
           fileList.setRootPath(project.path)
           useSettingsStore.getState().setActiveProject(project.id)
-          useSettingsStore.getState().setDefaultSaveDirectory(project.path)
+          // Note: defaultSaveDirectory (the stable base root the explorer's
+          // Back button returns to) is intentionally NOT changed — pointing it
+          // at the project's path made backToProjectsList/exitToRoot resolve
+          // back into the project, trapping navigation inside it (TestFlight
+          // v1.6.1 report). Projects are additive pointers over the base root,
+          // same contract as switchToProject below.
           // Persist bookmark in the legacy single-bookmark slot too so the
           // existing settings:load bookmark restoration still works.
           if (project.bookmark) {
@@ -218,9 +223,11 @@ export const useProjectsStore = create<ProjectsState>()(
       useSettingsStore.getState().saveSettings()
 
       const fileList = await getFileListStore()
-      if (baseRoot) {
-        fileList.setRootPath(baseRoot)
-      }
+      // No base root configured (fresh install, or healed after the
+      // defaultSaveDirectory clobber) — drop to the folder-picker empty state
+      // rather than leaving rootPath inside the project, which would render
+      // the project's files in the Files panel and look like being stuck.
+      fileList.setRootPath(baseRoot ?? null)
       // Drop to the base-root Files navigator (contrast: FileListPanel.backToProjectsList
       // clears the active project but stays in the 'projects' panel).
       fileList.setViewMode('folder')
@@ -246,7 +253,10 @@ export const useProjectsStore = create<ProjectsState>()(
       if (wasActive) {
         const baseRoot = useSettingsStore.getState().settings.defaultSaveDirectory
         void getFileListStore().then((fileList) => {
-          if (baseRoot) fileList.setRootPath(baseRoot)
+          // Same null-fallback as exitToRoot: without a base root, drop to the
+          // folder-picker empty state instead of lingering inside the removed
+          // project's folder.
+          fileList.setRootPath(baseRoot ?? null)
           fileList.setViewMode('folder')
         })
       }

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -147,7 +147,19 @@ function migrateOnDiskSettings(raw: SettingsOnDisk): Settings {
     resolved = FRESH_INSTALL_APPEARANCE
   }
 
-  return { ...rest, appearance: resolved }
+  // Heal a base root clobbered by addProjectFromPicker in v1.6.0/v1.6.1, which
+  // set defaultSaveDirectory to the newly added project's path. The explorer's
+  // back-navigation (backToProjectsList / exitToRoot) returns to
+  // defaultSaveDirectory, so a base root equal to a project path resolved
+  // straight back into the project — trapping navigation inside it. Clearing
+  // it falls back to the documents default; the Files panel's folder picker
+  // re-sets it on the next explicit pick.
+  let defaultSaveDirectory = rest.defaultSaveDirectory
+  if (defaultSaveDirectory && (rest.projects ?? []).some((p) => p.path === defaultSaveDirectory)) {
+    defaultSaveDirectory = undefined
+  }
+
+  return { ...rest, defaultSaveDirectory, appearance: resolved }
 }
 
 // Single tracked cleanup for the prefers-color-scheme listener. Stored at
@@ -235,10 +247,10 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
       // changes the icon. This is what makes the icon choice persist visually.
       window.api.setAppIcon?.(migrated.appearance.icon)
 
-      // If we migrated a legacy theme field, persist the cleaned shape so the
-      // next launch reads the new schema and the migration code path becomes
-      // a no-op for this user.
-      if (raw.theme) {
+      // If we migrated a legacy theme field or healed a project-clobbered
+      // base root, persist the cleaned shape so the next launch reads the
+      // new values and the migration code path becomes a no-op for this user.
+      if (raw.theme || raw.defaultSaveDirectory !== migrated.defaultSaveDirectory) {
         get().saveSettings().catch((err) => {
           console.warn('[settings] failed to persist migrated appearance:', err)
         })


### PR DESCRIPTION
## Summary

**TestFlight v1.6.1 (build 23) bug report:** after opening a Project, neither the back button nor the Files toggle could leave it — the explorer was trapped inside the project.

**Root cause:** `addProjectFromPicker` set `defaultSaveDirectory` — the stable base root that both `backToProjectsList` and `exitToRoot` return to — to the new project's path. Since `currentProject` derives from `rootPath` matching a project path prefix, every exit resolved straight back into the project. This contradicted `switchToProject`'s own documented contract ("the selected root is intentionally NOT changed — it stays stable as the base the Back button returns to"). First-run flow (add your first project via the picker) hits it immediately.

## Changes

| File | Change |
|---|---|
| `projectsStore.ts` | `addProjectFromPicker` no longer touches `defaultSaveDirectory`; `exitToRoot`/`removeProject` fall back to the folder-picker empty state when no base root is configured (instead of re-rendering the project's files, which looks like being stuck) |
| `settingsStore.ts` | `migrateOnDiskSettings` heals already-affected installs: a base root exactly equal to a project path is cleared and the healed shape persisted on load |
| `src/main/index.ts`, `src/main/paths.ts` | `PROSE_USER_DATA_DIR` test seam — e2e/QA harnesses get an isolated profile (settings, IndexedDB, caches) instead of the developer's real one. No-op unless the env var is set; covers both `app.getPath('userData')` and the pre-ready `getUserDataPath()` Sentry read |
| `e2e/helpers.ts` | `launchApp` accepts env overrides (merged over inherited env) |
| `e2e/electron.projects.spec.ts` | Regression spec: boot heal, back button returns to Projects index, Files toggle exits the project |

## Verification

- New spec **passes against the fixed build** (3/3) and **fails against the unfixed stores** (3/3, verified by stashing the store changes and rebuilding) — the back-button failure signature matches the report exactly (back chevron still visible after clicking it).
- Full electron e2e suite: 16 passed, 3 flaky (pre-existing editor-spec dialog timing, pass on retry).
- `HOME` overrides do **not** isolate Electron's `userData` on macOS (verified empirically — the test initially read the real profile), hence the explicit env seam.

## Out of scope (tracked in #654)

The MAS legacy single-bookmark slot (`masDirectoryBookmark`) is still overwritten with the project's bookmark on add/switch, which destroys the **base root's** security-scoped access on the next launch — after restart the healed base root may list empty on MAS until the user re-picks the folder. That's the bookmark-architecture work in #654 (privilege boundary, own PR). This PR fixes the navigation trap, which reproduces independently of MAS.

Refs #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)