### PR TITLE
fix(annotations): detach-don't-delete + close every annotation loss path

### DIFF
--- a/docs/issues/674/plan.md
+++ b/docs/issues/674/plan.md
@@ -22,6 +22,18 @@ disappeared, except two"). Follows #671/#672/#673.
 | **Annotation creation ran before the accept transaction applied.** TipTap applies a command's `tr` after the command body returns, so `createWordDiffAnnotations` → `addAnnotation` (which pauses position updates) executed *before* the aiAnnotations plugin mapped the transaction — the pause swallowed the mapping pass entirely. Every pre-existing annotation kept stale positions forever: collapse-detection starved (entries never detached/cleaned) and decorations drifted after each accept. | Both accept commands defer annotation creation to a `queueMicrotask` — the plugin maps (and detaches) old annotations first; the new annotation's coordinates come from `tr.mapping` and remain valid. |
 | **`executeSelectTab` (select_tab tool) had drifted from `useTabs.switchToTab`**: it saved only the conversation before switching — agent-driven tab switches silently discarded the active tab's unsaved content, annotations, suggestions, and comments. Worse, the editor→store content sync is debounced 500ms (Editor.tsx onUpdate), so an agent accepting an edit and switching tabs immediately snapshotted pre-edit content and reverted the edit on toggle-back. | The executor now mirrors the full save-then-load sequence and serializes the **live editor state** (`getMarkdown()` + `serializeMarkdown`) instead of trusting the debounced `document.content`; pre-sets documentId; loads comments too. |
 
+## Known limitation (follow-up candidate)
+
+The annotation store suppresses position mapping for ~100ms after tab and
+document switches (`setLoadingDocument` + `setTimeout`). Any edit transaction
+landing inside that window is excluded from mapping — existing annotations
+keep pre-edit positions and collapse/detach detection doesn't run for that
+transaction. Rare for humans (sub-100ms switch-then-edit), but agents hit it
+(three IPC roundtrips fit inside the window — found as a CI flake in the
+lifecycle spec). The spec polls `__prose_tools.isAnnotationMappingPaused()`
+before asserting on mapping effects. A real fix would scope suppression to
+the specific load-replacement transaction instead of wall-clock time.
+
 ## Schema note
 
 `AIAnnotation.detached?: boolean` — optional, JSON-compatible; existing stored

--- a/docs/issues/674/plan.md
+++ b/docs/issues/674/plan.md
@@ -22,7 +22,16 @@ disappeared, except two"). Follows #671/#672/#673.
 | **Annotation creation ran before the accept transaction applied.** TipTap applies a command's `tr` after the command body returns, so `createWordDiffAnnotations` → `addAnnotation` (which pauses position updates) executed *before* the aiAnnotations plugin mapped the transaction — the pause swallowed the mapping pass entirely. Every pre-existing annotation kept stale positions forever: collapse-detection starved (entries never detached/cleaned) and decorations drifted after each accept. | Both accept commands defer annotation creation to a `queueMicrotask` — the plugin maps (and detaches) old annotations first; the new annotation's coordinates come from `tr.mapping` and remain valid. |
 | **`executeSelectTab` (select_tab tool) had drifted from `useTabs.switchToTab`**: it saved only the conversation before switching — agent-driven tab switches silently discarded the active tab's unsaved content, annotations, suggestions, and comments. Worse, the editor→store content sync is debounced 500ms (Editor.tsx onUpdate), so an agent accepting an edit and switching tabs immediately snapshotted pre-edit content and reverted the edit on toggle-back. | The executor now mirrors the full save-then-load sequence and serializes the **live editor state** (`getMarkdown()` + `serializeMarkdown`) instead of trusting the debounced `document.content`; pre-sets documentId; loads comments too. |
 
-## Known limitation (follow-up candidate)
+## Known limitations (follow-up candidates)
+
+**Partial-collapse splits still drop the lost half quietly.** When an
+insertion splits an annotation and only ONE remnant survives mapping, the
+collapsed half vanishes without a history record (pre-existing behavior; the
+detach-don't-delete rule fires only when BOTH remnants collapse — detaching
+the original alongside a live remnant would duplicate its content in the
+panel). Flagged in #677 review; revisit if partial-collapse data loss shows
+up in practice.
+
 
 The annotation store suppresses position mapping for ~100ms after tab and
 document switches (`setLoadingDocument` + `setTimeout`). Any edit transaction

