### PR TITLE
fix(editor): dedupe node IDs created by node splits

### DIFF
--- a/e2e/electron.node-ids.spec.ts
+++ b/e2e/electron.node-ids.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Node ID uniqueness (#681) — regression coverage for duplicate nodeIds
+ * created by node splits.
+ *
+ * ProseMirror copies a node's attributes (including `nodeId`) to BOTH halves
+ * when a block is split (Enter mid-paragraph, or an insert that produces a
+ * sibling). The nodeIds extension's appendTransaction only assigned ids to
+ * id-LESS nodes, so both halves kept the same id forever — which broke
+ * id-based targeting (read_document emitted two nodes with one id;
+ * suggest_edit resolved to the wrong occurrence and tripped the
+ * destructive-edit guard).
+ *
+ * Drives the editor directly (window.__prose_editor) + the real read_document
+ * tool (window.__prose_tools) in an isolated PROSE_USER_DATA_DIR profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+  executeProseTool,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+
+  const newDocButton = page.getByRole('button', { name: 'New Document' })
+  if (await newDocButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await newDocButton.click({ force: true })
+  }
+  await waitForEditor(page)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+})
+
+/** Collect every block nodeId in the document (in order). */
+async function blockNodeIds(testPage: Page): Promise<string[]> {
+  return testPage.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (window as any).__prose_editor
+    const ids: string[] = []
+    editor.state.doc.descendants((node: { attrs: Record<string, unknown> }) => {
+      const id = node.attrs.nodeId
+      if (typeof id === 'string' && id) ids.push(id)
+    })
+    return ids
+  })
+}
+
+test.describe('Electron — node ID uniqueness (#681)', () => {
+  test('splitting a paragraph yields distinct nodeIds for both halves', async () => {
+    // One paragraph; the extension assigns it an id on load.
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      editor.commands.setContent('<p>First half and second half live here together.</p>')
+    })
+
+    const before = await blockNodeIds(page)
+    expect(before).toHaveLength(1)
+
+    // Split it mid-text (the Enter-key path) — ProseMirror copies nodeId to both halves.
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      // Place the cursor after "First half " (position ~12 in content coords)
+      editor.commands.setTextSelection(12)
+      editor.commands.splitBlock()
+    })
+
+    const after = await blockNodeIds(page)
+    expect(after.length).toBeGreaterThanOrEqual(2)
+    // The two halves must have DISTINCT ids (the bug left them equal).
+    expect(new Set(after).size).toBe(after.length)
+  })
+
+  test('read_document never emits duplicate nodeIds after repeated splits', async () => {
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      editor.commands.setContent('<p>Alpha beta gamma delta epsilon zeta eta theta.</p>')
+    })
+
+    // Split several times at different offsets.
+    for (const offset of [30, 18, 6]) {
+      await page.evaluate((pos) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const editor = (window as any).__prose_editor
+        editor.commands.setTextSelection(pos)
+        editor.commands.splitBlock()
+      }, offset)
+    }
+
+    // Live doc: all ids unique.
+    const ids = await blockNodeIds(page)
+    expect(ids.length).toBeGreaterThanOrEqual(4)
+    expect(new Set(ids).size).toBe(ids.length)
+
+    // read_document (the AI-facing surface): flatten the tree, assert unique.
+    const read = await executeProseTool(page, 'read_document', {})
+    expect(read.success).toBe(true)
+    interface DocNode { id: string; children?: DocNode[] }
+    const flatten = (nodes: DocNode[]): string[] =>
+      nodes.flatMap((n) => [n.id, ...(n.children ? flatten(n.children) : [])]).filter(Boolean)
+    const docIds = flatten((read.data as { nodes: DocNode[] }).nodes)
+    expect(new Set(docIds).size).toBe(docIds.length)
+  })
+
+  test('suggest_edit targets the correct half after a split', async () => {
+    // Reproduce the report: a long paragraph, then a short sibling created by
+    // a split. Targeting the short one by id must NOT resolve to the long one.
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      editor.commands.setContent(
+        '<p>This is a deliberately long load-bearing paragraph that comfortably exceeds two hundred characters so that the destructive-edit guard would fire if a short replacement were mistakenly routed to it instead of the short sibling node below.</p>',
+      )
+      // Cursor at the very end, split to create an empty sibling, type the short text.
+      editor.commands.setTextSelection(editor.state.doc.content.size)
+      editor.commands.splitBlock()
+      editor.commands.insertContent('This should be a heading')
+    })
+
+    const read = await executeProseTool(page, 'read_document', {})
+    expect(read.success).toBe(true)
+    const nodes = (read.data as { nodes: Array<{ id: string; content: string }> }).nodes
+    const shortNode = nodes.find((n) => n.content === 'This should be a heading')
+    expect(shortNode, 'short sibling present in read_document').toBeTruthy()
+
+    // Block-convert the short node to a heading — must succeed (it resolved to
+    // the short node, not the >200-char paragraph, so no destructive guard).
+    const suggested = await executeProseTool(page, 'suggest_edit', {
+      nodeId: shortNode!.id,
+      content: '## This should be a heading',
+    })
+    expect(suggested.success, `suggest_edit failed: ${suggested.code} ${suggested.error}`).toBe(true)
+  })
+})

