### PR TITLE
feat(debug): AI pipeline instrumentation, test seams, round-trip canary

### DIFF
--- a/e2e/electron.markdown-create.spec.ts
+++ b/e2e/electron.markdown-create.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Markdown creation + round-trip canary (#672) — Case B of the AI markdown
+ * hardening plan: create a document through the real create_and_open_file
+ * tool with every supported block type, verify all of them land as real
+ * ProseMirror nodes (not literal syntax), and verify getMarkdown()
+ * serialization is idempotent.
+ *
+ * Isolated PROSE_USER_DATA_DIR profile. The profile's settings.json seeds
+ * defaultSaveDirectory to a temp dir — create_and_open_file writes there
+ * instead of the developer's real ~/Documents — and enables
+ * featureFlags.aiPipelineDebug so the spec also exercises the pipeline log.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+  executeProseTool,
+  exportPipelineLog,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaDocsDir: string
+
+const FULL_MARKDOWN = [
+  '# Heading One',
+  '',
+  'Intro paragraph with **bold** and *italic* text.',
+  '',
+  '## Heading Two',
+  '',
+  '> A quoted line of text',
+  '',
+  '- Bullet item one',
+  '- Bullet item two',
+  '',
+  '1. Ordered item one',
+  '2. Ordered item two',
+  '',
+  '| Col1 | Col2 |',
+  '| --- | --- |',
+  '| A | B |',
+  '',
+  '```js',
+  'const x = 1',
+  '```',
+].join('\n')
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaDocsDir = mkdtempSync(join(tmpdir(), 'prose-qa-docs-'))
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        defaultSaveDirectory: qaDocsDir,
+        featureFlags: { aiPipelineDebug: true },
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaDocsDir, { recursive: true, force: true })
+})
+
+test.describe('Electron — Markdown creation round-trip', () => {
+  test('create_and_open_file renders every block type as real nodes', async () => {
+    const result = await executeProseTool(page, 'create_and_open_file', {
+      filename: 'roundtrip.md',
+      content: FULL_MARKDOWN,
+    })
+    expect(result.success).toBe(true)
+
+    await waitForEditor(page)
+
+    // Collect all node types and heading levels present in the document
+    const summary = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      const types = new Set<string>()
+      const headingLevels: number[] = []
+      const boldRuns: string[] = []
+      editor.state.doc.descendants(
+        (node: {
+          type: { name: string }
+          attrs: Record<string, unknown>
+          isText: boolean
+          text?: string
+          marks: Array<{ type: { name: string } }>
+        }) => {
+          types.add(node.type.name)
+          if (node.type.name === 'heading') headingLevels.push(node.attrs.level as number)
+          if (node.isText && node.marks.some((m) => m.type.name === 'bold')) {
+            boldRuns.push(node.text ?? '')
+          }
+        },
+      )
+      return {
+        types: Array.from(types),
+        headingLevels,
+        boldRuns,
+        text: editor.state.doc.textContent as string,
+      }
+    })
+
+    // Every block type must be a real node
+    for (const expected of ['heading', 'blockquote', 'bulletList', 'orderedList', 'table', 'codeBlock']) {
+      expect(summary.types, `expected node type "${expected}"`).toContain(expected)
+    }
+    expect(summary.headingLevels).toEqual([1, 2])
+    expect(summary.boldRuns).toContain('bold')
+
+    // No literal markdown syntax may survive as text
+    expect(summary.text).not.toContain('# ')
+    expect(summary.text).not.toContain('> ')
+    expect(summary.text).not.toContain('**')
+    expect(summary.text).not.toContain('| Col1')
+  })
+
+  test('getMarkdown serialization is idempotent', async () => {
+    const first = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      return editor.storage.markdown.getMarkdown() as string
+    })
+
+    // Serialized output must contain the canonical syntax
+    expect(first).toContain('# Heading One')
+    expect(first).toContain('> A quoted line of text')
+    expect(first).toContain('- Bullet item one')
+    expect(first).toContain('**bold**')
+    expect(first).toContain('| Col1 | Col2 |')
+
+    // Round-trip: re-parse the serialized markdown, serialize again — stable
+    const second = await page.evaluate((md) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      editor.commands.setContent(md)
+      return editor.storage.markdown.getMarkdown() as string
+    }, first)
+
+    expect(second).toBe(first)
+  })
+
+  test('pipeline debug log captured structured events', async () => {
+    const raw = await exportPipelineLog(page)
+    const entries = JSON.parse(raw) as Array<{ ts: number; event: string; data: unknown }>
+    expect(Array.isArray(entries)).toBe(true)
+    expect(entries.length).toBeGreaterThan(0)
+    // Opening the created file loads its (empty) annotation set → annotation:load
+    expect(entries.map((e) => e.event)).toContain('annotation:load')
+  })
+})