--- a/docs/issues/674/plan.md
+++ b/docs/issues/674/plan.md
@@ -1,0 +1,39 @@
+# #674 — Annotation robustness: detach-don't-delete + loss-path fixes
+
+Part of the AI markdown-editing hardening plan (TestFlight v1.6.1 QA:
+"accepted edits showed in the history panel, then toggling around they
+disappeared, except two"). Follows #671/#672/#673.
+
+## Loss paths fixed
+
+| Path | Fix |
+|---|---|
+| `acceptAllAISuggestions` created **no annotations** | Per-suggestion params collected in the end-to-start batch loop; annotations created after `dispatch(tr)` using `tr.mapping` (range-start boundaries are step-stable; later lower-position steps shift via the accumulated mapping). Conversion results use `insertedAt`-based ranges. |
+| Position mapping silently **deleted** collapsed annotations | **Detach, don't delete**: `updatePositions` / `updatePositionsWithSplitting` push `{ ...annotation, detached: true }` (keeping last-valid from/to) instead of dropping. Detached entries pass through future mapping untouched, render **no decoration** (plugin skips them), show dimmed + "superseded" badge in the history panel (jump disabled, remove still works), and persist to IndexedDB — history is an immutable per-document log. Saves fire only when a detach occurred (mapping runs per keystroke). |
+| No `priorAnnotations` protection in `acceptAISuggestion` | Overlapping annotations captured pre-dispatch and passed to `createWordDiffAnnotations` (parity with `executeEdit`); unchanged words keep their provenance marks. Skipped in the batch path (needs per-step snapshots) — overlaps there detach instead of vanishing. |
+| Fire-and-forget save racing tab switches | `pendingSave: Promise \| null` on the store, set by `addAnnotation`; `saveCurrentTabState` awaits it before the next document's `loadAnnotations` replaces the array. |
+| `Editor.tsx` double-load race | All tab paths (`switchToTab`, `openFileInTab`, `openFileInPreviewTab` ×2, `createNewTab`, `reopenLastClosedTab`) pre-set `annotationStore.setDocumentId(newId)` **before** `setDocument(...)` so the recovery effect sees a match and doesn't fire a competing load. |
+| `renameTab` orphaned annotations | documentId is SHA-256(path); rename now migrates annotations (re-keyed + `documentId` rewritten), conversations, suggestions, and comments to the new key, updates the tab/editor/annotation-store identity in-session. Old keys left in place (harmless). |
+
+## Additional root causes found while building the spec
+
+| Finding | Fix |
+|---|---|
+| **Annotation creation ran before the accept transaction applied.** TipTap applies a command's `tr` after the command body returns, so `createWordDiffAnnotations` → `addAnnotation` (which pauses position updates) executed *before* the aiAnnotations plugin mapped the transaction — the pause swallowed the mapping pass entirely. Every pre-existing annotation kept stale positions forever: collapse-detection starved (entries never detached/cleaned) and decorations drifted after each accept. | Both accept commands defer annotation creation to a `queueMicrotask` — the plugin maps (and detaches) old annotations first; the new annotation's coordinates come from `tr.mapping` and remain valid. |
+| **`executeSelectTab` (select_tab tool) had drifted from `useTabs.switchToTab`**: it saved only the conversation before switching — agent-driven tab switches silently discarded the active tab's unsaved content, annotations, suggestions, and comments. Worse, the editor→store content sync is debounced 500ms (Editor.tsx onUpdate), so an agent accepting an edit and switching tabs immediately snapshotted pre-edit content and reverted the edit on toggle-back. | The executor now mirrors the full save-then-load sequence and serializes the **live editor state** (`getMarkdown()` + `serializeMarkdown`) instead of trusting the debounced `document.content`; pre-sets documentId; loads comments too. |
+
+## Schema note
+
+`AIAnnotation.detached?: boolean` — optional, JSON-compatible; existing stored
+annotations read as not-detached. **No DB_VERSION bump** (no object-store
+change).
+
+## Verification
+
+`e2e/electron.ai-edit-lifecycle.spec.ts`:
+- C1 single accepts (inline + block conversion) create annotations
+- C2 accept-all creates one per suggestion (previously zero)
+- C3a annotations survive tab toggling (count + docId stable)
+- C3b overlapping accept detaches the earlier annotation (nothing vanishes)
+- rename migrates to the new path-derived documentId (store + IndexedDB)
+- restart: IndexedDB retains live + detached entries with a fresh app instance

--- a/e2e/electron.ai-edit-lifecycle.spec.ts
+++ b/e2e/electron.ai-edit-lifecycle.spec.ts
@@ -199,18 +199,24 @@ test.describe('Electron — AI edit annotation lifecycle', () => {
   test('rename migrates annotations to the new path-derived documentId', async () => {
     // Switch to lifecycle.md and rename its tab
     const select = await executeProseTool(page, 'select_tab', { match: 'lifecycle' })
-    expect(select.success).toBe(true)
+    expect(select.success, `select_tab failed: ${select.code} ${select.error}`).toBe(true)
     await waitForEditor(page)
 
     const docIdBefore = await getAnnotationDocId(page)
     const countBefore = (await getAnnotations(page)).length
     expect(countBefore).toBeGreaterThanOrEqual(2)
 
-    // Double-click the tab title → inline rename input → type new name
-    await page.getByText('lifecycle', { exact: false }).first().dblclick()
-    await page.keyboard.press('ControlOrMeta+A')
-    await page.keyboard.type('lifecycle-renamed')
-    await page.keyboard.press('Enter')
+    // Rename the active tab via the test seam (window.__prose_renameTab),
+    // exercising the same renameTab path the inline-rename UI calls — without
+    // the fragile double-click → input → keyboard dance. The migration logic
+    // (annotations re-keyed to the new path-derived documentId) is the point.
+    const renamed = await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any
+      const tabId = w.__prose_tools.getActiveTabId()
+      return w.__prose_renameTab(tabId, 'lifecycle-renamed')
+    })
+    expect(renamed, 'renameTab returned null (rename failed)').toBeTruthy()
 
     // The store's documentId must change (path-derived) and annotations survive
     await expect.poll(async () => getAnnotationDocId(page), { timeout: 5_000 }).not.toBe(docIdBefore)

--- a/e2e/electron.ai-edit-lifecycle.spec.ts
+++ b/e2e/electron.ai-edit-lifecycle.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * AI-edit annotation lifecycle (#674) — regression coverage for the
+ * TestFlight v1.6.1 report "accepted edits showed in the history panel, then
+ * toggling around they disappeared, except two."
+ *
+ * Verified loss paths covered here:
+ *   • accept-all created NO annotations at all
+ *   • a later overlapping accept silently DELETED the earlier annotation
+ *     (now: detach-don't-delete — history is an immutable per-document log)
+ *   • annotations lost across tab switches (save race / double-load)
+ *   • annotations orphaned by file rename (path-derived documentId)
+ *   • persistence across app restart
+ *
+ * Drives the real tool pipeline through window.__prose_tools in an isolated
+ * PROSE_USER_DATA_DIR profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+  executeProseTool,
+  getAnnotations,
+  getAnnotationDocId,
+  readAnnotationsFromDB,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaDocsDir: string
+
+/** read_document → first top-level node id whose content contains `text`. */
+async function nodeIdByText(testPage: Page, text: string): Promise<string> {
+  const result = await executeProseTool(testPage, 'read_document', {})
+  expect(result.success).toBe(true)
+  interface DocNode { id: string; content?: string; children?: DocNode[] }
+  const flatten = (nodes: DocNode[]): DocNode[] =>
+    nodes.flatMap((n) => [n, ...(n.children ? flatten(n.children) : [])])
+  const match = flatten((result.data as { nodes: DocNode[] }).nodes).find((n) =>
+    (n.content ?? '').includes(text),
+  )
+  expect(match, `node containing "${text}"`).toBeTruthy()
+  return match!.id
+}
+
+async function suggestAndAccept(testPage: Page, nodeId: string, content: string): Promise<void> {
+  const suggested = await executeProseTool(testPage, 'suggest_edit', { nodeId, content })
+  expect(suggested.success).toBe(true)
+  const accepted = await executeProseTool(testPage, 'accept_diff', {
+    id: (suggested.data as { suggestionId: string }).suggestionId,
+  })
+  expect(accepted.success).toBe(true)
+}
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaDocsDir = mkdtempSync(join(tmpdir(), 'prose-qa-docs-'))
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        defaultSaveDirectory: qaDocsDir,
+        featureFlags: { aiPipelineDebug: true },
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaDocsDir, { recursive: true, force: true })
+})
+
+test.describe('Electron — AI edit annotation lifecycle', () => {
+  test('C1: single accepts create annotations (inline + block conversion)', async () => {
+    const created = await executeProseTool(page, 'create_and_open_file', {
+      filename: 'lifecycle.md',
+      content: 'First paragraph here.\n\nSection title line.\n\nClosing paragraph stays.',
+    })
+    expect(created.success).toBe(true)
+    await waitForEditor(page)
+
+    // Inline-markdown accept
+    const p1 = await nodeIdByText(page, 'First paragraph here.')
+    await suggestAndAccept(page, p1, '**First** paragraph here.')
+
+    // Block-conversion accept
+    const p2 = await nodeIdByText(page, 'Section title line.')
+    await suggestAndAccept(page, p2, '## Section title line.')
+
+    const annotations = await getAnnotations(page)
+    expect(annotations.length).toBeGreaterThanOrEqual(2)
+    expect(annotations.every((a) => a.detached !== true)).toBe(true)
+  })
+
+  test('C2: accept-all creates annotations for every suggestion', async () => {
+    const created = await executeProseTool(page, 'create_and_open_file', {
+      filename: 'accept-all.md',
+      content: 'Alpha line one.\n\nBeta line two.\n\nGamma line three.',
+    })
+    expect(created.success).toBe(true)
+    await waitForEditor(page)
+
+    for (const [text, replacement] of [
+      ['Alpha line one.', 'Alpha line improved.'],
+      ['Beta line two.', 'Beta line refined.'],
+      ['Gamma line three.', '## Gamma heading three'],
+    ] as const) {
+      const nodeId = await nodeIdByText(page, text)
+      const suggested = await executeProseTool(page, 'suggest_edit', { nodeId, content: replacement })
+      expect(suggested.success).toBe(true)
+    }
+
+    // Batch accept — previously created ZERO annotations
+    const acceptAll = await executeProseTool(page, 'accept_diff', {})
+    expect(acceptAll.success).toBe(true)
+
+    const annotations = await getAnnotations(page)
+    expect(annotations.length).toBeGreaterThanOrEqual(3)
+  })
+
+  test('C3a: annotations survive tab toggling', async () => {
+    // Currently on accept-all.md (3+ annotations). Toggle to lifecycle.md and back.
+    const before = await getAnnotations(page)
+    const beforeCount = before.length
+    const docIdBefore = await getAnnotationDocId(page)
+
+    const toLifecycle = await executeProseTool(page, 'select_tab', { match: 'lifecycle' })
+    expect(toLifecycle.success).toBe(true)
+    // lifecycle.md has its own annotations from C1
+    expect((await getAnnotations(page)).length).toBeGreaterThanOrEqual(2)
+
+    const backAgain = await executeProseTool(page, 'select_tab', { match: 'accept-all' })
+    expect(backAgain.success).toBe(true)
+
+    expect(await getAnnotationDocId(page)).toBe(docIdBefore)
+    expect((await getAnnotations(page)).length).toBe(beforeCount)
+  })
+
+  test('C3b: overlapping accept detaches the earlier annotation instead of deleting it', async () => {
+    // On accept-all.md, the 'Alpha line improved.' node already has an
+    // annotation. Accept ANOTHER suggestion on the same node — the earlier
+    // annotation's range collapses under mapping and must detach, not vanish.
+    const before = await getAnnotations(page)
+    const beforeCount = before.length
+
+    const alphaId = await nodeIdByText(page, 'Alpha line improved.')
+    await suggestAndAccept(page, alphaId, 'Alpha sentence rewritten entirely.')
+
+    const after = await getAnnotations(page)
+    // Nothing vanished: the earlier annotation detached, the new accept added one or more
+    expect(after.length).toBeGreaterThan(beforeCount)
+    expect(after.some((a) => a.detached === true)).toBe(true)
+    expect(after.some((a) => a.detached !== true)).toBe(true)
+  })
+
+  test('rename migrates annotations to the new path-derived documentId', async () => {
+    // Switch to lifecycle.md and rename its tab
+    const select = await executeProseTool(page, 'select_tab', { match: 'lifecycle' })
+    expect(select.success).toBe(true)
+    await waitForEditor(page)
+
+    const docIdBefore = await getAnnotationDocId(page)
+    const countBefore = (await getAnnotations(page)).length
+    expect(countBefore).toBeGreaterThanOrEqual(2)
+
+    // Double-click the tab title → inline rename input → type new name
+    await page.getByText('lifecycle', { exact: false }).first().dblclick()
+    await page.keyboard.press('ControlOrMeta+A')
+    await page.keyboard.type('lifecycle-renamed')
+    await page.keyboard.press('Enter')
+
+    // The store's documentId must change (path-derived) and annotations survive
+    await expect.poll(async () => getAnnotationDocId(page), { timeout: 5_000 }).not.toBe(docIdBefore)
+    const docIdAfter = await getAnnotationDocId(page)
+    expect(docIdAfter).toBeTruthy()
+    expect((await getAnnotations(page)).length).toBe(countBefore)
+
+    // And the migrated key holds them in IndexedDB
+    const persisted = await readAnnotationsFromDB(page, docIdAfter!)
+    expect(persisted.length).toBe(countBefore)
+  })
+
+  test('annotations survive app restart (including detached entries)', async () => {
+    // Capture accept-all.md's state, then restart with the same profile
+    const select = await executeProseTool(page, 'select_tab', { match: 'accept-all' })
+    expect(select.success).toBe(true)
+    const docId = await getAnnotationDocId(page)
+    const liveCount = (await getAnnotations(page)).length
+    const detachedCount = (await getAnnotations(page)).filter((a) => a.detached === true).length
+    expect(docId).toBeTruthy()
+    expect(liveCount).toBeGreaterThan(0)
+    expect(detachedCount).toBeGreaterThan(0)
+
+    await app.close()
+    const relaunched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+    app = relaunched.app
+    page = relaunched.page
+    await waitForAppReady(page)
+    await dismissOnboarding(page)
+    await dismissOverlay(page)
+
+    // Read straight from IndexedDB — the immutable log survives restart
+    const persisted = await readAnnotationsFromDB(page, docId!)
+    expect(persisted.length).toBe(liveCount)
+    expect(persisted.filter((a) => a.detached === true).length).toBe(detachedCount)
+  })
+})

--- a/e2e/electron.ai-edit-lifecycle.spec.ts
+++ b/e2e/electron.ai-edit-lifecycle.spec.ts
@@ -51,9 +51,28 @@ async function nodeIdByText(testPage: Page, text: string): Promise<string> {
   return match!.id
 }
 
+/**
+ * The annotation store suppresses position mapping for ~100ms after tab and
+ * document switches (setLoadingDocument). An edit dispatched inside that
+ * window is excluded from mapping — its collapse/detach effects on existing
+ * annotations never run. Poll the seam until the window closes so accepts
+ * always get a real mapping pass (this is what made the detach assertion
+ * CI-flaky: three fast IPC roundtrips can land inside the window).
+ */
+async function waitForMappingResumed(testPage: Page): Promise<void> {
+  await expect
+    .poll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async () => testPage.evaluate(() => (window as any).__prose_tools.isAnnotationMappingPaused()),
+      { timeout: 5_000 },
+    )
+    .toBe(false)
+}
+
 async function suggestAndAccept(testPage: Page, nodeId: string, content: string): Promise<void> {
   const suggested = await executeProseTool(testPage, 'suggest_edit', { nodeId, content })
   expect(suggested.success).toBe(true)
+  await waitForMappingResumed(testPage)
   const accepted = await executeProseTool(testPage, 'accept_diff', {
     id: (suggested.data as { suggestionId: string }).suggestionId,
   })
@@ -134,6 +153,7 @@ test.describe('Electron — AI edit annotation lifecycle', () => {
     }
 
     // Batch accept — previously created ZERO annotations
+    await waitForMappingResumed(page)
     const acceptAll = await executeProseTool(page, 'accept_diff', {})
     expect(acceptAll.success).toBe(true)
 

--- a/src/renderer/components/editor/AIEditsHistoryPanel.tsx
+++ b/src/renderer/components/editor/AIEditsHistoryPanel.tsx
@@ -35,6 +35,9 @@ export function AIEditsHistoryPanel() {
   const handleJump = useCallback(
     (annotation: AIAnnotation) => {
       if (!editor) return
+      // Detached entries are history-only (#674): the annotated text was
+      // replaced by a later edit, so the stored positions are stale.
+      if (annotation.detached) return
       editor.commands.setTextSelection({ from: annotation.from, to: annotation.to })
       editor.commands.focus()
 
@@ -125,6 +128,7 @@ interface HistoryEntryRowProps {
 function HistoryEntryRow({ annotation, onJump, onRemove }: HistoryEntryRowProps) {
   const snippet = annotation.content.slice(0, 80).replace(/\n/g, ' ')
   const isLong = annotation.content.length > 80
+  const detached = annotation.detached === true
 
   return (
     <div
@@ -137,14 +141,25 @@ function HistoryEntryRow({ annotation, onJump, onRemove }: HistoryEntryRowProps)
           onJump(annotation)
         }
       }}
-      title="Jump to in document"
-      className="group px-3 py-2.5 hover:bg-muted/40 transition-colors cursor-pointer focus:outline-none focus:bg-muted/40"
+      title={detached ? 'This edit was later replaced — history record only' : 'Jump to in document'}
+      className={cn(
+        'group px-3 py-2.5 hover:bg-muted/40 transition-colors focus:outline-none focus:bg-muted/40',
+        detached ? 'opacity-60 cursor-default' : 'cursor-pointer'
+      )}
     >
       <div className="flex items-start justify-between gap-2">
         {/* Left: type badge + snippet */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 mb-1">
             <TypeBadge type={annotation.type} />
+            {detached && (
+              <span
+                data-testid="annotation-detached-badge"
+                className="inline-flex items-center rounded px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider bg-muted text-muted-foreground"
+              >
+                superseded
+              </span>
+            )}
             <span className="text-[10px] text-muted-foreground/70 shrink-0">
               {formatModelName(annotation.provenance.model)}
             </span>
@@ -167,12 +182,14 @@ function HistoryEntryRow({ annotation, onJump, onRemove }: HistoryEntryRowProps)
           )}
         </div>
 
-        {/* Right: jump affordance (always visible) + remove (on hover) */}
+        {/* Right: jump affordance (hidden for detached) + remove (on hover) */}
         <div className="flex items-center gap-1 shrink-0">
-          <LocateFixed
-            aria-hidden="true"
-            className="h-3.5 w-3.5 text-muted-foreground/50 group-hover:text-foreground transition-colors"
-          />
+          {!detached && (
+            <LocateFixed
+              aria-hidden="true"
+              className="h-3.5 w-3.5 text-muted-foreground/50 group-hover:text-foreground transition-colors"
+            />
+          )}
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -362,6 +362,14 @@ export function Editor() {
 
       isUpdatingFromStore.current = false
 
+      // The setContent/updateState above dispatched the document-load transaction
+      // which correctly skipped position updates (isLoadingDocument was true). Now
+      // that the load transaction has fired, clear the guard immediately so the
+      // NEXT user-initiated transaction (e.g. accept_diff) runs updatePositions.
+      // The 100ms setTimeout in select_tab / executeOpenFile remains as a fallback
+      // for tab switches where content didn't change.
+      useAnnotationStore.getState().setLoadingDocument(false)
+
       // Scroll to top when new content is loaded
       const editorContainer = editor.view.dom.closest('.overflow-auto')
       if (editorContainer) {

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -111,6 +111,19 @@ export function Toolbar() {
   const tabBarContainerRef = useRef<HTMLDivElement>(null)
   const { tier, containerWidth } = useTabTier(tabBarContainerRef, { tabCount: tabs.length })
 
+  // Test seam: expose renameTab so e2e can exercise the rename + annotation
+  // migration logic (#674) deterministically, without driving the fragile
+  // double-click → inline-input → keyboard UI dance. Same always-on tier as
+  // window.__prose_editor / __prose_tools (editorInstanceStore / main.tsx).
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).__prose_renameTab = renameTab
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).__prose_renameTab
+    }
+  }, [renameTab])
+
   // Track fullscreen state for traffic light padding
   useEffect(() => {
     const api = getApi()

--- a/src/renderer/extensions/ai-annotations/plugin.ts
+++ b/src/renderer/extensions/ai-annotations/plugin.ts
@@ -114,6 +114,9 @@ export function createAIAnnotationsPlugin(options: AIAnnotationOptions = {}) {
 
         if (isVisible) {
           for (const annotation of currentAnnotations) {
+            // Detached annotations are history-only (#674) — no decoration,
+            // and their stale positions must not hit the bounds warning.
+            if (annotation.detached) continue
             if (annotation.from < 0 || annotation.to > doc.nodeSize - 2 || annotation.from >= annotation.to) {
               console.warn('[AIAnnotations:plugin] Skipping invalid annotation (init):', {
                 id: annotation.id,
@@ -225,6 +228,9 @@ export function createAIAnnotationsPlugin(options: AIAnnotationOptions = {}) {
 
           if (isVisible) {
             for (const annotation of storeAnnotations) {
+              // Detached annotations are history-only (#674) — no decoration,
+              // and their stale positions must not hit the bounds warning.
+              if (annotation.detached) continue
               // Validate bounds
               const maxPos = doc.nodeSize - 2
               if (annotation.from < 0 || annotation.to > maxPos || annotation.from >= annotation.to) {

--- a/src/renderer/extensions/ai-annotations/store.ts
+++ b/src/renderer/extensions/ai-annotations/store.ts
@@ -15,6 +15,25 @@ type AnnotationStore = AnnotationState & AnnotationActions & {
   createdThisSession: Set<string>
 }
 
+/**
+ * Run saveAnnotations and record the in-flight write in `pendingSave` so
+ * tab-switch code (saveCurrentTabState / select_tab) can await it before
+ * loading the next document (#674). Every mutator that persists must route
+ * through this — leaving any path on a bare fire-and-forget save reopens the
+ * "annotation lost to a tab-switch race" gap. Clears pendingSave only if it
+ * still points at this write (a newer save supersedes it).
+ */
+function trackedSave(
+  get: () => AnnotationStore,
+  set: (partial: Partial<AnnotationStore>) => void
+): void {
+  const savePromise = get().saveAnnotations()
+  set({ pendingSave: savePromise })
+  savePromise.finally(() => {
+    if (get().pendingSave === savePromise) set({ pendingSave: null })
+  })
+}
+
 export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
   // Initial state
   annotations: [],
@@ -71,14 +90,10 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
       }))
     }
 
-    // Auto-save after adding. Track the in-flight write so tab switches can
-    // await it — a fire-and-forget save racing loadAnnotations(nextDoc) was
-    // one of the "history entries vanished" paths (#674).
-    const savePromise = get().saveAnnotations()
-    set({ pendingSave: savePromise })
-    savePromise.finally(() => {
-      if (get().pendingSave === savePromise) set({ pendingSave: null })
-    })
+    // Auto-save after adding. Tracked so tab switches await it — a
+    // fire-and-forget save racing loadAnnotations(nextDoc) was one of the
+    // "history entries vanished" paths (#674).
+    trackedSave(get, set)
 
     // Track that this annotation was created this session (should not animate)
     get().createdThisSession.add(id)
@@ -98,7 +113,7 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
       annotations: state.annotations.filter((a) => a.id !== id),
     }))
 
-    get().saveAnnotations()
+    trackedSave(get, set)
   },
 
   // Remove annotations in a range, splitting partially-overlapping ones into remnants
@@ -135,7 +150,7 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
       return { annotations: updated }
     })
 
-    get().saveAnnotations()
+    trackedSave(get, set)
   },
 
   // Update positions after document edits using ProseMirror position mapping
@@ -200,14 +215,10 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
     })
     // Persist only when a detach happened — this path runs on every
     // docChanged transaction (including typing), so unconditional saves
-    // would hammer IndexedDB. Track the write in pendingSave so a tab
-    // switch racing this save awaits it (same invariant as addAnnotation).
+    // would hammer IndexedDB. Tracked so a tab switch racing this save
+    // awaits it (same invariant as addAnnotation).
     if (detachedThisPass > 0) {
-      const savePromise = get().saveAnnotations()
-      set({ pendingSave: savePromise })
-      savePromise.finally(() => {
-        if (get().pendingSave === savePromise) set({ pendingSave: null })
-      })
+      trackedSave(get, set)
     }
   },
 
@@ -319,11 +330,7 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
     })
     // Tracked save — see updatePositions for rationale.
     if (detachedThisPass > 0) {
-      const savePromise = get().saveAnnotations()
-      set({ pendingSave: savePromise })
-      savePromise.finally(() => {
-        if (get().pendingSave === savePromise) set({ pendingSave: null })
-      })
+      trackedSave(get, set)
     }
   },
 

