### PR TITLE
feat(editor): block-type conversion on suggestion accept + .txt/table guards

### DIFF
--- a/docs/issues/673/plan.md
+++ b/docs/issues/673/plan.md
@@ -1,0 +1,69 @@
+# #673 — Block-type conversion + .txt/table guards
+
+Part of the AI markdown-editing hardening plan (TestFlight v1.6.1 QA). See
+issue #673 for symptoms; #671 (inline-markdown accept) and #672
+(instrumentation/test seams) landed first.
+
+## Root causes addressed
+
+1. **Suggestions could never change a node's type.** The `aiSuggestion` mark
+   spans the host node's inline content; accept replaced text within the node.
+   `# Heading` on a paragraph either kept a literal `#` or had it stripped by
+   `stripLeadingBlockMarkup`. Restructuring a flat document was impossible.
+2. **`.txt` docs silently flatten markdown** (PlainTextMode) — AI formatting
+   work was destroyed without feedback to the model or user.
+3. **Table-internal suggestions corrupt GFM serialization** — the mark can't
+   represent row/cell structure; replacements land literal pipe text. Tables
+   carry no nodeId, so the reachable target is the *paragraph inside a cell* —
+   the guard checks ancestors.
+
+## Design
+
+- `detectBlockConversion(content, hostType, hostLevel, isTopLevel)`
+  (`executors/editor.ts`): returns the raw markdown when content opens with
+  block markup differing from the host (heading level change, `>`, list
+  markers, ``` fences), null otherwise. **Top-level paragraph/heading hosts
+  only** — converting nested hosts (list items, quoted paragraphs, cells) is
+  ambiguous and excluded.
+- The raw markdown rides the mark as a new `blockConversionIntent` attr
+  (persisted via `data-ai-block-intent`, round-trips through
+  `getAISuggestions`/`restoreAISuggestions` so tab switches keep it). The
+  popover shows the parsed *visible* text (`sliceVisibleText`).
+- **Accept** (`applyBlockConversion`, both `acceptAISuggestion` and
+  `acceptAllAISuggestions`): parse the intent via `parseMarkdownToSlice` and
+  `tr.replace` the **whole host textblock** with a **closed** slice
+  (`new Slice(content, 0, 0)`) — open ends would merge the parsed content back
+  into the host node and lose the conversion. `setNodeMarkup` was rejected:
+  blockquote/lists are wrapper nodes, not textblocks.
+- **Annotations**: single-textblock conversions get word-diff annotations at
+  `insertedAt + 1` (content offset inside the new node); wrapper/multi-node
+  results get one full-range annotation (nested structure breaks linear
+  offset math).
+- **Guards**: `PLAIN_TEXT_DOCUMENT` (suggest_edit + edit) and
+  `TABLE_NODE_NOT_SUPPORTED` (suggest_edit; edit keeps table access for
+  whole-table replacement). Error messages teach the model the recovery path;
+  tool schema descriptions updated to match.
+- `pipelineLog` events: `suggest_edit:start/result`, `edit:start/result`,
+  `accept:path` (which branch fired: blockConversion/multiBlock/inline/
+  literal/delete).
+
+## Known limitations (deliberate)
+
+- Adjacent paragraphs converted to single-item lists yield separate lists
+  (no cross-suggestion consolidation) — an LLM-prompting concern, not pipeline.
+- The popover doesn't yet label the node-type change ("converts to heading") —
+  cosmetic follow-up.
+- Two block-conversion suggestions on the same node would conflict in the
+  accept-all batch; in practice one node holds one suggestion mark at a time
+  (same-type marks replace on overlap).
+
+## Verification
+
+- `e2e/electron.restructure.spec.ts` — the user's core scenario: flat .md →
+  `#`/`##`/`>`/`-` suggestions → accept (single + batch) → real
+  heading/blockquote/bulletList nodes, zero literal syntax, clean
+  serialization; heading level change.
+- `e2e/electron.suggestions.spec.ts` — `.txt` guard, table guard (cell
+  paragraph), executor-driven paragraph→heading conversion; the existing
+  literal-fallback test documents that direct `setAISuggestion` (no executor
+  context) still refuses structural changes.

--- a/e2e/electron.restructure.spec.ts
+++ b/e2e/electron.restructure.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Document restructuring via AI suggestions (#673) — Case A of the AI
+ * markdown hardening plan, the user's core scenario: a .md document whose
+ * formatting was stripped (all flat paragraphs, e.g. after a .txt
+ * round-trip), restored to structured markdown through suggest_edit calls
+ * carrying block markup. Accepting them must CONVERT node types — paragraphs
+ * become real headings/blockquotes/lists — not insert literal syntax.
+ *
+ * Drives the real tool pipeline (suggest_edit → accept_diff) through the
+ * window.__prose_tools seam with zero LLM involvement, in an isolated
+ * PROSE_USER_DATA_DIR profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+  executeProseTool,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaDocsDir: string
+
+// The flat, formatting-stripped document (post-.txt-round-trip state)
+const FLAT_DOC = [
+  'Test Document',
+  '',
+  'A test markdown document for editing demonstrations.',
+  '',
+  'Section One',
+  '',
+  'Sample text demonstrating paragraph structure.',
+  '',
+  'A wise quote belongs here.',
+  '',
+  'Item one of a list.',
+].join('\n')
+
+/** Top-level node summaries from the live editor doc. */
+async function getDocOutline(
+  testPage: Page,
+): Promise<Array<{ type: string; level?: number; text: string }>> {
+  return testPage.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    const outline: Array<{ type: string; level?: number; text: string }> = []
+    editor.state.doc.forEach(
+      (node: { type: { name: string }; attrs: Record<string, unknown>; textContent: string }) => {
+        outline.push({
+          type: node.type.name,
+          ...(node.type.name === 'heading' ? { level: node.attrs.level as number } : {}),
+          text: node.textContent,
+        })
+      },
+    )
+    return outline
+  })
+}
+
+/** Resolve a top-level node's nodeId by its text content via read_document. */
+async function nodeIdByText(testPage: Page, text: string): Promise<string> {
+  const result = await executeProseTool(testPage, 'read_document', {})
+  expect(result.success).toBe(true)
+  const data = result.data as { nodes: Array<{ id: string; content?: string; children?: unknown[] }> }
+  interface DocNode { id: string; content?: string; children?: DocNode[] }
+  const flatten = (nodes: DocNode[]): DocNode[] =>
+    nodes.flatMap((n) => [n, ...(n.children ? flatten(n.children) : [])])
+  const match = flatten(data.nodes as DocNode[]).find((n) => (n.content ?? '').includes(text))
+  expect(match, `node containing "${text}"`).toBeTruthy()
+  return match!.id
+}
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaDocsDir = mkdtempSync(join(tmpdir(), 'prose-qa-docs-'))
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        defaultSaveDirectory: qaDocsDir,
+        featureFlags: { aiPipelineDebug: true },
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+
+  const created = await executeProseTool(page, 'create_and_open_file', {
+    filename: 'flat-restructure.md',
+    content: FLAT_DOC,
+  })
+  expect(created.success).toBe(true)
+  await waitForEditor(page)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaDocsDir, { recursive: true, force: true })
+})
+
+test.describe('Electron — Restructure flat document via suggestions', () => {
+  test('block-markup suggestions convert node types on accept', async () => {
+    // Baseline: everything is a flat paragraph
+    const before = await getDocOutline(page)
+    expect(before.every((n) => n.type === 'paragraph')).toBe(true)
+
+    // The "restore my formatting" suggestion set an agent would produce
+    const titleId = await nodeIdByText(page, 'Test Document')
+    const r1 = await executeProseTool(page, 'suggest_edit', {
+      nodeId: titleId,
+      content: '# Test Document',
+      comment: 'Make this the document title',
+    })
+    expect(r1.success).toBe(true)
+
+    const sectionId = await nodeIdByText(page, 'Section One')
+    const r2 = await executeProseTool(page, 'suggest_edit', {
+      nodeId: sectionId,
+      content: '## Section One',
+      comment: 'Promote to section heading',
+    })
+    expect(r2.success).toBe(true)
+
+    const quoteId = await nodeIdByText(page, 'A wise quote belongs here.')
+    const r3 = await executeProseTool(page, 'suggest_edit', {
+      nodeId: quoteId,
+      content: '> A wise quote belongs here.',
+      comment: 'Format as blockquote',
+    })
+    expect(r3.success).toBe(true)
+
+    const itemId = await nodeIdByText(page, 'Item one of a list.')
+    const r4 = await executeProseTool(page, 'suggest_edit', {
+      nodeId: itemId,
+      content: '- Item one of a list.',
+      comment: 'Format as list item',
+    })
+    expect(r4.success).toBe(true)
+
+    // Accept the title individually (single-accept path)…
+    const titleSuggestionId = (r1.data as { suggestionId: string }).suggestionId
+    const acceptOne = await executeProseTool(page, 'accept_diff', { id: titleSuggestionId })
+    expect(acceptOne.success).toBe(true)
+
+    // …and the rest in one batch (accept-all path)
+    const acceptRest = await executeProseTool(page, 'accept_diff', {})
+    expect(acceptRest.success).toBe(true)
+
+    // The document must now have real structure
+    const after = await getDocOutline(page)
+    const types = after.map((n) => `${n.type}${n.level ?? ''}`)
+    expect(types).toContain('heading1')
+    expect(types).toContain('heading2')
+    expect(types).toContain('blockquote')
+    expect(types).toContain('bulletList')
+
+    const title = after.find((n) => n.type === 'heading' && n.level === 1)
+    expect(title?.text).toBe('Test Document')
+    const section = after.find((n) => n.type === 'heading' && n.level === 2)
+    expect(section?.text).toBe('Section One')
+
+    // Zero literal markdown syntax may survive in the rendered text
+    const fullText = after.map((n) => n.text).join('\n')
+    expect(fullText).not.toContain('#')
+    expect(fullText).not.toContain('>')
+    expect(fullText).not.toMatch(/^- /m)
+
+    // And the serialization must be the intended markdown document
+    const markdown = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      return editor.storage.markdown.getMarkdown() as string
+    })
+    expect(markdown).toContain('# Test Document')
+    expect(markdown).toContain('## Section One')
+    expect(markdown).toContain('> A wise quote belongs here.')
+    expect(markdown).toContain('- Item one of a list.')
+    expect(markdown).not.toContain('\\#')
+    expect(markdown).not.toContain('\\>')
+  })
+
+  test('heading level change converts via the same path', async () => {
+    // 'Section One' is now an H2 — promote it to H1 via suggestion
+    const sectionId = await nodeIdByText(page, 'Section One')
+    const r = await executeProseTool(page, 'suggest_edit', {
+      nodeId: sectionId,
+      content: '# Section One',
+    })
+    expect(r.success).toBe(true)
+    const accept = await executeProseTool(page, 'accept_diff', {
+      id: (r.data as { suggestionId: string }).suggestionId,
+    })
+    expect(accept.success).toBe(true)
+
+    const outline = await getDocOutline(page)
+    const section = outline.find((n) => n.text === 'Section One')
+    expect(section?.type).toBe('heading')
+    expect(section?.level).toBe(1)
+  })
+})

