### PR TITLE
chore(mas): bump buildVersion to 25 for TestFlight

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -14,7 +14,7 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
 
 - **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
   automation edge; clicking "Submit for Review" is always a human decision and action.
-- **`buildVersion` is global-monotonic.** Currently `"24"` in `electron-builder.yml`.
+- **`buildVersion` is global-monotonic.** Currently `"25"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
   **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.1`).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "24"
+buildVersion: "25"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
## Summary

Bumps `buildVersion` 24 → 25. **Build 25 = v1.6.1 + the AI markdown-editing hardening tranche** from the TestFlight v1.6.1 QA findings:

- **#671** — inline-markdown suggestion accept (`**bold**` renders, not literal asterisks)
- **#675** — AI pipeline instrumentation (`aiPipelineDebug` flag, `__prose_debug.exportLog()`) + test seams
- **#676** — block-type conversion on accept + `.txt`/table guards (restructuring a flat doc works)
- **#677** — annotation robustness: detach-don't-delete + six closed loss paths (the "history disappeared" bug)

buildVersion is global monotonic — 24 is consumed on App Store Connect.

Part of the Wave 0.5 TestFlight iteration loop: merge fixes → cut build → upload → human QA.

Refs #671, #675, #676, #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)