--- a/src/renderer/extensions/ai-annotations/store.ts
+++ b/src/renderer/extensions/ai-annotations/store.ts
@@ -200,9 +200,14 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
     })
     // Persist only when a detach happened — this path runs on every
     // docChanged transaction (including typing), so unconditional saves
-    // would hammer IndexedDB.
+    // would hammer IndexedDB. Track the write in pendingSave so a tab
+    // switch racing this save awaits it (same invariant as addAnnotation).
     if (detachedThisPass > 0) {
-      get().saveAnnotations()
+      const savePromise = get().saveAnnotations()
+      set({ pendingSave: savePromise })
+      savePromise.finally(() => {
+        if (get().pendingSave === savePromise) set({ pendingSave: null })
+      })
     }
   },
 
@@ -312,8 +317,13 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
 
       return { annotations: updatedAnnotations }
     })
+    // Tracked save — see updatePositions for rationale.
     if (detachedThisPass > 0) {
-      get().saveAnnotations()
+      const savePromise = get().saveAnnotations()
+      set({ pendingSave: savePromise })
+      savePromise.finally(() => {
+        if (get().pendingSave === savePromise) set({ pendingSave: null })
+      })
     }
   },
 

--- a/src/renderer/extensions/ai-annotations/store.ts
+++ b/src/renderer/extensions/ai-annotations/store.ts
@@ -21,6 +21,7 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
   isVisible: true,
   documentId: null,
   isLoadingDocument: false,
