### PR TITLE
fix(editor): parse inline markdown when accepting AI suggestions

### DIFF
--- a/e2e/electron.suggestions.spec.ts
+++ b/e2e/electron.suggestions.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * AI suggestion acceptance tests — regression coverage for inline-markdown
+ * suggestions landing as literal syntax characters (TestFlight v1.6.1 report:
+ * accepted `**bold**` showed raw asterisks in the WYSIWYG doc and serialized
+ * escaped as `\*\*bold\*\*`).
+ *
+ * Drives the aiSuggestion extension commands directly through the exposed
+ * editor instance (window.__prose_editor) — no LLM involved. Uses an isolated
+ * PROSE_USER_DATA_DIR profile so annotation-store writes never touch the
+ * developer's real profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+
+  // Fresh profile opens to the empty state — create a document to edit
+  const newDocButton = page.getByRole('button', { name: 'New Document' })
+  const isEmptyState = await newDocButton.isVisible({ timeout: 3_000 }).catch(() => false)
+  if (isEmptyState) {
+    await newDocButton.click({ force: true })
+  }
+  await waitForEditor(page)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+})
+
+/** Apply a suggestion over the full content of a fresh paragraph and accept it. */
+async function acceptSuggestion(
+  testPage: Page,
+  original: string,
+  suggested: string,
+): Promise<{ text: string; markdown: string; boldRuns: string[]; italicRuns: string[] }> {
+  return testPage.evaluate(
+    ([originalText, suggestedText]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      editor.commands.setContent(`<p>${originalText}</p>`)
+      editor.commands.setTextSelection({ from: 1, to: 1 + originalText.length })
+      editor.commands.setAISuggestion({
+        id: 'qa-inline-md',
+        type: 'edit',
+        originalText,
+        suggestedText,
+        explanation: 'qa',
+      })
+      editor.commands.acceptAISuggestion('qa-inline-md')
+
+      const boldRuns: string[] = []
+      const italicRuns: string[] = []
+      editor.state.doc.descendants((node: { isText: boolean; text?: string; marks: Array<{ type: { name: string } }> }) => {
+        if (!node.isText) return
+        if (node.marks.some((m) => m.type.name === 'bold')) boldRuns.push(node.text ?? '')
+        if (node.marks.some((m) => m.type.name === 'italic')) italicRuns.push(node.text ?? '')
+      })
+
+      return {
+        text: editor.state.doc.textContent as string,
+        markdown: editor.storage.markdown.getMarkdown() as string,
+        boldRuns,
+        italicRuns,
+      }
+    },
+    [original, suggested] as const,
+  )
+}
+
+test.describe('Electron — AI suggestion acceptance', () => {
+  test('inline markdown in a suggestion becomes real formatting, not literal asterisks', async () => {
+    const result = await acceptSuggestion(
+      page,
+      'Plain sentence to be replaced.',
+      '**Bold text** and *italic text* demonstrate inline formatting.',
+    )
+
+    // The rendered document must contain the visible text only — no asterisks
+    expect(result.text).toBe('Bold text and italic text demonstrate inline formatting.')
+    // The syntax must have become real marks
+    expect(result.boldRuns).toContain('Bold text')
+    expect(result.italicRuns).toContain('italic text')
+    // Serialization must round-trip as markdown syntax, not escaped literals
+    expect(result.markdown).toContain('**Bold text**')
+    expect(result.markdown).not.toContain('\\*')
+  })
+
+  test('plain suggestions keep byte-for-byte insertion', async () => {
+    const result = await acceptSuggestion(
+      page,
+      'Original wording for this sentence.',
+      'Tightened wording for this sentence.',
+    )
+
+    expect(result.text).toBe('Tightened wording for this sentence.')
+    expect(result.boldRuns).toHaveLength(0)
+    expect(result.italicRuns).toHaveLength(0)
+  })
+
+  test('single-line list-like suggestions stay literal (conservative fallback)', async () => {
+    // `- item` parses to a bullet list — a structural change the inline path
+    // deliberately refuses; it must fall back to the existing literal insert
+    // rather than restructure the paragraph.
+    const result = await acceptSuggestion(
+      page,
+      'A sentence that was here before.',
+      '- bullet style replacement',
+    )
+
+    expect(result.text).toBe('- bullet style replacement')
+  })
+})