--- a/e2e/electron.suggestions.spec.ts
+++ b/e2e/electron.suggestions.spec.ts
@@ -12,7 +12,7 @@
 
 import { test, expect } from '@playwright/test'
 import type { ElectronApplication, Page } from '@playwright/test'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -21,16 +21,19 @@ import {
   dismissOnboarding,
   dismissOverlay,
   waitForEditor,
+  executeProseTool,
 } from './helpers'
 
 let app: ElectronApplication
 let page: Page
 let qaUserDataDir: string
+let qaFixturesDir: string
 
 test.beforeAll(async () => {
   test.setTimeout(60_000)
 
   qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaFixturesDir = mkdtempSync(join(tmpdir(), 'prose-qa-fixtures-'))
   const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
   app = launched.app
   page = launched.page
@@ -51,6 +54,7 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   await app?.close()
   rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaFixturesDir, { recursive: true, force: true })
 })
 
 /** Apply a suggestion over the full content of a fresh paragraph and accept it. */
@@ -126,7 +130,11 @@ test.describe('Electron — AI suggestion acceptance', () => {
   test('single-line list-like suggestions stay literal (conservative fallback)', async () => {
     // `- item` parses to a bullet list — a structural change the inline path
     // deliberately refuses; it must fall back to the existing literal insert
-    // rather than restructure the paragraph.
+    // rather than restructure the paragraph. (Driving setAISuggestion
+    // directly carries no blockConversionIntent — conversion only happens
+    // when the suggestion goes through executeSuggestEdit, which has the
+    // host-node context; see the block-conversion tests below and
+    // electron.restructure.spec.ts.)
     const result = await acceptSuggestion(
       page,
       'A sentence that was here before.',
@@ -134,5 +142,107 @@ test.describe('Electron — AI suggestion acceptance', () => {
     )
 
     expect(result.text).toBe('- bullet style replacement')
+  })
+})
+
+test.describe('Electron — suggest_edit guards and block conversion (#673)', () => {
+  test('suggest_edit on a .txt document returns PLAIN_TEXT_DOCUMENT guidance', async () => {
+    const txtPath = join(qaFixturesDir, 'plain-notes.txt')
+    writeFileSync(txtPath, 'Some plain text content.\nAnother line of it.\n')
+
+    const opened = await executeProseTool(page, 'open_file', { path: txtPath })
+    expect(opened.success).toBe(true)
+    await waitForEditor(page)
+
+    const read = await executeProseTool(page, 'read_document', {})
+    expect(read.success).toBe(true)
+    const firstNode = (read.data as { nodes: Array<{ id: string }> }).nodes[0]
+
+    const result = await executeProseTool(page, 'suggest_edit', {
+      nodeId: firstNode.id,
+      content: '# Some plain text content.',
+    })
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('PLAIN_TEXT_DOCUMENT')
+    // The message must teach the model the recovery path
+    expect(result.error).toContain('create_and_open_file')
+  })
+
+  test('suggest_edit inside a table returns TABLE_NODE_NOT_SUPPORTED guidance', async () => {
+    const mdPath = join(qaFixturesDir, 'with-table.md')
+    writeFileSync(
+      mdPath,
+      ['Intro paragraph.', '', '| Name | Role |', '| --- | --- |', '| Ada | Engineer |', ''].join('\n'),
+    )
+
+    const opened = await executeProseTool(page, 'open_file', { path: mdPath })
+    expect(opened.success).toBe(true)
+    await waitForEditor(page)
+
+    // Table nodes carry no nodeId — the reachable target is the paragraph
+    // inside a cell. Find it by content.
+    const read = await executeProseTool(page, 'read_document', {})
+    expect(read.success).toBe(true)
+    interface DocNode { id: string; content?: string; children?: DocNode[] }
+    const flatten = (nodes: DocNode[]): DocNode[] =>
+      nodes.flatMap((n) => [n, ...(n.children ? flatten(n.children) : [])])
+    const cellNode = flatten((read.data as { nodes: DocNode[] }).nodes).find((n) =>
+      (n.content ?? '').includes('Ada'),
+    )
+
+    // The cell paragraph may or may not surface in read_document's tree; if it
+    // does, suggest_edit must refuse it. Either way a direct id-less search
+    // fallback must also refuse.
+    const result = await executeProseTool(page, 'suggest_edit', {
+      nodeId: cellNode?.id ?? 'nonexistent-table-target',
+      content: 'Grace',
+      search: 'Ada',
+    })
+    expect(result.success).toBe(false)
+    expect(['TABLE_NODE_NOT_SUPPORTED', 'NODE_NOT_FOUND']).toContain(result.code)
+    if (result.code === 'TABLE_NODE_NOT_SUPPORTED') {
+      expect(result.error).toContain('edit')
+    }
+  })
+
+  test('block conversion via the executor: paragraph becomes heading', async () => {
+    const mdPath = join(qaFixturesDir, 'convert-me.md')
+    writeFileSync(mdPath, 'A future heading\n\nBody text stays a paragraph.\n')
+
+    const opened = await executeProseTool(page, 'open_file', { path: mdPath })
+    expect(opened.success).toBe(true)
+    await waitForEditor(page)
+
+    const read = await executeProseTool(page, 'read_document', {})
+    const firstNode = (read.data as { nodes: Array<{ id: string }> }).nodes[0]
+
+    const suggested = await executeProseTool(page, 'suggest_edit', {
+      nodeId: firstNode.id,
+      content: '## A future heading',
+    })
+    expect(suggested.success).toBe(true)
+
+    const accepted = await executeProseTool(page, 'accept_diff', {
+      id: (suggested.data as { suggestionId: string }).suggestionId,
+    })
+    expect(accepted.success).toBe(true)
+
+    const outline = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      const nodes: Array<{ type: string; level?: number; text: string }> = []
+      editor.state.doc.forEach(
+        (node: { type: { name: string }; attrs: Record<string, unknown>; textContent: string }) => {
+          nodes.push({
+            type: node.type.name,
+            ...(node.type.name === 'heading' ? { level: node.attrs.level as number } : {}),
+            text: node.textContent,
+          })
+        },
+      )
+      return nodes
+    })
+    expect(outline[0]).toEqual({ type: 'heading', level: 2, text: 'A future heading' })
+    expect(outline[1].type).toBe('paragraph')
   })
 })