+  pendingSave: null,
   createdThisSession: new Set(),
 
   // Add a new annotation
@@ -70,8 +71,14 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
       }))
     }
 
-    // Auto-save after adding
-    get().saveAnnotations()
+    // Auto-save after adding. Track the in-flight write so tab switches can
+    // await it — a fire-and-forget save racing loadAnnotations(nextDoc) was
+    // one of the "history entries vanished" paths (#674).
+    const savePromise = get().saveAnnotations()
+    set({ pendingSave: savePromise })
+    savePromise.finally(() => {
+      if (get().pendingSave === savePromise) set({ pendingSave: null })
+    })
 
     // Track that this annotation was created this session (should not animate)
     get().createdThisSession.add(id)
@@ -139,10 +146,17 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
       return
     }
 
+    let detachedThisPass = 0
     set((state) => {
       const updatedAnnotations: AIAnnotation[] = []
 
       for (const annotation of state.annotations) {
+        // Detached annotations are history-only — their positions are stale
+        // by definition, so they pass through untouched (#674).
+        if (annotation.detached) {
+          updatedAnnotations.push(annotation)
+          continue
+        }
         const mapped = mapping(annotation.from, annotation.to)
 
         if (mapped) {
@@ -162,17 +176,34 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
             to: mapped.to,
           })
         } else {
-          console.log('[AnnotationStore] updatePositions - annotation deleted by mapping:', {
+          // Range collapsed (the annotated text was replaced/deleted by a
+          // later edit). Detach instead of deleting (#674): the entry stays
+          // in the history panel and IndexedDB — history is an immutable
+          // per-document log — but renders no decoration.
+          pipelineLog('annotation:detach', {
+            id: annotation.id,
+            from: annotation.from,
+            to: annotation.to,
+            reason: 'mapping-collapse',
+          })
+          console.log('[AnnotationStore] updatePositions - annotation detached by mapping:', {
             id: annotation.id,
             from: annotation.from,
             to: annotation.to
           })
+          detachedThisPass++
+          updatedAnnotations.push({ ...annotation, detached: true })
         }
-        // If mapping returns null, the annotation was deleted
       }
 
       return { annotations: updatedAnnotations }
     })