--- a/src/renderer/extensions/ai-suggestions/extension.ts
+++ b/src/renderer/extensions/ai-suggestions/extension.ts
@@ -69,6 +69,45 @@ export function parseMarkdownToSlice(editor: Editor, schema: Schema, text: strin
 }
 
 /**
+ * Parse a single-line suggestion whose only markdown structure is inline
+ * marks (bold/italic/code/links) into a ProseMirror slice, returning the
+ * slice and its visible text. Returns null — meaning "use the byte-for-byte
+ * schema.text() path" — for anything else:
+ *   • plain text with no markdown syntax (visible text === raw text), so the
+ *     overwhelmingly common case keeps its exact current behaviour;
+ *   • multi-line input (block structure is the multi-block path's job;
+ *     soft-breaks would desync annotation offsets);
+ *   • parses to multiple blocks or a non-textblock (e.g. `- item` → list);
+ *   • produces non-text inline nodes (images, breaks) whose positions don't
+ *     map 1:1 onto visible-text offsets used by word-diff annotations.
+ *
+ * Why: suggestions arrive as markdown (read_document serializes the doc as
+ * markdown, so the model replies in kind), but acceptance inserted the raw
+ * string — `**bold**` landed as literal asterisks in the WYSIWYG doc
+ * (TestFlight v1.6.1 report). The returned visible text must be used as the
+ * annotation `newText` so word-diff offsets index the rendered document.
+ */
+function parseInlineSuggestion(
+  editor: Editor,
+  schema: Schema,
+  suggestedText: string
+): { slice: Slice; text: string } | null {
+  if (suggestedText.includes('\n')) return null
+  const slice = parseMarkdownToSlice(editor, schema, suggestedText)
+  if (!slice || slice.content.childCount !== 1) return null
+  const block = slice.content.firstChild
+  if (!block || !block.isTextblock) return null
+  let marksOnly = true
+  block.content.forEach((inline) => {
+    if (!inline.isText) marksOnly = false
+  })
+  if (!marksOnly) return null
+  const text = block.textContent
+  if (text === suggestedText) return null
+  return { slice, text }
+}
+
+/**
  * Markdown serializer for AI suggestion marks - outputs just the text content
  */
 export const aiSuggestionMarkdownSerializer: MarkSerializerSpec = {
@@ -376,9 +415,16 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           // collapse into a single inline run. Parse it through the
           // tiptap-markdown parser instead to preserve block nodes.
           //
-          // Single-block path (the overwhelmingly common case — a sentence or
-          // phrase edit): schema.text() is kept byte-for-byte so annotation
-          // position math and current behaviour are untouched.
+          // Inline-markdown path: a single-line suggestion carrying inline
+          // syntax (`**bold**`, `*italic*`, `` `code` ``, links) parses into
+          // real marks instead of landing as literal characters; the parsed
+          // visible text replaces suggestedText for annotation offsets.
+          //
+          // Plain single-block path (the overwhelmingly common case — a
+          // sentence or phrase edit with no markdown): schema.text() is kept
+          // byte-for-byte so annotation position math and current behaviour
+          // are untouched.
+          let annotationNewText = suggestedText
           if (suggestedText.length > 0) {
             if (isMultiBlock(suggestedText)) {
               const slice = parseMarkdownToSlice(editor, state.schema, suggestedText)
@@ -389,7 +435,13 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
                 tr.replaceWith(markFrom, markTo, state.schema.text(suggestedText))
               }
             } else {
-              tr.replaceWith(markFrom, markTo, state.schema.text(suggestedText))
+              const inline = parseInlineSuggestion(editor, state.schema, suggestedText)
+              if (inline) {
+                tr.replace(markFrom, markTo, inline.slice)
+                annotationNewText = inline.text
+              } else {
+                tr.replaceWith(markFrom, markTo, state.schema.text(suggestedText))
+              }
             }
           } else {
             tr.delete(markFrom, markTo)
@@ -427,7 +479,10 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
             createWordDiffAnnotations({
               documentId: docId,
               originalText,
-              newText: suggestedText,
+              // Parsed visible text when the inline-markdown path fired —
+              // word-diff offsets must index the rendered document, not the
+              // raw markdown source.
+              newText: annotationNewText,
               rangeFrom: newFrom,
               rangeTo: newTo,
               provenance: {
@@ -542,8 +597,9 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           // Apply each suggestion. Processing end-to-start means earlier
           // suggestions' positions are not shifted by later ones.
           // Multi-block suggestions are parsed through the markdown parser to
-          // preserve paragraph structure; single-run suggestions use the
-          // existing schema.text() path unchanged.
+          // preserve paragraph structure; single-line suggestions with inline
+          // markdown parse to real marks (same contract as acceptAISuggestion);
+          // plain single-run suggestions use the schema.text() path unchanged.
           for (const suggestion of suggestions) {
             tr.removeMark(suggestion.from, suggestion.to, state.schema.marks.aiSuggestion)
             if (suggestion.suggestedText.length > 0) {
@@ -555,7 +611,12 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
                   tr.replaceWith(suggestion.from, suggestion.to, state.schema.text(suggestion.suggestedText))
                 }
               } else {
-                tr.replaceWith(suggestion.from, suggestion.to, state.schema.text(suggestion.suggestedText))
+                const inline = parseInlineSuggestion(editor, state.schema, suggestion.suggestedText)
+                if (inline) {
+                  tr.replace(suggestion.from, suggestion.to, inline.slice)
+                } else {
+                  tr.replaceWith(suggestion.from, suggestion.to, state.schema.text(suggestion.suggestedText))
+                }
               }
             } else {
               tr.delete(suggestion.from, suggestion.to)


### PR DESCRIPTION
## Summary

**TestFlight v1.6.1 QA report:** an accepted AI suggestion containing `**Bold text**` and `*italic text*` landed as **literal asterisks** in the WYSIWYG doc, serializing escaped (`\*\*Bold text\*\*`) via the Copy button.

**Root cause (longstanding gap, not a recent regression):** suggestions arrive as markdown (`read_document` serializes the doc as markdown, so the model replies in kind), but single-block acceptance inserted the raw string byte-for-byte via `schema.text()`. Multi-block (`\n\n`) suggestions were already markdown-parsed by #619; single-block — the common case — deliberately kept literal insertion to protect word-diff annotation offset math.

## Fix

- New `parseInlineSuggestion()`: single-**line** suggestions whose only markdown structure is **inline marks** (bold/italic/code/links) parse into real formatting; the parsed visible text is fed to `createWordDiffAnnotations` as `newText` so word-diff offsets index the **rendered** document — the annotation-math concern that motivated byte-for-byte is preserved.
- Deliberately conservative fallbacks (zero behavior change outside the broken case):
  - plain text → byte-for-byte `schema.text()` exactly as before
  - structural parses (`- item` → list, images, soft breaks, multi-block) → existing paths
- Covers **both** `acceptAISuggestion` and `acceptAllAISuggestions` — the popover, Quick Review, and side-by-side panels all route through these two commands.

## Verification

- New spec `e2e/electron.suggestions.spec.ts` — isolated `PROSE_USER_DATA_DIR` profile, drives the extension commands directly through `window.__prose_editor` (no LLM): **3/3 green with the fix**.
- **Negative control** (stash fix → rebuild → rerun): the inline-markdown test fails against unfixed code with the exact reported signature, while the two unchanged-behavior guards (plain byte-for-byte, list-like fallback) stay green on both builds — the fix is surgical.

## Context

First PR of the AI markdown-editing hardening plan (from TestFlight v1.6.1 QA): block-type conversion, .txt/table guards, annotation robustness (detach-don't-delete), and an AI-pipeline instrumentation layer follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)