--- a/src/renderer/extensions/ai-suggestions/extension.ts
+++ b/src/renderer/extensions/ai-suggestions/extension.ts
@@ -7,12 +7,14 @@
 
 import { Mark, mergeAttributes } from '@tiptap/core'
 import type { Editor } from '@tiptap/core'
-import type { Schema, Slice } from '@tiptap/pm/model'
-import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model'
+import type { Schema, Node as PMNode } from '@tiptap/pm/model'
+import { DOMParser as ProseMirrorDOMParser, Slice } from '@tiptap/pm/model'
+import type { Transaction } from '@tiptap/pm/state'
 import type { MarkSerializerSpec } from 'prosemirror-markdown'
 import type { AISuggestionOptions, AISuggestionData, SuggestionType } from './types'
 import { useAnnotationStore } from '../ai-annotations'
 import { createWordDiffAnnotations } from '../../lib/diffUtils'
+import { pipelineLog } from '../../lib/aiPipelineLog'
 
 /**
  * Returns true when `text` contains block-level structure that would be lost
@@ -108,6 +110,71 @@ function parseInlineSuggestion(
 }
 
 /**
+ * Visible text of a parsed slice — top-level blocks' text joined by newline.
+ * Used as the popover display text and the annotation `newText` for
+ * block-converted suggestions (#673): annotation offsets must index the
+ * rendered document, not the raw markdown source.
+ */
+export function sliceVisibleText(slice: Slice): string {
+  const parts: string[] = []
+  slice.content.forEach((child) => {
+    parts.push(child.textContent)
+  })
+  return parts.join('\n')
+}
+
+/**
+ * Block-type conversion on accept (#673): parse the suggestion's original
+ * markdown (`blockConversionIntent` mark attr) and replace the WHOLE host
+ * textblock with the parsed block(s) as a closed slice — converting the
+ * node's type (paragraph → heading/blockquote/list/codeBlock, heading level
+ * changes). A closed slice (openStart/openEnd = 0) substitutes complete
+ * nodes; an open slice here would merge the parsed content back into the
+ * host node and lose the conversion.
+ *
+ * `from`/`to` are the suggestion mark's range in the CURRENT doc coordinates
+ * of `tr` — callers batching multiple conversions must process end-to-start.
+ *
+ * Returns the inserted geometry for annotation creation, or null when the
+ * host node or parser is unavailable (caller falls through to the text
+ * replacement paths).
+ */
+function applyBlockConversion(
+  tr: Transaction,
+  doc: PMNode,
+  editor: Editor,
+  schema: Schema,
+  from: number,
+  to: number,
+  intentMarkdown: string
+): { insertedAt: number; insertedSize: number; singleTextblock: boolean; visibleText: string } | null {
+  let blockPos = -1
+  let blockNodeSize = 0
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (node.isTextblock) {
+      blockPos = pos
+      blockNodeSize = node.nodeSize
+      return false
+    }
+    return true
+  })
+  if (blockPos < 0) return null
+
+  const slice = parseMarkdownToSlice(editor, schema, intentMarkdown)
+  if (!slice || slice.content.childCount === 0) return null
+
+  const closed = new Slice(slice.content, 0, 0)
+  tr.replace(blockPos, blockPos + blockNodeSize, closed)
+
+  return {
+    insertedAt: blockPos,
+    insertedSize: slice.content.size,
+    singleTextblock: slice.content.childCount === 1 && slice.content.firstChild!.isTextblock,
+    visibleText: sliceVisibleText(slice),
+  }
+}
+
+/**
  * Markdown serializer for AI suggestion marks - outputs just the text content
  */
 export const aiSuggestionMarkdownSerializer: MarkSerializerSpec = {
@@ -133,6 +200,8 @@ declare module '@tiptap/core' {
         provenanceConversationId?: string
         provenanceMessageId?: string
         documentId?: string
+        /** Raw markdown for a block-type conversion (#673); null/absent = text replacement */
+        blockConversionIntent?: string | null
       }) => ReturnType
       /**
        * Set user reply on an AI suggestion by ID
@@ -271,6 +340,18 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           return { 'data-document-id': attributes.documentId }
         },
       },
+      // Raw markdown of a block-type conversion (#673) — set by
+      // executeSuggestEdit when the suggestion's content opens with block
+      // markup differing from the host node. The accept path parses it and
+      // replaces the whole host node, converting its type.
+      blockConversionIntent: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-ai-block-intent'),
+        renderHTML: (attributes) => {
+          if (!attributes.blockConversionIntent) return {}
+          return { 'data-ai-block-intent': attributes.blockConversionIntent }
+        },
+      },
     }
   },
 
@@ -308,6 +389,7 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
             createdAt: Date.now(),
             from,
             to,
+            blockConversionIntent: attrs.blockConversionIntent ?? null,
           }
 
           const result = commands.setMark(this.name, {
@@ -321,6 +403,7 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
             provenanceConversationId: attrs.provenanceConversationId || '',
             provenanceMessageId: attrs.provenanceMessageId || '',
             documentId: attrs.documentId || '',
+            blockConversionIntent: attrs.blockConversionIntent ?? null,
           })
 
           if (result && this.options.onSuggestionAdded) {
@@ -410,6 +493,11 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
 
           // Replace the text with suggested text, or delete if empty.
           //
+          // Block-conversion path (#673): the suggestion carries a
+          // blockConversionIntent (raw markdown opening with block markup that
+          // differs from the host node, e.g. `# Title` on a paragraph). Parse
+          // it and replace the WHOLE host node — converting its type.
+          //
           // Multi-block path (#578 structural fix): when suggestedText contains
           // `\n\n` it has paragraph-level structure that schema.text() would
           // collapse into a single inline run. Parse it through the
@@ -424,19 +512,32 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           // sentence or phrase edit with no markdown): schema.text() is kept
           // byte-for-byte so annotation position math and current behaviour
           // are untouched.
+          const blockIntent =
+            (suggestionAttrs as { blockConversionIntent?: string | null }).blockConversionIntent ?? null
           let annotationNewText = suggestedText
+          let acceptPath: 'blockConversion' | 'multiBlock' | 'inline' | 'literal' | 'delete' = 'literal'
+          let conversion: ReturnType<typeof applyBlockConversion> = null
           if (suggestedText.length > 0) {
-            if (isMultiBlock(suggestedText)) {
+            if (blockIntent) {
+              conversion = applyBlockConversion(tr, state.doc, editor, state.schema, markFrom, markTo, blockIntent)
+            }
+            if (conversion) {
+              annotationNewText = conversion.visibleText
+              acceptPath = 'blockConversion'
+            } else if (isMultiBlock(suggestedText)) {
+              acceptPath = 'multiBlock'
               const slice = parseMarkdownToSlice(editor, state.schema, suggestedText)
               if (slice) {
                 tr.replace(markFrom, markTo, slice)
               } else {
                 // Parser unavailable — fall back to flat text rather than dropping the edit.
+                acceptPath = 'literal'
                 tr.replaceWith(markFrom, markTo, state.schema.text(suggestedText))
               }
             } else {
               const inline = parseInlineSuggestion(editor, state.schema, suggestedText)
               if (inline) {
+                acceptPath = 'inline'
                 tr.replace(markFrom, markTo, inline.slice)
                 annotationNewText = inline.text
               } else {
@@ -444,8 +545,16 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
               }
             }
           } else {
+            acceptPath = 'delete'
             tr.delete(markFrom, markTo)
           }
+          pipelineLog('accept:path', {
+            id,
+            path: acceptPath,
+            markFrom,
+            markTo,
+            suggestedTextPreview: suggestedText.substring(0, 60),
+          })
 
           // Create AI annotation for provenance tracking
           const attrs = suggestionAttrs as {
@@ -473,25 +582,54 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           // positions at/after markTo forward by (inserted size − replaced size)
           // in both cases.
           if (docId && suggestedText.length > 0) {
-            const newFrom = tr.mapping.map(markFrom, -1)
-            const newTo = tr.mapping.map(markTo, 1)
-            console.log('[AISuggestion] Creating annotation:', { docId, model, from: newFrom, to: newTo })
-            createWordDiffAnnotations({
-              documentId: docId,
-              originalText,
-              // Parsed visible text when the inline-markdown path fired —
-              // word-diff offsets must index the rendered document, not the
-              // raw markdown source.
-              newText: annotationNewText,
-              rangeFrom: newFrom,
-              rangeTo: newTo,
-              provenance: {
-                model,
-                conversationId: attrs.provenanceConversationId || '',
-                messageId: attrs.provenanceMessageId || '',
-              },
-              explanation: explanation || undefined,
-            })
+            const provenance = {
+              model,
+              conversationId: attrs.provenanceConversationId || '',
+              messageId: attrs.provenanceMessageId || '',
+            }
+            if (conversion && conversion.singleTextblock) {
+              // Converted node sits at its pre-replace position (nothing
+              // before it shifted); content starts one position inside the
+              // node's opening token — word-diff offsets index that content.
+              createWordDiffAnnotations({
+                documentId: docId,
+                originalText,
+                newText: annotationNewText,
+                rangeFrom: conversion.insertedAt + 1,
+                rangeTo: conversion.insertedAt + 1 + conversion.visibleText.length,
+                provenance,
+                explanation: explanation || undefined,
+              })
+            } else if (conversion) {
+              // Wrapper conversion (blockquote/list) or multi-node result:
+              // nested structure breaks linear text-offset math — record a
+              // single full-range annotation over the inserted content.
+              useAnnotationStore.getState().addAnnotation({
+                documentId: docId,
+                type: 'replacement',
+                from: conversion.insertedAt,
+                to: conversion.insertedAt + conversion.insertedSize,
+                content: conversion.visibleText,
+                provenance,
+                explanation: explanation || undefined,
+              })
+            } else {
+              const newFrom = tr.mapping.map(markFrom, -1)
+              const newTo = tr.mapping.map(markTo, 1)
+              console.log('[AISuggestion] Creating annotation:', { docId, model, from: newFrom, to: newTo })
+              createWordDiffAnnotations({
+                documentId: docId,
+                originalText,
+                // Parsed visible text when the inline-markdown path fired —
+                // word-diff offsets must index the rendered document, not the
+                // raw markdown source.
+                newText: annotationNewText,
+                rangeFrom: newFrom,
+                rangeTo: newTo,
+                provenance,
+                explanation: explanation || undefined,
+              })
+            }
           } else {
             console.warn('[AISuggestion] Cannot create annotation - missing docId:', { docId, suggestedText: suggestedText.length })
           }
@@ -554,6 +692,7 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
             from: number
             to: number
             suggestedText: string
+            blockConversionIntent: string | null
           }> = []
 
           // First pass: collect all unique suggestion IDs and their ranges
@@ -582,7 +721,8 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
                     id: mark.attrs.id,
                     from,
                     to,
-                    suggestedText: mark.attrs.suggestedText || ''
+                    suggestedText: mark.attrs.suggestedText || '',
+                    blockConversionIntent: mark.attrs.blockConversionIntent ?? null
                   })
                 }
               }
@@ -595,15 +735,29 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           suggestions.sort((a, b) => b.from - a.from)
 
           // Apply each suggestion. Processing end-to-start means earlier
-          // suggestions' positions are not shifted by later ones.
-          // Multi-block suggestions are parsed through the markdown parser to
-          // preserve paragraph structure; single-line suggestions with inline
-          // markdown parse to real marks (same contract as acceptAISuggestion);
-          // plain single-run suggestions use the schema.text() path unchanged.
+          // suggestions' positions are not shifted by later ones — which also
+          // makes the block-conversion whole-node replacement safe here: each
+          // suggestion's pre-dispatch coordinates stay valid because all
+          // later (higher-position) replacements have already been applied.
+          // Path selection mirrors acceptAISuggestion: blockConversion →
+          // multiBlock → inline → literal.
           for (const suggestion of suggestions) {
             tr.removeMark(suggestion.from, suggestion.to, state.schema.marks.aiSuggestion)
             if (suggestion.suggestedText.length > 0) {
-              if (isMultiBlock(suggestion.suggestedText)) {
+              const conversion = suggestion.blockConversionIntent
+                ? applyBlockConversion(
+                    tr,
+                    doc,
+                    editor,
+                    state.schema,
+                    suggestion.from,
+                    suggestion.to,
+                    suggestion.blockConversionIntent
+                  )
+                : null
+              if (conversion) {
+                pipelineLog('accept:path', { id: suggestion.id, path: 'blockConversion', batch: true })
+              } else if (isMultiBlock(suggestion.suggestedText)) {
                 const slice = parseMarkdownToSlice(editor, state.schema, suggestion.suggestedText)
                 if (slice) {
                   tr.replace(suggestion.from, suggestion.to, slice)
@@ -741,6 +895,7 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
               provenanceConversationId: suggestion.provenanceConversationId || '',
               provenanceMessageId: suggestion.provenanceMessageId || '',
               documentId: suggestion.documentId || '',
+              blockConversionIntent: suggestion.blockConversionIntent ?? null,
             })
 
             tr.addMark(foundStart, foundEnd, mark)
@@ -788,6 +943,7 @@ export function getAISuggestions(editor: {
                 provenanceConversationId?: string
                 provenanceMessageId?: string
                 documentId?: string
+                blockConversionIntent?: string | null
               }
             }>
             nodeSize: number
@@ -818,6 +974,7 @@ export function getAISuggestions(editor: {
           provenanceConversationId: mark.attrs.provenanceConversationId || undefined,
           provenanceMessageId: mark.attrs.provenanceMessageId || undefined,
           documentId: mark.attrs.documentId || undefined,
+          blockConversionIntent: mark.attrs.blockConversionIntent ?? null,
         })
       }
     })

--- a/src/renderer/extensions/ai-suggestions/index.ts
+++ b/src/renderer/extensions/ai-suggestions/index.ts
@@ -1,4 +1,4 @@
-export { AISuggestion, getAISuggestions, getSuggestionsWithFeedback, aiSuggestionMarkdownSerializer, parseMarkdownToSlice } from './extension'
+export { AISuggestion, getAISuggestions, getSuggestionsWithFeedback, aiSuggestionMarkdownSerializer, parseMarkdownToSlice, sliceVisibleText } from './extension'
 export { useSuggestionStore } from './store'
 export type {
   AISuggestionMark,

--- a/src/renderer/extensions/ai-suggestions/types.ts
+++ b/src/renderer/extensions/ai-suggestions/types.ts
@@ -28,6 +28,14 @@ export interface AISuggestionData {
   provenanceConversationId?: string
   provenanceMessageId?: string
   documentId?: string
+  /**
+   * Raw markdown of a block-type conversion (#673) — present when the
+   * suggestion's content opened with block markup differing from the host
+   * node (e.g. `# Title` on a paragraph). The accept path parses this and
+   * replaces the whole host node, converting its type. Null/absent = plain
+   * text replacement.
+   */
+  blockConversionIntent?: string | null
 }
 
 export interface AISuggestionOptions {

--- a/src/renderer/lib/tools/executors/editor.ts
+++ b/src/renderer/lib/tools/executors/editor.ts
@@ -12,8 +12,9 @@ import { useAnnotationStore } from '../../../extensions/ai-annotations'
 import { createWordDiffAnnotations } from '../../diffUtils'
 import { findNodeById, findNodeByContent, getNodesWithIds, flattenNodes } from '../../../extensions/node-ids'
 import { generateId } from '../../persistence'
-import { getAISuggestions, parseMarkdownToSlice } from '../../../extensions/ai-suggestions'
+import { getAISuggestions, parseMarkdownToSlice, sliceVisibleText } from '../../../extensions/ai-suggestions'
 import { parseMarkdown, FRONTMATTER_REGEX } from '../../markdown'
+import { pipelineLog } from '../../aiPipelineLog'
 import { load as parseYaml } from 'js-yaml'
 
 /**
@@ -193,6 +194,60 @@ function stripLeadingBlockMarkup(content: string, nodeType: string, level?: numb
 }
 
 /**
+ * True when the open document is a .txt file rendered in PlainTextMode.
+ * PlainTextMode's appendTransaction flattens every structured node (headings,
+ * blockquotes, lists) and strips all marks on every transaction — any
+ * markdown formatting an AI edit produces would be silently destroyed.
+ */
+function isPlainTextDocument(editor: Editor): boolean {
+  return editor.storage?.plainTextMode?.enabled === true
+}
+
+/** Node types whose internals suggest_edit cannot mark safely. */
+const TABLE_NODE_TYPES = new Set(['table', 'tableRow', 'tableHeader', 'tableCell'])
+
+/**
+ * Detect a block-type conversion intent (#673): the suggestion's content
+ * carries leading block markup that differs from the host node's type, e.g.
+ * `# Title` targeting a paragraph, or `## Sub` targeting an H1. Returns the
+ * raw markdown to parse at accept-time, or null when the suggestion is a
+ * plain text edit for the existing node (same type and level — the existing
+ * stripLeadingBlockMarkup path remains correct).
+ *
+ * Deliberately conservative: only fires for TOP-LEVEL paragraph/heading
+ * hosts. Nested hosts (list items, blockquote children, table cells) keep the
+ * current text-replacement semantics — converting those is ambiguous (does
+ * `- item` on a quoted paragraph mean "make the quote a list" or "make the
+ * paragraph inside the quote a list"?).
+ */
+function detectBlockConversion(
+  content: string,
+  hostType: string,
+  hostLevel: number | undefined,
+  isTopLevel: boolean
+): string | null {
+  if (!isTopLevel) return null
+  if (hostType !== 'paragraph' && hostType !== 'heading') return null
+
+  const trimmed = content.replace(/^[\r\n]+/, '')
+
+  const headingMatch = trimmed.match(/^(#{1,6})\s+/)
+  if (headingMatch) {
+    const level = headingMatch[1].length
+    // Same type AND same level → plain text edit, not a conversion
+    if (hostType === 'heading' && hostLevel === level) return null
+    return trimmed
+  }
+
+  if (/^>\s/.test(trimmed)) return trimmed
+  if (/^(?:[-*+]|\d+\.)\s+/.test(trimmed)) return trimmed
+  if (/^```/.test(trimmed)) return trimmed
+  // Heading host whose replacement carries no block markup → plain text edit
+  return null
+}
+
+
+/**
  * Resolve the target document position for an editor-mutating tool call.
  * Used to sort tool calls by position (descending) before batch execution,
  * so bottom-of-document edits don't shift positions of earlier edits.
@@ -277,6 +332,24 @@ export async function executeEdit(
   }
 
   const { nodeId, content, comment, search } = args
+
+  pipelineLog('edit:start', {
+    nodeId,
+    contentLength: content?.length ?? 0,
+    isPlainText: isPlainTextDocument(editor),
+  })
+
+  if (isPlainTextDocument(editor)) {
+    pipelineLog('edit:result', { nodeId, blocked: 'PLAIN_TEXT_DOCUMENT' })
+    return toolError(
+      'This document is a plain-text (.txt) file — markdown formatting is ' +
+        'intentionally flattened in plain-text mode, so formatting in this edit ' +
+        'would be silently destroyed. To apply markdown formatting, create a ' +
+        'markdown copy instead: call create_and_open_file with a .md filename ' +
+        'and the fully formatted content, then continue editing there.',
+      'PLAIN_TEXT_DOCUMENT'
+    )
+  }
 
   if (!nodeId) {
     return toolError('Node ID is required', 'INVALID_INPUT')
@@ -616,6 +689,25 @@ export function executeSuggestEdit(
   const { nodeId, comment, search } = args
   let { content } = args
 
+  pipelineLog('suggest_edit:start', {
+    nodeId,
+    contentLength: content?.length ?? 0,
+    contentPreview: content?.substring(0, 60),
+    isPlainText: isPlainTextDocument(editor),
+  })
+
+  if (isPlainTextDocument(editor)) {
+    pipelineLog('suggest_edit:result', { nodeId, blocked: 'PLAIN_TEXT_DOCUMENT' })
+    return toolError(
+      'This document is a plain-text (.txt) file — markdown formatting is ' +
+        'intentionally flattened in plain-text mode, so this suggestion would be ' +
+        'silently destroyed. To apply markdown formatting, create a markdown ' +
+        'copy instead: call create_and_open_file with a .md filename and the ' +
+        'fully formatted content, then continue editing there.',
+      'PLAIN_TEXT_DOCUMENT'
+    )
+  }
+
   if (!nodeId) {
     return toolError('Node ID is required', 'INVALID_INPUT')
   }
@@ -723,14 +815,66 @@ export function executeSuggestEdit(
   const { node, pos } = found
   const suggestionId = generateId()
 
+  // Table internals can't host a whole-node suggestion mark: the mark spans
+  // inline content, but table semantics live in the row/cell STRUCTURE, so an
+  // accepted replacement lands literal pipe text and corrupts the GFM
+  // serialization (#673). Note: table nodes themselves carry no nodeId
+  // (NODE_TYPES_WITH_IDS) — the reachable targets are the PARAGRAPHS inside
+  // cells, so the guard must check ancestors, not just the resolved node.
+  const $resolvedPos = editor.state.doc.resolve(pos)
+  let insideTable = TABLE_NODE_TYPES.has(node.type.name)
+  for (let d = $resolvedPos.depth; d > 0 && !insideTable; d--) {
+    if (TABLE_NODE_TYPES.has($resolvedPos.node(d).type.name)) insideTable = true
+  }
+  if (insideTable) {
+    pipelineLog('suggest_edit:result', { nodeId, blocked: 'TABLE_NODE_NOT_SUPPORTED' })
+    return toolError(
+      'suggest_edit cannot target table nodes — the suggestion mark cannot ' +
+        'represent table structure, and accepting it would corrupt the table. ' +
+        'To change a table, use the edit tool to replace the entire table ' +
+        '(pass the full updated GFM table as content), or insert a new table ' +
+        'with insert(position: "after_node").',
+      'TABLE_NODE_NOT_SUPPORTED'
+    )
+  }
+
   // Get the original text content
   const originalText = node.textContent
+
+  // Block-type conversion intent (#673): when the suggestion's content opens
+  // with block markup that differs from the host node (e.g. `# Title` on a
+  // paragraph, `## Sub` on an H1, `> quote` / `- item` / ``` on a paragraph),
+  // the raw markdown is preserved on the mark and the ACCEPT path replaces
+  // the whole node through the markdown parser — converting its type instead
+  // of inserting literal syntax characters.
+  let blockConversionIntent = detectBlockConversion(
+    content,
+    node.type.name,
+    node.attrs?.level,
+    $resolvedPos.depth === 0
+  )
 
   // Normalize suggested text to match the target node's shape. If the target
   // is a heading and the LLM wrapped the replacement in markdown syntax (e.g.
   // "# New Title" for an H1), strip the matching prefix so the diff popover
   // shows just the visible text instead of the raw markdown source.
-  const suggestedText = stripLeadingBlockMarkup(content, node.type.name, node.attrs?.level)
+  // For block conversions, the popover text is the parsed visible text of the
+  // converted content.
+  let suggestedText: string
+  if (blockConversionIntent) {
+    const slice = parseMarkdownToSlice(editor, editor.state.schema, blockConversionIntent)
+    if (slice) {
+      suggestedText = sliceVisibleText(slice)
+    } else {
+      // Markdown parser unavailable — drop the conversion intent so the
+      // accept path doesn't attempt (and fail) the same parse; degrade to
+      // the plain text-replacement behavior.
+      blockConversionIntent = null
+      suggestedText = stripLeadingBlockMarkup(content, node.type.name, node.attrs?.level)
+    }
+  } else {
+    suggestedText = stripLeadingBlockMarkup(content, node.type.name, node.attrs?.level)
+  }
 
   // Defensive guard (#578): a localized edit (e.g., fix a typo in the first
   // sentence) must never silently overwrite the majority of a large node.
@@ -795,8 +939,17 @@ export function executeSuggestEdit(
       provenanceConversationId: provenance?.conversationId || '',
       provenanceMessageId: provenance?.messageId || '',
       documentId: provenance?.documentId || '',
+      blockConversionIntent,
     })
     .run()
+
+  pipelineLog('suggest_edit:result', {
+    suggestionId,
+    nodeId,
+    hostType: node.type.name,
+    blockConversion: !!blockConversionIntent,
+    suggestedTextPreview: suggestedText.substring(0, 60),
+  })
 
   return toolSuccess({
     suggested: true,

--- a/src/shared/tools/schemas/editor.ts
+++ b/src/shared/tools/schemas/editor.ts
@@ -33,7 +33,7 @@ export const editSchema = z.object({
 export const editConfig: ToolConfig<typeof editSchema> = {
   name: 'edit',
   description:
-    "Replace the content of a specific node by ID. Use read_document first to see all nodes with their IDs, then target the node you want to edit. Always include the search parameter with the original text for reliability. Special nodeId: pass 'frontmatter' with the COMPLETE new YAML (with or without --- fences) to direct-write the frontmatter block (no overlay, no search needed).",
+    "Replace the content of a specific node by ID. Use read_document first to see all nodes with their IDs, then target the node you want to edit. Always include the search parameter with the original text for reliability. Special nodeId: pass 'frontmatter' with the COMPLETE new YAML (with or without --- fences) to direct-write the frontmatter block (no overlay, no search needed). Not supported on plain-text .txt documents (returns PLAIN_TEXT_DOCUMENT — markdown would be flattened; create a .md copy via create_and_open_file instead).",
   schema: editSchema,
   category: 'editor',
   requiresMode: 'create', // Direct writes — only available in Create Mode
@@ -109,7 +109,7 @@ export const suggestEditSchema = z.object({
 export const suggestEditConfig: ToolConfig<typeof suggestEditSchema> = {
   name: 'suggest_edit',
   description:
-    'Create an inline diff suggestion on a node. The user sees a highlighted comparison and can accept or reject it. Use read_document first to get node IDs. Always include the search parameter with the original text for reliability.',
+    'Create an inline diff suggestion on a node. The user sees a highlighted comparison and can accept or reject it. Use read_document first to get node IDs. Always include the search parameter with the original text for reliability. Block-type conversion is supported: content opening with block markup (e.g. "# Title", "> quote", "- item") on a top-level paragraph or heading converts the node to that type when accepted. Not supported: table nodes (returns TABLE_NODE_NOT_SUPPORTED — use the edit tool to replace the whole table) and plain-text .txt documents (returns PLAIN_TEXT_DOCUMENT — create a .md copy via create_and_open_file instead).',
   schema: suggestEditSchema,
   category: 'editor',
   // Suggestions are still mutations of pending document state (the diff


### PR DESCRIPTION
## Summary

PR 3 of the AI markdown-editing hardening plan (follows #671, #675) — **the centerpiece fix** for the TestFlight v1.6.1 mangling report. Restructuring a document via AI suggestions now actually works: accepting `# Title` on a paragraph produces a real heading, not literal syntax.

## Root causes fixed

1. **Suggestions could never change a node's type** — the mark spans inline content; accept replaced text within the node. `# Heading` on a paragraph either kept a literal `#` or had it stripped. "Restore my formatting" was structurally impossible.
2. **`.txt` docs silently flatten markdown** (PlainTextMode by design) — AI formatting was destroyed with no feedback.
3. **Table-internal suggestions corrupt GFM** — and since tables carry no nodeId, the reachable target is the *paragraph inside a cell*, so the guard checks ancestors.

## Design highlights

- `detectBlockConversion` fires only for **top-level paragraph/heading hosts** (nested conversion is ambiguous); intent rides the mark as `blockConversionIntent` and survives tab-switch persistence
- Accept replaces the **whole host textblock with a closed slice** (`new Slice(content, 0, 0)`) — `setNodeMarkup` can't produce wrapper nodes (blockquote/lists), and open ends would merge content back into the host
- Annotation offsets: single-textblock conversions get word-diff annotations at the new node's content offset; wrapper/multi-node results get one full-range annotation
- Guards return teaching errors (`PLAIN_TEXT_DOCUMENT` → create a .md via `create_and_open_file`; `TABLE_NODE_NOT_SUPPORTED` → whole-table `edit`); tool schema descriptions updated so the model self-corrects
- `pipelineLog` instrumentation at every decision point (`accept:path` logs which branch fired)

## Verification

- **`e2e/electron.restructure.spec.ts` — the user's exact scenario**: flat formatting-stripped .md → `#`/`##`/`>`/`-` suggestions → accept (single **and** batch) → real heading/blockquote/bulletList nodes, zero literal syntax in the rendered text, clean `getMarkdown()` serialization; plus heading level change
- Guard + executor-conversion cases in `electron.suggestions.spec.ts`; the pre-existing literal-fallback test still passes (direct `setAISuggestion` carries no intent — conversion requires executor context, by design)
- **8/8 new+existing suggestion tests green; negative control: all 5 new tests fail against unfixed code while the 3 PR-#671 tests stay green**
- Full electron suite: 27 passed (3 pre-existing editor-spec flakes, green on retry)

Design doc: `docs/issues/673/plan.md`

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)