### PR TITLE
chore(mas): bump buildVersion to 24 for TestFlight

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -14,7 +14,7 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
 
 - **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
   automation edge; clicking "Submit for Review" is always a human decision and action.
-- **`buildVersion` is global-monotonic.** Currently `"23"` in `electron-builder.yml`.
+- **`buildVersion` is global-monotonic.** Currently `"24"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
   **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.1`).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "23"
+buildVersion: "24"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
## Summary

Bumps `buildVersion` 23 → 24. **Build 24 = v1.6.1 + the #669 project back-navigation fix** (merged at `5dfc670`). Build 23 ships the nav trap and should not be submitted for App Store review.

Part of the Wave 0.5 TestFlight iteration loop: merge fix → cut build → upload → human TestFlight QA.

Refs #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)