--- a/src/renderer/extensions/node-ids/index.ts
+++ b/src/renderer/extensions/node-ids/index.ts
@@ -64,6 +64,19 @@ export const NodeIds = Extension.create({
           let modified = false
           const tr = newState.tr
 
+          // Track every id we've kept or assigned this pass, so we can both
+          // generate collision-free new ids AND detect duplicates. Duplicates
+          // arise when ProseMirror copies the `nodeId` attribute across a node
+          // split (Enter mid-paragraph, or an insert that produces a sibling) —
+          // both halves carry the same id, and without dedup they persist
+          // forever, breaking id-based targeting (#681).
+          const seen = new Set<string>()
+          const freshId = (): string => {
+            let id = generateNodeId()
+            while (seen.has(id)) id = generateNodeId()
+            return id
+          }
+
           newState.doc.descendants((node, pos) => {
             // Only process nodes that should have IDs
             if (!NODE_TYPES_WITH_IDS.includes(node.type.name)) return
@@ -77,12 +90,22 @@ export const NodeIds = Extension.create({
             // siblings to report the same id. Reading from `tr.doc` gives us the actual
             // committed state for each node individually.
             const currentNode = tr.doc.nodeAt(pos)
-            if (currentNode?.attrs.nodeId) return
+            const existingId = currentNode?.attrs.nodeId as string | null | undefined
 
-            // Assign a new ID
+            // Keep the first occurrence of a real, not-yet-seen id.
+            if (existingId && !seen.has(existingId)) {
+              seen.add(existingId)
+              return
+            }
+
+            // Either no id, or a duplicate of one already seen this pass →
+            // assign a fresh collision-free id (first occurrence above keeps
+            // the original, so annotations/suggestions on it still resolve).
+            const newId = freshId()
+            seen.add(newId)
             tr.setNodeMarkup(pos, undefined, {
-              ...node.attrs,
-              nodeId: generateNodeId(),
+              ...(currentNode ?? node).attrs,
+              nodeId: newId,
             })
             modified = true
           })

--- a/src/renderer/extensions/node-ids/index.ts
+++ b/src/renderer/extensions/node-ids/index.ts
@@ -64,6 +64,16 @@ export const NodeIds = Extension.create({
           let modified = false
           const tr = newState.tr
 
+          // Pre-collect every id currently in the document so a regenerated
+          // id can't collide with a real, not-yet-visited node's id (a fresh
+          // id checked only against already-seen nodes could otherwise match
+          // an unvisited unique id and wrongly displace it).
+          const existingIds = new Set<string>()
+          newState.doc.descendants((node) => {
+            const id = node.attrs.nodeId
+            if (typeof id === 'string' && id) existingIds.add(id)
+          })
+
           // Track every id we've kept or assigned this pass, so we can both
           // generate collision-free new ids AND detect duplicates. Duplicates
           // arise when ProseMirror copies the `nodeId` attribute across a node
@@ -73,7 +83,7 @@ export const NodeIds = Extension.create({
           const seen = new Set<string>()
           const freshId = (): string => {
             let id = generateNodeId()
-            while (seen.has(id)) id = generateNodeId()
+            while (existingIds.has(id) || seen.has(id)) id = generateNodeId()
             return id
           }
 


### PR DESCRIPTION
## Summary

Local QA of build 25 surfaced a duplicate-`nodeId` bug (great repro from the in-app agent): `read_document` emitted **two nodes sharing one id** (`ui5g8nyd` — a 226-char paragraph and a 24-char paragraph), so `suggest_edit` resolved to the wrong (long) occurrence and tripped the destructive-edit guard (`SUGGESTION_DESTRUCTIVE`) — the intended edit could never land.

## Root cause

`node-ids/index.ts` `appendTransaction` only assigned ids to nodes that **lacked** one. When ProseMirror splits a block (Enter mid-paragraph, or an insert that produces a sibling) it copies the `nodeId` attribute to *both* halves — both then have a truthy id, both were skipped, and the duplicate persisted forever.

## Fix

Track ids seen during the pass: keep the first occurrence of each real id, reassign a fresh **collision-free** id to any duplicate, and still fill id-less nodes as before. First occurrence keeps the original id, so existing annotations/suggestions keep resolving. Idempotent + terminating (next pass finds no collisions → returns `null`).

**Scope decision:** deliberately did **not** touch the six `findNodeById` call sites with search-disambiguation (issue #681's fix #2). IDs are deduped synchronously after every transaction and never persist to disk (markdown serialization drops them; they regenerate on open), so the unique-id invariant holds and the resolver change would be speculative complexity across 6 sites for a now-impossible state.

## Verification

`e2e/electron.node-ids.spec.ts`:
- split a paragraph → both halves get **distinct** ids
- repeated splits → `read_document` returns all-unique ids (live doc + flattened tree)
- **the reported repro**: a >200-char paragraph + a short sibling created by a split → the short node is targetable by id, `suggest_edit` succeeds (no false destructive-guard)

**3/3 green; negative control: all 3 fail against unfixed code** — test 3 reproduces the exact `SUGGESTION_DESTRUCTIVE` 24-vs-237-char error from the report. Full electron suite: 36 passed.

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)