--- a/e2e/shared.ts
+++ b/e2e/shared.ts
@@ -323,6 +323,68 @@ export async function preseedSettings(page: Page): Promise<void> {
   await page.waitForLoadState('networkidle')
 }
 
+// ---------------------------------------------------------------------------
+// AI tool pipeline helpers (window.__prose_tools seam — see renderer/main.tsx)
+// ---------------------------------------------------------------------------
+
+/** Result shape mirrored from src/shared/tools/types.ts ToolResult */
+export interface ProseToolResult {
+  success: boolean
+  data?: unknown
+  error?: string
+  code?: string
+}
+
+/**
+ * Execute a tool through the REAL pipeline (registry lookup, mode access
+ * check, Zod validation, executor) with zero LLM involvement.
+ */
+export async function executeProseTool(
+  page: Page,
+  toolName: string,
+  args: Record<string, unknown>,
+  mode: 'chat' | 'editor' | 'create' = 'create',
+): Promise<ProseToolResult> {
+  return page.evaluate(
+    async ({ name, toolArgs, toolMode }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tools = (window as any).__prose_tools
+      return tools.executeTool(name, toolArgs, toolMode)
+    },
+    { name: toolName, toolArgs: args, toolMode: mode },
+  )
+}
+
+/** Live annotation store contents. */
+export async function getAnnotations(page: Page): Promise<Array<Record<string, unknown>>> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return page.evaluate(() => (window as any).__prose_tools.getAnnotations())
+}
+
+/** The annotation store's current documentId. */
+export async function getAnnotationDocId(page: Page): Promise<string | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return page.evaluate(() => (window as any).__prose_tools.getAnnotationDocId())
+}
+
+/** Annotations as persisted in IndexedDB for a documentId (post-restart checks). */
+export async function readAnnotationsFromDB(
+  page: Page,
+  documentId: string,
+): Promise<Array<Record<string, unknown>>> {
+  return page.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (docId) => (window as any).__prose_tools.loadAnnotationsFromDB(docId),
+    documentId,
+  )
+}
+
+/** Export the AI pipeline debug log (requires featureFlags.aiPipelineDebug). */
+export async function exportPipelineLog(page: Page): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return page.evaluate(() => (window as any).__prose_debug.exportLog())
+}
+
 /** Check if a TipTap mark is currently active. */
 export async function isMarkActive(page: Page, mark: string): Promise<boolean> {
   return page.evaluate((m) => {

--- a/src/renderer/extensions/ai-annotations/store.ts
+++ b/src/renderer/extensions/ai-annotations/store.ts
@@ -7,6 +7,7 @@
 import { create } from 'zustand'
 import type { AIAnnotation, AnnotationState, AnnotationActions } from '../../types/annotations'
 import { generateId, saveAnnotations, loadAnnotations } from '../../lib/persistence'
+import { pipelineLog } from '../../lib/aiPipelineLog'
 
 type AnnotationStore = AnnotationState & AnnotationActions & {
   // Session-scoped set of annotation IDs created (not loaded) this session
@@ -33,6 +34,15 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
 
     // Ensure store's documentId matches the annotation's documentId for correct persistence
     const currentDocId = get().documentId
+    pipelineLog('annotation:create', {
+      id,
+      from: annotationData.from,
+      to: annotationData.to,
+      type: annotationData.type,
+      content: annotationData.content?.substring(0, 30),
+      annotationDocId: annotationData.documentId,
+      storeDocId: currentDocId,
+    })
     console.log('[AnnotationStore] addAnnotation:', {
       id,
       from: annotationData.from,
@@ -259,6 +269,12 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
     console.log('[AnnotationStore] loadAnnotations called:', { documentId })
     try {
       const annotations = await loadAnnotations(documentId)
+      pipelineLog('annotation:load', {
+        documentId,
+        count: annotations.length,
+        replacedCount: get().annotations.length,
+        previousDocId: get().documentId,
+      })
       console.log('[AnnotationStore] Loaded from IndexedDB:', {
         documentId,
         count: annotations.length,
@@ -289,6 +305,7 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
 
     try {
       await saveAnnotations(documentId, annotations)
+      pipelineLog('annotation:save', { documentId, count: annotations.length })
       console.log('[AnnotationStore] Saved successfully:', { documentId, count: annotations.length })
     } catch (error) {
       console.error('Failed to save annotations:', error)

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -11,6 +11,7 @@ import { getComments } from '../extensions/comments'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useFileListStore } from '../stores/fileListStore'
 import { parseMarkdown, serializeMarkdown, prepareTextContent } from '../lib/markdown'
+import { pipelineLog } from '../lib/aiPipelineLog'
 import {
   generateId,
   generateIdFromPath,
@@ -138,6 +139,13 @@ export function useTabs() {
 
     // Save current tab state first
     await saveCurrentTabState()
+
+    pipelineLog('tab:switch', {
+      toTabId: tabId,
+      toDocId: targetTab.documentId,
+      fromDocId: useAnnotationStore.getState().documentId,
+      annotationCountBefore: useAnnotationStore.getState().annotations.length,
+    })
 
     // Pause annotation position updates during document loading
     // This prevents the plugin from deleting annotations when doc content changes
@@ -849,6 +857,15 @@ export function useTabs() {
 
       // Rename the file
       await window.api.renameFile(tab.path, newPath)
+
+      pipelineLog('tab:rename', {
+        oldPath: tab.path,
+        newPath,
+        tabDocId: tab.documentId,
+        // NOTE (#674): documentId is path-derived for saved files but is NOT
+        // migrated here yet — annotations stored under the old id orphan on
+        // the next fresh open. Logged so the gap is visible until fixed.
+      })
 
       // Update tab
       updateTab(tabId, {

--- a/src/renderer/lib/aiPipelineLog.ts
+++ b/src/renderer/lib/aiPipelineLog.ts
@@ -1,0 +1,56 @@
+/**
+ * AI pipeline debug log — stage-by-stage visibility into the AI edit pipeline
+ * (#672): tool calls, suggestion accept decisions, annotation lifecycle
+ * (create/map/detach/load/save), tab switches, documentId changes.
+ *
+ * Gated on `featureFlags.aiPipelineDebug` (settings.json, no rebuild needed):
+ *
+ *   "featureFlags": { "aiPipelineDebug": true }
+ *
+ * When enabled, every event is mirrored to the console as
+ * `[AIPipeline] <event> <data>` and retained in an in-memory circular buffer
+ * (last 500 entries). The buffer is exposed for bug reports via the always-on
+ * window seam (see main.tsx):
+ *
+ *   window.__prose_debug.exportLog()  // JSON string of the buffer
+ *   window.__prose_debug.copyLog()    // same, straight to the clipboard
+ *
+ * When the flag is off, pipelineLog() is a no-op — zero production noise.
+ */
+import { useSettingsStore } from '../stores/settingsStore'
+
+export interface PipelineLogEntry {
+  /** Epoch ms */
+  ts: number
+  /** Stage-qualified event name, e.g. 'suggest_edit:start', 'annotation:detach' */
+  event: string
+  data: Record<string, unknown>
+}
+
+const MAX_ENTRIES = 500
+const buffer: PipelineLogEntry[] = []
+
+export function isPipelineDebugEnabled(): boolean {
+  return useSettingsStore.getState().settings.featureFlags?.aiPipelineDebug === true
+}
+
+/**
+ * Record a pipeline event. Cheap no-op unless the debug flag is on, so call
+ * sites don't need their own gating. Keep `data` JSON-serializable and small —
+ * truncate document content to short prefixes at the call site.
+ */
+export function pipelineLog(event: string, data: Record<string, unknown> = {}): void {
+  if (!isPipelineDebugEnabled()) return
+  buffer.push({ ts: Date.now(), event, data })
+  if (buffer.length > MAX_ENTRIES) buffer.splice(0, buffer.length - MAX_ENTRIES)
+  console.log('[AIPipeline]', event, data)
+}
+
+/** JSON dump of the buffer — the paste-into-bug-report payload. */
+export function dumpPipelineLog(): string {
+  return JSON.stringify(buffer, null, 2)
+}
+
+export function clearPipelineLog(): void {
+  buffer.length = 0
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,12 +1,37 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './components/layout/App'
-import { initDB } from './lib/persistence'
+import { initDB, loadAnnotations as loadAnnotationsFromDB } from './lib/persistence'
 import { useCommandHistoryStore } from './stores/commandHistoryStore'
 import { seedEmojiCache } from './lib/emojiService'
 import { ErrorBoundary } from './lib/sentry'
+import { dumpPipelineLog, clearPipelineLog } from './lib/aiPipelineLog'
+import { executeTool } from './lib/tools'
+import { useAnnotationStore } from './extensions/ai-annotations'
+import { getApi } from './lib/browserApi'
 import './lib/remarkableBridge'
 import './index.css'
+
+// Debug + test seams — same always-on tier as window.__prose_editor
+// (editorInstanceStore.ts). __prose_debug is the bug-report workflow for the
+// AI pipeline log (#672); __prose_tools lets Playwright drive the real tool
+// pipeline (executors, mode checks, schema validation) with zero LLM
+// involvement and inspect annotation state live and from IndexedDB.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(window as any).__prose_debug = {
+  exportLog: dumpPipelineLog,
+  clearLog: clearPipelineLog,
+  copyLog: async () => {
+    await getApi().copyToClipboard(dumpPipelineLog())
+  },
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(window as any).__prose_tools = {
+  executeTool,
+  getAnnotations: () => useAnnotationStore.getState().annotations,
+  getAnnotationDocId: () => useAnnotationStore.getState().documentId,
+  loadAnnotationsFromDB,
+}
 
 function SentryFallback() {
   return (

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -111,6 +111,8 @@ interface SettingsBase {
   featureFlags?: {
     googleDocs?: boolean
     remarkable?: boolean
+    /** AI edit pipeline debug logging (#672) — see lib/aiPipelineLog.ts. Default: off. */
+    aiPipelineDebug?: boolean
   }
   /**
    * Persisted tool mode for the AI assistant (global, shared across all tabs/conversations).


### PR DESCRIPTION
## Summary

PR 2 of the AI markdown-editing hardening plan (follows #671). **Maximum-visibility layer** for the AI edit pipeline: structured, gated debug logging at every stage plus the test seams that let Playwright drive the real tool pipeline with zero LLM involvement.

## What's in it

| Piece | Detail |
|---|---|
| `lib/aiPipelineLog.ts` | `pipelineLog(event, data)` — gated on `featureFlags.aiPipelineDebug` (settings.json, no rebuild needed); in-memory circular buffer (500 entries) + `[AIPipeline]` console mirror; **zero production noise when off** |
| `window.__prose_debug` | `exportLog()` / `copyLog()` (clipboard IPC) / `clearLog()` — the paste-into-bug-report workflow |
| `window.__prose_tools` | `executeTool`, `getAnnotations`, `getAnnotationDocId`, `loadAnnotationsFromDB` — same always-on tier as `__prose_editor`; tests exercise the registry/mode/Zod/executor path exactly as the LLM does |
| Log points | annotation create/load/save, `tab:switch`, `tab:rename` (rename logs the known #674 documentId-orphan gap). Accept-path + executor points land with #673 where those functions change. |
| e2e helpers | `executeProseTool`, `getAnnotations`, `readAnnotationsFromDB`, `exportPipelineLog` in `shared.ts` |
| **Case B canary** | `electron.markdown-create.spec.ts`: full-markdown `create_and_open_file` → headings/blockquote/lists/GFM table/code block all render as real nodes → `getMarkdown()` round-trip **idempotent** → pipeline log captures structured events |

## Verification

- Canary spec **3/3 green** — and a useful diagnostic result in itself: document creation and markdown round-trip are *healthy*; the v1.6.1 mangling lives in the suggestion-accept path (fixed next in #673).
- The spec seeds `defaultSaveDirectory` in its isolated profile so `create_and_open_file` never writes to the real `~/Documents`.

## Deviation from plan

The optional JSONL file sink was dropped — it needs new preload IPC surface (privilege boundary) and the buffer + clipboard export already covers the bug-report workflow. Revisit if TestFlight-side capture proves necessary.

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)