+    // Persist only when a detach happened — this path runs on every
+    // docChanged transaction (including typing), so unconditional saves
+    // would hammer IndexedDB.
+    if (detachedThisPass > 0) {
+      get().saveAnnotations()
+    }
   },
 
   // Update positions with proper handling of insertions inside annotations
@@ -191,10 +222,16 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
       insertions,
       annotationCount: get().annotations.length
     })
+    let detachedThisPass = 0
     set((state) => {
       const updatedAnnotations: AIAnnotation[] = []
 
       for (const annotation of state.annotations) {
+        // Detached annotations are history-only — pass through untouched (#674).
+        if (annotation.detached) {
+          updatedAnnotations.push(annotation)
+          continue
+        }
         // Check if any insertion was strictly inside this annotation
         const insertionInside = insertions.find(
           (ins) => ins.pos > annotation.from && ins.pos < annotation.to
@@ -235,6 +272,19 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
               content: annotation.content.slice(insertionInside.pos - annotation.from),
             })
           }
+
+          // Both remnants collapsed — keep ONE detached entry carrying the
+          // original annotation so the history record survives (#674).
+          if (beforeFrom >= beforeTo && afterFrom >= afterTo) {
+            pipelineLog('annotation:detach', {
+              id: annotation.id,
+              from: annotation.from,
+              to: annotation.to,
+              reason: 'split-collapse',
+            })
+            detachedThisPass++
+            updatedAnnotations.push({ ...annotation, detached: true })
+          }
         } else {
           // No insertion inside, just map positions normally
           const mappedFrom = mapPos(annotation.from, 1)
@@ -246,12 +296,25 @@ export const useAnnotationStore = create<AnnotationStore>((set, get) => ({
               from: mappedFrom,
               to: mappedTo,
             })
+          } else {
+            // Range collapsed — detach, don't delete (#674).
+            pipelineLog('annotation:detach', {
+              id: annotation.id,
+              from: annotation.from,
+              to: annotation.to,
+              reason: 'mapping-collapse',
+            })
+            detachedThisPass++
+            updatedAnnotations.push({ ...annotation, detached: true })
           }
         }
       }
 
       return { annotations: updatedAnnotations }
     })
+    if (detachedThisPass > 0) {
+      get().saveAnnotations()
+    }
   },
 
   // Toggle visibility

--- a/src/renderer/extensions/ai-suggestions/extension.ts
+++ b/src/renderer/extensions/ai-suggestions/extension.ts
@@ -573,63 +573,81 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           const originalText = attrs.originalText || ''
           const explanation = attrs.explanation || ''
 
+          // Capture annotations overlapping the replaced range BEFORE
+          // dispatch (#674) — position mapping will collapse them; passing
+          // them to createWordDiffAnnotations lets unchanged words keep
+          // their prior provenance marks (parity with executeEdit's
+          // priorAnnotations capture in executors/editor.ts).
+          const priorAnnotations = docId
+            ? annotationStore.annotations.filter(
+                (a) => !a.detached && a.documentId === docId && a.to > markFrom && a.from < markTo
+              )
+            : []
+
           dispatch(tr)
 
-          // Create word-level annotations after dispatch so positions reference
-          // the updated document. tr.mapping.map() correctly accounts for the
-          // size of the inserted content regardless of whether it was inserted
-          // as a flat text node or a multi-block slice — the ReplaceStep maps
-          // positions at/after markTo forward by (inserted size − replaced size)
-          // in both cases.
+          // Create word-level annotations in a MICROTASK (#674). TipTap
+          // applies the command's transaction after the command body returns
+          // — creating annotations inline here would run BEFORE the
+          // aiAnnotations plugin maps existing annotations through this
+          // transaction, and addAnnotation's position-update pause would
+          // then swallow that mapping pass entirely. The result was stale
+          // positions on every pre-existing annotation (collapse-detection
+          // starved → entries never detached, decorations drifted). Deferring
+          // lets the plugin map (and detach) old annotations first; the new
+          // annotation's coordinates come from tr.mapping and stay valid.
           if (docId && suggestedText.length > 0) {
             const provenance = {
               model,
               conversationId: attrs.provenanceConversationId || '',
               messageId: attrs.provenanceMessageId || '',
             }
-            if (conversion && conversion.singleTextblock) {
-              // Converted node sits at its pre-replace position (nothing
-              // before it shifted); content starts one position inside the
-              // node's opening token — word-diff offsets index that content.
-              createWordDiffAnnotations({
-                documentId: docId,
-                originalText,
-                newText: annotationNewText,
-                rangeFrom: conversion.insertedAt + 1,
-                rangeTo: conversion.insertedAt + 1 + conversion.visibleText.length,
-                provenance,
-                explanation: explanation || undefined,
-              })
-            } else if (conversion) {
-              // Wrapper conversion (blockquote/list) or multi-node result:
-              // nested structure breaks linear text-offset math — record a
-              // single full-range annotation over the inserted content.
-              useAnnotationStore.getState().addAnnotation({
-                documentId: docId,
-                type: 'replacement',
-                from: conversion.insertedAt,
-                to: conversion.insertedAt + conversion.insertedSize,
-                content: conversion.visibleText,
-                provenance,
-                explanation: explanation || undefined,
-              })
-            } else {
-              const newFrom = tr.mapping.map(markFrom, -1)
-              const newTo = tr.mapping.map(markTo, 1)
-              console.log('[AISuggestion] Creating annotation:', { docId, model, from: newFrom, to: newTo })
-              createWordDiffAnnotations({
-                documentId: docId,
-                originalText,
-                // Parsed visible text when the inline-markdown path fired —
-                // word-diff offsets must index the rendered document, not the
-                // raw markdown source.
-                newText: annotationNewText,
-                rangeFrom: newFrom,
-                rangeTo: newTo,
-                provenance,
-                explanation: explanation || undefined,
-              })
-            }
+            queueMicrotask(() => {
+              if (conversion && conversion.singleTextblock) {
+                // Converted node sits at its pre-replace position (nothing
+                // before it shifted); content starts one position inside the
+                // node's opening token — word-diff offsets index that content.
+                createWordDiffAnnotations({
+                  documentId: docId,
+                  originalText,
+                  newText: annotationNewText,
+                  rangeFrom: conversion.insertedAt + 1,
+                  rangeTo: conversion.insertedAt + 1 + conversion.visibleText.length,
+                  provenance,
+                  explanation: explanation || undefined,
+                })
+              } else if (conversion) {
+                // Wrapper conversion (blockquote/list) or multi-node result:
+                // nested structure breaks linear text-offset math — record a
+                // single full-range annotation over the inserted content.
+                useAnnotationStore.getState().addAnnotation({
+                  documentId: docId,
+                  type: 'replacement',
+                  from: conversion.insertedAt,
+                  to: conversion.insertedAt + conversion.insertedSize,
+                  content: conversion.visibleText,
+                  provenance,
+                  explanation: explanation || undefined,
+                })
+              } else {
+                const newFrom = tr.mapping.map(markFrom, -1)
+                const newTo = tr.mapping.map(markTo, 1)
+                console.log('[AISuggestion] Creating annotation:', { docId, model, from: newFrom, to: newTo })
+                createWordDiffAnnotations({
+                  documentId: docId,
+                  originalText,
+                  // Parsed visible text when the inline-markdown path fired —
+                  // word-diff offsets must index the rendered document, not the
+                  // raw markdown source.
+                  newText: annotationNewText,
+                  rangeFrom: newFrom,
+                  rangeTo: newTo,
+                  provenance,
+                  explanation: explanation || undefined,
+                  priorAnnotations,
+                })
+              }
+            })
           } else {
             console.warn('[AISuggestion] Cannot create annotation - missing docId:', { docId, suggestedText: suggestedText.length })
           }
@@ -693,6 +711,12 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
             to: number
             suggestedText: string
             blockConversionIntent: string | null
+            originalText: string
+            explanation: string
+            provenanceModel: string
+            provenanceConversationId: string
+            provenanceMessageId: string
+            documentId: string
           }> = []
 
           // First pass: collect all unique suggestion IDs and their ranges
@@ -722,7 +746,13 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
                     from,
                     to,
                     suggestedText: mark.attrs.suggestedText || '',
-                    blockConversionIntent: mark.attrs.blockConversionIntent ?? null
+                    blockConversionIntent: mark.attrs.blockConversionIntent ?? null,
+                    originalText: mark.attrs.originalText || '',
+                    explanation: mark.attrs.explanation || '',
+                    provenanceModel: mark.attrs.provenanceModel || '',
+                    provenanceConversationId: mark.attrs.provenanceConversationId || '',
+                    provenanceMessageId: mark.attrs.provenanceMessageId || '',
+                    documentId: mark.attrs.documentId || ''
                   })
                 }
               }
@@ -741,10 +771,21 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           // later (higher-position) replacements have already been applied.
           // Path selection mirrors acceptAISuggestion: blockConversion →
           // multiBlock → inline → literal.
+          // Collected per-suggestion data for post-dispatch annotation
+          // creation (#674): accept-all previously created NO annotations,
+          // so batch-accepted edits never appeared in the history panel.
+          const applied: Array<{
+            suggestion: (typeof suggestions)[number]
+            conversion: ReturnType<typeof applyBlockConversion>
+            annotationNewText: string
+          }> = []
+
           for (const suggestion of suggestions) {
             tr.removeMark(suggestion.from, suggestion.to, state.schema.marks.aiSuggestion)
+            let conversion: ReturnType<typeof applyBlockConversion> = null
+            let annotationNewText = suggestion.suggestedText
             if (suggestion.suggestedText.length > 0) {
-              const conversion = suggestion.blockConversionIntent
+              conversion = suggestion.blockConversionIntent
                 ? applyBlockConversion(
                     tr,
                     doc,
@@ -757,6 +798,7 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
                 : null
               if (conversion) {
                 pipelineLog('accept:path', { id: suggestion.id, path: 'blockConversion', batch: true })
+                annotationNewText = conversion.visibleText
               } else if (isMultiBlock(suggestion.suggestedText)) {
                 const slice = parseMarkdownToSlice(editor, state.schema, suggestion.suggestedText)
                 if (slice) {
@@ -768,10 +810,12 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
                 const inline = parseInlineSuggestion(editor, state.schema, suggestion.suggestedText)
                 if (inline) {
                   tr.replace(suggestion.from, suggestion.to, inline.slice)
+                  annotationNewText = inline.text
                 } else {
                   tr.replaceWith(suggestion.from, suggestion.to, state.schema.text(suggestion.suggestedText))
                 }
               }
+              applied.push({ suggestion, conversion, annotationNewText })
             } else {
               tr.delete(suggestion.from, suggestion.to)
             }
@@ -782,6 +826,67 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
           }
 
           dispatch(tr)
+
+          // Create annotations in a MICROTASK after the transaction actually
+          // applies (see acceptAISuggestion — TipTap applies the tr after the
+          // command body returns; inline creation would starve existing
+          // annotations of this transaction's position mapping). Pre-dispatch
+          // coordinates map through the full accumulated step list:
+          // end-to-start processing means each suggestion's own step leaves
+          // its range-start boundary stable, and later (lower-position) steps
+          // shift it by their length delta — exactly what tr.mapping.map
+          // computes. priorAnnotations restoration is intentionally skipped
+          // in the batch path (it would need a per-step snapshot);
+          // overlapping older annotations detach rather than vanish (#674).
+          queueMicrotask(() => {
+            const annotationStore = useAnnotationStore.getState()
+            for (const { suggestion, conversion, annotationNewText } of applied) {
+              const docId = suggestion.documentId || annotationStore.documentId
+              if (!docId) {
+                console.warn('[AISuggestion] acceptAll: cannot create annotation - missing docId:', suggestion.id)
+                continue
+              }
+              const provenance = {
+                model: suggestion.provenanceModel || 'unknown',
+                conversationId: suggestion.provenanceConversationId,
+                messageId: suggestion.provenanceMessageId,
+              }
+              if (conversion && conversion.singleTextblock) {
+                const base = tr.mapping.map(conversion.insertedAt, -1)
+                createWordDiffAnnotations({
+                  documentId: docId,
+                  originalText: suggestion.originalText,
+                  newText: annotationNewText,
+                  rangeFrom: base + 1,
+                  rangeTo: base + 1 + conversion.visibleText.length,
+                  provenance,
+                  explanation: suggestion.explanation || undefined,
+                })
+              } else if (conversion) {
+                const base = tr.mapping.map(conversion.insertedAt, -1)
+                annotationStore.addAnnotation({
+                  documentId: docId,
+                  type: 'replacement',
+                  from: base,
+                  to: base + conversion.insertedSize,
+                  content: conversion.visibleText,
+                  provenance,
+                  explanation: suggestion.explanation || undefined,
+                })
+              } else {
+                createWordDiffAnnotations({
+                  documentId: docId,
+                  originalText: suggestion.originalText,
+                  newText: annotationNewText,
+                  rangeFrom: tr.mapping.map(suggestion.from, -1),
+                  rangeTo: tr.mapping.map(suggestion.to, 1),
+                  provenance,
+                  explanation: suggestion.explanation || undefined,
+                })
+              }
+            }
+          })
+
           return true
         },
 

--- a/src/renderer/extensions/ai-suggestions/extension.ts
+++ b/src/renderer/extensions/ai-suggestions/extension.ts
@@ -630,6 +630,13 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
                   explanation: explanation || undefined,
                 })
               } else {
+                // Coordinate-consistency note (#677 review): priorAnnotations
+                // carry PRE-dispatch from/to, while rangeFrom is mapped
+                // through tr. This command's only position-shifting step is
+                // the mark-range replacement itself (removeMark doesn't move
+                // positions), so map(markFrom, -1) === markFrom and
+                // diffUtils' originalContentStart (= rangeFrom) stays in the
+                // same coordinate space as the prior annotations.
                 const newFrom = tr.mapping.map(markFrom, -1)
                 const newTo = tr.mapping.map(markTo, 1)
                 console.log('[AISuggestion] Creating annotation:', { docId, model, from: newFrom, to: newTo })
@@ -845,6 +852,16 @@ export const AISuggestion = Mark.create<AISuggestionOptions>({
               if (!docId) {
                 console.warn('[AISuggestion] acceptAll: cannot create annotation - missing docId:', suggestion.id)
                 continue
+              }
+              // Surface the fallback (#677 review): if a tab switch ever
+              // raced this microtask, the store's documentId would be the
+              // NEW tab's — make that visible rather than silently
+              // mis-keying the annotation.
+              if (!suggestion.documentId) {
+                console.warn('[AISuggestion] acceptAll: annotation documentId fell back to store documentId:', {
+                  suggestionId: suggestion.id,
+                  docId,
+                })
               }
               const provenance = {
                 model: suggestion.provenanceModel || 'unknown',

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -24,7 +24,11 @@ import {
   saveAnnotations,
   loadAnnotations,
   deleteAnnotations,
+  saveSuggestions,
+  loadSuggestions,
   deleteSuggestions,
+  saveComments,
+  loadComments,
   deleteComments,
   SESSION_ID
 } from '../lib/persistence'
@@ -93,7 +97,11 @@ export function useTabs() {
     // Save conversations for current document
     await saveCurrentConversation(document.documentId)
 
-    // Save annotations for current document
+    // Save annotations for current document. Await any in-flight write from
+    // addAnnotation first (#674) — a just-created annotation's fire-and-forget
+    // save racing the tab switch was a "history entries vanished" path.
+    const pendingSave = useAnnotationStore.getState().pendingSave
+    if (pendingSave) await pendingSave
     await useAnnotationStore.getState().saveAnnotations()
 
     // Save AI suggestions and comment marks for current document
@@ -150,6 +158,13 @@ export function useTabs() {
     // Pause annotation position updates during document loading
     // This prevents the plugin from deleting annotations when doc content changes
     useAnnotationStore.getState().setLoadingDocument(true)
+
+    // Pre-set the annotation store's documentId BEFORE setDocument (#674):
+    // Editor.tsx's recovery effect fires its own (unguarded) loadAnnotations
+    // whenever annotationStoreDocumentId !== document.documentId — pre-
+    // setting makes the effect see a match immediately, killing the
+    // double-load race with the awaited loadAnnotations below.
+    useAnnotationStore.getState().setDocumentId(targetTab.documentId)
 
     // Activate the new tab
     setActiveTab(tabId)
@@ -245,6 +260,10 @@ export function useTabs() {
       frontmatter: initialFrontmatter,
       cursorPosition: { line: 1, column: 1 }
     })
+
+    // Pre-set the annotation store's documentId before setDocument so the
+    // Editor.tsx recovery effect doesn't fire a competing load (#674).
+    useAnnotationStore.getState().setDocumentId(newDocumentId)
 
     // Set up new document in editorStore
     setDocument({
@@ -383,6 +402,10 @@ export function useTabs() {
       })
     }
 
+    // Pre-set the annotation store's documentId before setDocument so the
+    // Editor.tsx recovery effect doesn't fire a competing load (#674).
+    useAnnotationStore.getState().setDocumentId(newDocumentId)
+
     // Set up document in editorStore
     setDocument({
       documentId: newDocumentId,
@@ -501,6 +524,10 @@ export function useTabs() {
 
       setActiveTab(previewTab.id)
 
+      // Pre-set the annotation store's documentId before setDocument so the
+      // Editor.tsx recovery effect doesn't fire a competing load (#674).
+      useAnnotationStore.getState().setDocumentId(newDocumentId)
+
       // Load document into editor
       setDocument({
         documentId: newDocumentId,
@@ -564,6 +591,10 @@ export function useTabs() {
         cursorPosition: { line: 1, column: 1 }
       })
     }
+
+    // Pre-set the annotation store's documentId before setDocument so the
+    // Editor.tsx recovery effect doesn't fire a competing load (#674).
+    useAnnotationStore.getState().setDocumentId(newDocumentId)
 
     setDocument({
       documentId: newDocumentId,
@@ -858,27 +889,65 @@ export function useTabs() {
       // Rename the file
       await window.api.renameFile(tab.path, newPath)
 
+      // Migrate path-derived persistence (#674): documentId is
+      // SHA-256(path) for saved files, so a rename changes the identity the
+      // NEXT fresh open computes. Copy annotations/conversations/suggestions/
+      // comments to the new key so they don't orphan. The old keys are left
+      // in place (harmless; a future cleanup sweep can collect them).
+      const oldDocumentId = await generateIdFromPath(tab.path)
+      const newDocumentId = await generateIdFromPath(newPath)
       pipelineLog('tab:rename', {
         oldPath: tab.path,
         newPath,
-        tabDocId: tab.documentId,
-        // NOTE (#674): documentId is path-derived for saved files but is NOT
-        // migrated here yet — annotations stored under the old id orphan on
-        // the next fresh open. Logged so the gap is visible until fixed.
+        oldDocId: oldDocumentId,
+        newDocId: newDocumentId,
       })
+      if (oldDocumentId !== newDocumentId) {
+        const [annotations, conversations, suggestions, comments] = await Promise.all([
+          loadAnnotations(oldDocumentId),
+          loadConversations(oldDocumentId),
+          loadSuggestions(oldDocumentId),
+          loadComments(oldDocumentId),
+        ])
+        await Promise.all([
+          annotations.length > 0
+            ? saveAnnotations(newDocumentId, annotations.map((a) => ({ ...a, documentId: newDocumentId })))
+            : Promise.resolve(),
+          conversations.length > 0 ? saveConversations(newDocumentId, conversations) : Promise.resolve(),
+          suggestions.length > 0 ? saveSuggestions(newDocumentId, suggestions) : Promise.resolve(),
+          comments.length > 0 ? saveComments(newDocumentId, comments) : Promise.resolve(),
+        ])
+        pipelineLog('tab:rename:migrated', {
+          newDocId: newDocumentId,
+          annotations: annotations.length,
+          conversations: conversations.length,
+          suggestions: suggestions.length,
+          comments: comments.length,
+        })
+      }
 
-      // Update tab
+      // Update tab (including its documentId — the old path-derived id no
+      // longer matches what a fresh open of newPath would compute)
       updateTab(tabId, {
         path: newPath,
-        title: sanitized
+        title: sanitized,
+        documentId: newDocumentId
       })
 
-      // Update editor store if this is the active document
+      // Update editor store + annotation store if this is the active document
       if (document.path === tab.path) {
+        useAnnotationStore.getState().setDocumentId(newDocumentId)
         useEditorStore.getState().setDocument({
           ...document,
-          path: newPath
+          path: newPath,
+          documentId: newDocumentId
         })
+        setCurrentDocumentId(newDocumentId)
+        // Re-point in-memory annotations at the new identity so the next
+        // saveAnnotations writes to the migrated key
+        useAnnotationStore.setState((s) => ({
+          annotations: s.annotations.map((a) => ({ ...a, documentId: newDocumentId })),
+        }))
       }
 
       // Refresh file list
@@ -933,6 +1002,10 @@ export function useTabs() {
 
     // Create the new tab in the store (store sets activeTabId internally)
     reopenLastClosedTabStore(snapshot, documentId)
+
+    // Pre-set the annotation store's documentId before setDocument so the
+    // Editor.tsx recovery effect doesn't fire a competing load (#674).
+    useAnnotationStore.getState().setDocumentId(documentId)
 
     // Load the restored content into editorStore
     setDocument({

--- a/src/renderer/lib/tools/executors/tabs.ts
+++ b/src/renderer/lib/tools/executors/tabs.ts
@@ -6,10 +6,16 @@ import type { ToolResult } from '../../../../shared/tools/types'
 import { toolSuccess, toolError } from '../../../../shared/tools/types'
 import { useTabStore } from '../../../stores/tabStore'
 import { useEditorStore } from '../../../stores/editorStore'
+import { useEditorInstanceStore } from '../../../stores/editorInstanceStore'
 import { useChatStore, setCurrentDocumentId } from '../../../stores/chatStore'
 import { useAnnotationStore } from '../../../extensions/ai-annotations'
 import { useSuggestionStore } from '../../../extensions/ai-suggestions/store'
+import { getAISuggestions } from '../../../extensions/ai-suggestions'
+import { useCommentStore } from '../../../extensions/comments/store'
+import { getComments } from '../../../extensions/comments'
 import { useFileListStore } from '../../../stores/fileListStore'
+import { serializeMarkdown } from '../../markdown'
+import { pipelineLog } from '../../aiPipelineLog'
 
 // Tab summary shape returned to Claude
 interface TabSummary {
@@ -114,18 +120,61 @@ export async function executeSelectTab(args: {
   }
 
   try {
-    // Save current tab conversation state
-    const { document } = useEditorStore.getState()
+    // Persist the CURRENT tab's full state before switching (#674). This
+    // executor had drifted from useTabs.switchToTab: it saved only the
+    // conversation, so agent-driven tab switches silently discarded the
+    // active tab's unsaved content, annotations, suggestions, and comments.
+    const { document, cursorPosition } = useEditorStore.getState()
+    const activeTab = tabState.tabs.find((t) => t.id === tabState.activeTabId)
+    // The editor→store content sync is DEBOUNCED (500ms, Editor.tsx
+    // onUpdate). An agent accepting an edit and switching tabs in the same
+    // breath would snapshot pre-edit content and silently revert the edit on
+    // toggle-back — so serialize the LIVE editor state here instead of
+    // trusting editorStore.document.content.
+    const liveEditor = useEditorInstanceStore.getState().editor
+    const liveContent = liveEditor
+      ? serializeMarkdown(liveEditor.storage.markdown.getMarkdown(), document.frontmatter)
+      : document.content
+    if (activeTab) {
+      useTabStore.getState().updateTab(activeTab.id, {
+        content: liveContent,
+        frontmatter: document.frontmatter,
+        cursorPosition,
+        isDirty: document.isDirty || liveContent !== document.content
+      })
+    }
     await useChatStore.getState().saveCurrentConversation(document.documentId)
+
+    // Await any in-flight annotation write, then persist (#674 save race)
+    const pendingSave = useAnnotationStore.getState().pendingSave
+    if (pendingSave) await pendingSave
+    await useAnnotationStore.getState().saveAnnotations()
+
+    if (liveEditor && activeTab?.documentId) {
+      await useSuggestionStore.getState().saveSuggestions(activeTab.documentId, getAISuggestions(liveEditor))
+      await useCommentStore.getState().saveComments(activeTab.documentId, getComments(liveEditor))
+    }
+
+    pipelineLog('tab:switch', {
+      via: 'select_tab',
+      toTabId: targetTab.id,
+      toDocId: targetTab.documentId,
+      fromDocId: useAnnotationStore.getState().documentId,
+      annotationCountBefore: useAnnotationStore.getState().annotations.length,
+    })
 
     // Pause annotation position updates during document loading
     useAnnotationStore.getState().setLoadingDocument(true)
+
+    // Pre-set the annotation store's documentId before setDocument so the
+    // Editor.tsx recovery effect doesn't fire a competing load (#674).
+    const newDocumentId = targetTab.documentId
+    useAnnotationStore.getState().setDocumentId(newDocumentId)
 
     // Activate the new tab
     useTabStore.getState().setActiveTab(targetTab.id)
 
     // Load target tab's document into editorStore
-    const newDocumentId = targetTab.documentId
     useEditorStore.getState().setDocument({
       documentId: newDocumentId,
       path: targetTab.path,
@@ -141,11 +190,12 @@ export async function executeSelectTab(args: {
       )
     }
 
-    // Load conversations, annotations, and suggestions for the new document
+    // Load conversations, annotations, suggestions, and comments for the new document
     setCurrentDocumentId(newDocumentId)
     await useChatStore.getState().loadForDocument(newDocumentId)
     await useAnnotationStore.getState().loadAnnotations(newDocumentId)
     await useSuggestionStore.getState().loadSuggestions(newDocumentId)
+    await useCommentStore.getState().loadComments(newDocumentId)
 
     // Clear reMarkable read-only state
     useEditorStore.getState().setRemarkableReadOnly(false, null)

--- a/src/renderer/lib/tools/executors/tabs.ts
+++ b/src/renderer/lib/tools/executors/tabs.ts
@@ -132,7 +132,7 @@ export async function executeSelectTab(args: {
     // toggle-back — so serialize the LIVE editor state here instead of
     // trusting editorStore.document.content.
     const liveEditor = useEditorInstanceStore.getState().editor
-    const liveContent = liveEditor
+    const liveContent = liveEditor?.storage?.markdown?.getMarkdown != null
       ? serializeMarkdown(liveEditor.storage.markdown.getMarkdown(), document.frontmatter)
       : document.content
     if (activeTab) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -30,6 +30,11 @@ import './index.css'
   executeTool,
   getAnnotations: () => useAnnotationStore.getState().annotations,
   getAnnotationDocId: () => useAnnotationStore.getState().documentId,
+  // True while the annotation store suppresses position mapping (the ~100ms
+  // window after tab/document switches). Tests poll this before dispatching
+  // edits whose annotation mapping they assert on — an edit landing inside
+  // the window is excluded from mapping (#674 known limitation).
+  isAnnotationMappingPaused: () => useAnnotationStore.getState().isLoadingDocument,
   loadAnnotationsFromDB,
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from './lib/sentry'
 import { dumpPipelineLog, clearPipelineLog } from './lib/aiPipelineLog'
 import { executeTool } from './lib/tools'
 import { useAnnotationStore } from './extensions/ai-annotations'
+import { useTabStore } from './stores/tabStore'
 import { getApi } from './lib/browserApi'
 import './lib/remarkableBridge'
 import './index.css'
@@ -35,6 +36,7 @@ import './index.css'
   // edits whose annotation mapping they assert on — an edit landing inside
   // the window is excluded from mapping (#674 known limitation).
   isAnnotationMappingPaused: () => useAnnotationStore.getState().isLoadingDocument,
+  getActiveTabId: () => useTabStore.getState().activeTabId,
   loadAnnotationsFromDB,
 }
 

--- a/src/renderer/types/annotations.ts
+++ b/src/renderer/types/annotations.ts
@@ -44,6 +44,15 @@ export interface AIAnnotation {
   provenance: AIProvenance
   /** Model-supplied reason for the edit, preserved from the originating suggestion */
   explanation?: string
+  /**
+   * The annotation's range collapsed under position mapping (its text was
+   * replaced/deleted by a later edit). Detached annotations stay in the
+   * history panel and IndexedDB — history is an immutable per-document log
+   * (#674) — but render no decoration; from/to keep the last valid values.
+   * Optional and JSON-compatible: existing stored annotations read as
+   * not-detached.
+   */
+  detached?: boolean
 }
 
 /**
@@ -72,6 +81,13 @@ export interface AnnotationState {
   documentId: string | null
   /** Whether document is being loaded (skip position updates during tab switches) */
   isLoadingDocument: boolean
+  /**
+   * In-flight IndexedDB write from the most recent addAnnotation. Tab-switch
+   * paths await this before loading the next document's annotations so a
+   * just-created annotation can't be lost to the fire-and-forget save race
+   * (#674).
+   */
+  pendingSave: Promise<void> | null
 }
 
 /**


### PR DESCRIPTION
## Summary

PR 4 of the AI markdown-editing hardening plan (follows #671, #675, #676) — fixes the TestFlight v1.6.1 report: *"accepted edits showed in the annotation history… toggling around, they just disappeared, except two."*

**Six loss paths found and closed**, including two deep bugs the new spec flushed out that the original plan didn't anticipate.

## The planned fixes

- **`acceptAllAISuggestions` created no annotations** → batch accepts now create one per suggestion post-dispatch via `tr.mapping` (end-to-start coordinates map cleanly)
- **Mapping collapse silently deleted annotations** → **detach, don't delete**: `{ detached: true }` with last-valid positions; no decoration, dimmed "superseded" row in the history panel (jump disabled, remove works), persists to IndexedDB. History = immutable per-document log. Saves fire only when a detach occurs (mapping runs per keystroke).
- **`priorAnnotations` parity** for `acceptAISuggestion` (the `executeEdit` pattern) — unchanged words keep provenance
- **Save race**: `pendingSave` promise on the store, awaited before tab switches load the next doc
- **Double-load race**: all tab paths pre-set `annotationStore.setDocumentId` *before* `setDocument`
- **Rename orphaning**: `renameTab` migrates annotations/conversations/suggestions/comments to the new path-derived documentId and re-points the in-session identity

## The two bugs the spec found

1. **Annotation creation ran before the accept transaction applied.** TipTap applies a command's `tr` after the command body returns — so annotation creation (and `addAnnotation`'s position-update pause) executed *before* the aiAnnotations plugin mapped the transaction, and the pause swallowed that mapping pass entirely. **Every pre-existing annotation kept stale positions after every accept** — collapse-detection starved, decorations drifted. Both accept commands now defer annotation creation to a `queueMicrotask`. (Diagnosed live via the #672 pipeline log: `updatePositions SKIPPED - document is loading` firing inside the accept.)
2. **`select_tab` (the tool) had drifted from `useTabs.switchToTab`** — it saved only the conversation, so agent-driven tab switches discarded the active tab's content/annotations/suggestions/comments. Compounding it, the editor→store content sync is debounced 500ms, so an agent accepting an edit and switching tabs immediately **reverted the edit on toggle-back**. The executor now mirrors the full save-then-load sequence and serializes the **live editor state** instead of the debounced store content.

## Schema

`AIAnnotation.detached?: boolean` — optional, JSON-compatible, existing stored annotations read as not-detached. **No DB_VERSION bump.**

## Verification

`e2e/electron.ai-edit-lifecycle.spec.ts` (isolated profile, real tool pipeline, zero LLM):
- C1 single accepts (inline + block conversion) create annotations
- C2 accept-all creates one per suggestion
- C3a annotations survive tab toggling (count + docId stable)
- C3b overlapping accept **detaches** the earlier annotation — nothing vanishes
- rename migrates to the new documentId (store + IndexedDB)
- app restart: fresh instance reads live + detached entries from IndexedDB

**6/6 green; negative control: 5/6 fail against unfixed code** (C1 already worked — honest control). Full electron suite: 29 passed.

Design doc: `docs/issues/674/plan.md`

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)