### PR TITLE
feat(activity): redesign the AI edits panel + filter (Claude Design mocks)

### DIFF
--- a/e2e/electron.activity-panel.spec.ts
+++ b/e2e/electron.activity-panel.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Activity panel redesign (#684) — covers the tab rename, the visible-count
+ * badge, and the superseded filter wiring (lifted to ChatPanel's tab header).
+ *
+ * Seeds a real + a superseded annotation via the tool pipeline (accept an
+ * edit, then accept an overlapping edit on the same node — the first
+ * annotation's range collapses and detaches, #674), then drives the Activity
+ * tab UI. Isolated PROSE_USER_DATA_DIR profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+  executeProseTool,
+  getAnnotations,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaDocsDir: string
+
+async function nodeIdByText(testPage: Page, text: string): Promise<string> {
+  const read = await executeProseTool(testPage, 'read_document', {})
+  expect(read.success).toBe(true)
+  interface DocNode { id: string; content?: string; children?: DocNode[] }
+  const flatten = (nodes: DocNode[]): DocNode[] =>
+    nodes.flatMap((n) => [n, ...(n.children ? flatten(n.children) : [])])
+  const match = flatten((read.data as { nodes: DocNode[] }).nodes).find((n) =>
+    (n.content ?? '').includes(text),
+  )
+  expect(match, `node containing "${text}"`).toBeTruthy()
+  return match!.id
+}
+
+/** Poll out the ~100ms annotation mapping-pause window before an accept. */
+async function waitForMappingResumed(testPage: Page): Promise<void> {
+  await expect
+    .poll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async () => testPage.evaluate(() => (window as any).__prose_tools.isAnnotationMappingPaused()),
+      { timeout: 5_000 },
+    )
+    .toBe(false)
+}
+
+async function suggestAndAccept(testPage: Page, nodeId: string, content: string): Promise<void> {
+  const suggested = await executeProseTool(testPage, 'suggest_edit', { nodeId, content })
+  expect(suggested.success).toBe(true)
+  await waitForMappingResumed(testPage)
+  const accepted = await executeProseTool(testPage, 'accept_diff', {
+    id: (suggested.data as { suggestionId: string }).suggestionId,
+  })
+  expect(accepted.success).toBe(true)
+}
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaDocsDir = mkdtempSync(join(tmpdir(), 'prose-qa-docs-'))
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify({ appearance: { mode: 'dark', icon: 'default' }, defaultSaveDirectory: qaDocsDir }),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+
+  // Seed: one current annotation + one superseded.
+  const created = await executeProseTool(page, 'create_and_open_file', {
+    filename: 'activity.md',
+    content: 'A paragraph to be edited and then re-edited.\n\nA second untouched paragraph.',
+  })
+  expect(created.success).toBe(true)
+  await waitForEditor(page)
+
+  const p1 = await nodeIdByText(page, 'A paragraph to be edited')
+  await suggestAndAccept(page, p1, 'A paragraph after its first edit.') // annotation A
+  const p1b = await nodeIdByText(page, 'A paragraph after its first edit.')
+  await suggestAndAccept(page, p1b, 'A paragraph rewritten a second time.') // A detaches, B created
+
+  const anns = await getAnnotations(page)
+  expect(anns.length).toBe(2)
+  expect(anns.filter((a) => a.detached === true)).toHaveLength(1)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaDocsDir, { recursive: true, force: true })
+})
+
+test.describe('Electron — Activity panel', () => {
+  test('Activity tab + badge + superseded filter', async () => {
+    // Open the chat sidebar and switch to the Activity tab.
+    await page.keyboard.press('ControlOrMeta+Shift+L')
+    const activityTab = page.getByRole('button', { name: /Activity/ })
+    await activityTab.waitFor({ state: 'visible', timeout: 5_000 })
+    await activityTab.click()
+
+    // Badge shows the total (2) while superseded are included.
+    const badge = page.getByTestId('activity-count-badge')
+    await expect(badge).toHaveText('2')
+
+    // The superseded row + the filter funnel are present.
+    await expect(page.getByTestId('annotation-detached-badge')).toBeVisible()
+    const filterBtn = page.getByRole('button', { name: 'Hide superseded edits' })
+    await expect(filterBtn).toBeVisible()
+
+    // Engage the filter → superseded hidden, badge drops to current-only (1).
+    await filterBtn.click()
+    await expect(badge).toHaveText('1')
+    await expect(page.getByTestId('annotation-detached-badge')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Show superseded edits' })).toBeVisible()
+
+    // Toggle back → superseded reappears, badge back to 2.
+    await page.getByRole('button', { name: 'Show superseded edits' }).click()
+    await expect(badge).toHaveText('2')
+    await expect(page.getByTestId('annotation-detached-badge')).toBeVisible()
+  })
+})

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '../ui/dropdown-menu'
-import { MessageSquare, History, Bot, Plus, Trash2, Sparkles, Info, Loader2 } from 'lucide-react'
+import { MessageSquare, History, Plus, Trash2, Sparkles, Info, Loader2, Filter } from 'lucide-react'
 import { useChatStore } from '../../stores/chatStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
@@ -30,7 +30,11 @@ export function ChatPanel() {
   const scrollRef = useRef<HTMLDivElement>(null)
   const reviewMode = useReviewMode()
   const [infoOpen, setInfoOpen] = useState(false)
-  const [sidebarMode, setSidebarMode] = useState<'chat' | 'history'>('chat')
+  const [sidebarMode, setSidebarMode] = useState<'chat' | 'activity'>('chat')
+  // Filter superseded (detached) entries out of the Activity list. Lifted here
+  // because the toggle lives in this header but the filtering happens in
+  // AIEditsHistoryPanel.
+  const [hideSuperseded, setHideSuperseded] = useState(false)
 
   const {
     conversations,
@@ -83,8 +87,15 @@ export function ChatPanel() {
     return () => window.removeEventListener(MODE_SWITCH_RUN_EVENT, handler)
   }, [sendMessage])
 
-  // Annotation count for the badge on the history toggle
-  const annotationCount = useAnnotationStore((s) => s.annotations.length)
+  // Annotation counts for the Activity tab badge + filter affordance.
+  const annotations = useAnnotationStore((s) => s.annotations)
+  const supersededCount = useMemo(
+    () => annotations.reduce((n, a) => (a.detached ? n + 1 : n), 0),
+    [annotations]
+  )
+  // Badge reflects what's currently shown: total when including superseded,
+  // current-only when the filter is engaged.
+  const activityCount = hideSuperseded ? annotations.length - supersededCount : annotations.length
 
   // Track pending suggestion count
   const suggestionCount = useMemo(() => {
@@ -163,42 +174,64 @@ export function ChatPanel() {
 
   return (
     <div className="flex h-full flex-col bg-muted/20">
-      {/* Mode toggle header (Chat | History) — sibling toggles, File-Explorer convention */}
-      <div className="flex items-center justify-between border-b border-border px-2 py-1">
-        <div className="flex items-center gap-0.5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn("h-7 w-7", sidebarMode === 'chat' && "bg-accent text-accent-foreground")}
-                onClick={() => setSidebarMode('chat')}
-                aria-label="AI chat"
-              >
-                <MessageSquare className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>AI chat</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn("h-7 w-7 relative", sidebarMode === 'history' && "bg-accent text-accent-foreground")}
-                onClick={() => setSidebarMode('history')}
-                aria-label="AI edits history"
-              >
-                <Bot className="h-3.5 w-3.5" />
-                {annotationCount > 0 && (
-                  <span className="absolute -top-0.5 -right-0.5 flex h-3.5 min-w-[14px] w-auto px-0.5 items-center justify-center rounded-full bg-primary text-[8px] font-bold text-primary-foreground leading-none">
-                    {annotationCount > 99 ? '99+' : annotationCount}
-                  </span>
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>AI edits history</TooltipContent>
-          </Tooltip>
+      {/* Tab header (Chat | Activity) with the Activity count badge + filter */}
+      <div className="flex items-center justify-between border-b border-border px-3 py-1">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setSidebarMode('chat')}
+            aria-pressed={sidebarMode === 'chat'}
+            className={cn(
+              'text-sm border-b-2 pb-1 -mb-px transition-colors',
+              sidebarMode === 'chat'
+                ? 'text-foreground border-primary font-medium'
+                : 'text-muted-foreground border-transparent hover:text-foreground'
+            )}
+          >
+            Chat
+          </button>
+          <button
+            onClick={() => setSidebarMode('activity')}
+            aria-pressed={sidebarMode === 'activity'}
+            className={cn(
+              'flex items-center gap-1.5 text-sm border-b-2 pb-1 -mb-px transition-colors',
+              sidebarMode === 'activity'
+                ? 'text-foreground border-primary font-medium'
+                : 'text-muted-foreground border-transparent hover:text-foreground'
+            )}
+          >
+            Activity
+            {activityCount > 0 && (
+              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary leading-none">
+                {activityCount > 99 ? '99+' : activityCount}
+              </span>
+            )}
+          </button>
+
+          {/* Filter: hide/show superseded — only when there's something to filter */}
+          {sidebarMode === 'activity' && supersededCount > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={cn(
+                    'h-6 w-6',
+                    hideSuperseded ? 'bg-accent text-primary' : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  onClick={() => setHideSuperseded((v) => !v)}
+                  aria-pressed={hideSuperseded}
+                  aria-label={hideSuperseded ? 'Show superseded edits' : 'Hide superseded edits'}
+                >
+                  <Filter className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {hideSuperseded
+                  ? 'Showing current edits · click to include superseded'
+                  : 'Hide superseded edits'}
+              </TooltipContent>
+            </Tooltip>
+          )}
         </div>
 
         {/* Chat-mode actions */}
@@ -308,8 +341,11 @@ export function ChatPanel() {
         )}
       </div>
 
-      {sidebarMode === 'history' ? (
-        <AIEditsHistoryPanel />
+      {sidebarMode === 'activity' ? (
+        <AIEditsHistoryPanel
+          hideSuperseded={hideSuperseded}
+          onShowAll={() => setHideSuperseded(false)}
+        />
       ) : (
         <>
           {/* Collapsible summary panel */}

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -201,7 +201,10 @@ export function ChatPanel() {
           >
             Activity
             {activityCount > 0 && (
-              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary leading-none">
+              <span
+                data-testid="activity-count-badge"
+                className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary leading-none"
+              >
                 {activityCount > 99 ? '99+' : activityCount}
               </span>
             )}

--- a/src/renderer/components/editor/AIEditsHistoryPanel.tsx
+++ b/src/renderer/components/editor/AIEditsHistoryPanel.tsx
@@ -11,8 +11,8 @@
  * toggle in the ChatPanel header.
  */
 
-import { useCallback, useMemo, useState } from 'react'
-import { Wand2, LocateFixed, X, Eye, EyeOff, ListFilter } from 'lucide-react'
+import { useCallback, useMemo } from 'react'
+import { Wand2, Crosshair, X, Eye, EyeOff, Filter } from 'lucide-react'
 import { useAnnotationStore } from '../../extensions/ai-annotations/store'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
@@ -21,19 +21,21 @@ import type { AIAnnotation, AnnotationType } from '../../types/annotations'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { cn } from '../../lib/utils'
 
-export function AIEditsHistoryPanel() {
+interface AIEditsHistoryPanelProps {
+  /** Hide superseded (detached) entries. Owned by ChatPanel's tab header. */
+  hideSuperseded: boolean
+  /** Clear the filter (wired to the filtered-empty "Show all" affordance). */
+  onShowAll: () => void
+}
+
+export function AIEditsHistoryPanel({ hideSuperseded, onShowAll }: AIEditsHistoryPanelProps) {
   const annotations = useAnnotationStore((s) => s.annotations)
   const removeAnnotation = useAnnotationStore((s) => s.removeAnnotation)
   const editor = useEditorInstanceStore((s) => s.editor)
 
-  // Filter out superseded (detached) entries — those whose annotated text was
-  // replaced by a later edit (#674). Local UI state; resets when the panel
-  // unmounts. The toggle only surfaces when there's something to filter.
-  const [hideSuperseded, setHideSuperseded] = useState(false)
-  const supersededCount = useMemo(
-    () => annotations.reduce((n, a) => (a.detached ? n + 1 : n), 0),
-    [annotations]
-  )
+  // Superseded (detached) entries are history-only — their annotated text was
+  // replaced by a later edit (#674). The filter toggle lives in ChatPanel's
+  // tab header; this panel just honours the resulting flag.
   const visibleAnnotations = useMemo(
     () => (hideSuperseded ? annotations.filter((a) => !a.detached) : annotations),
     [annotations, hideSuperseded]
@@ -65,38 +67,12 @@ export function AIEditsHistoryPanel() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header: filter superseded toggle — only when there's something to filter */}
-      {supersededCount > 0 && (
-        <div className="flex items-center justify-end border-b border-border/40 px-3 py-1.5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={() => setHideSuperseded((v) => !v)}
-                aria-pressed={hideSuperseded}
-                aria-label={hideSuperseded ? 'Show superseded edits' : 'Hide superseded edits'}
-                className={cn(
-                  'flex items-center justify-center h-6 w-6 rounded transition-colors',
-                  hideSuperseded
-                    ? 'bg-accent text-accent-foreground'
-                    : 'text-muted-foreground hover:bg-muted'
-                )}
-              >
-                <ListFilter className="h-3.5 w-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="left">
-              {hideSuperseded ? 'Show superseded' : 'Hide superseded'}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      )}
-
       {/* Content */}
       <div className="flex-1 min-h-0 overflow-y-auto">
         {annotations.length === 0 ? (
           <EmptyState />
         ) : visibleAnnotations.length === 0 ? (
-          <FilteredEmptyState onShowAll={() => setHideSuperseded(false)} />
+          <FilteredEmptyState onShowAll={onShowAll} />
         ) : (
           <div className="py-1">
             {groups.map((group) => (
@@ -137,7 +113,7 @@ function EmptyState() {
 function FilteredEmptyState({ onShowAll }: { onShowAll: () => void }) {
   return (
     <div className="flex flex-col items-center justify-center h-full p-6 text-center gap-2">
-      <ListFilter className="h-8 w-8 text-muted-foreground/30" />
+      <Filter className="h-8 w-8 text-muted-foreground/30" />
       <p className="text-xs text-muted-foreground">All edits are superseded</p>
       <button
         onClick={onShowAll}
@@ -183,8 +159,8 @@ interface HistoryEntryRowProps {
 }
 
 function HistoryEntryRow({ annotation, onJump, onRemove }: HistoryEntryRowProps) {
-  const snippet = annotation.content.slice(0, 80).replace(/\n/g, ' ')
-  const isLong = annotation.content.length > 80
+  const snippet = annotation.content.slice(0, 200).replace(/\n/g, ' ')
+  const isLong = annotation.content.length > 200
   const detached = annotation.detached === true
 
   return (
@@ -200,71 +176,62 @@ function HistoryEntryRow({ annotation, onJump, onRemove }: HistoryEntryRowProps)
       }}
       title={detached ? 'This edit was later replaced — history record only' : 'Jump to in document'}
       className={cn(
-        'group px-3 py-2.5 hover:bg-muted/40 transition-colors focus:outline-none focus:bg-muted/40',
+        'group px-4 py-3 hover:bg-muted/40 transition-colors focus:outline-none focus:bg-muted/40',
         detached ? 'opacity-60 cursor-default' : 'cursor-pointer'
       )}
     >
-      <div className="flex items-start justify-between gap-2">
-        {/* Left: type badge + snippet */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 mb-1">
-            <TypeBadge type={annotation.type} />
-            {detached && (
-              <span
-                data-testid="annotation-detached-badge"
-                className="inline-flex items-center rounded px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider bg-muted text-muted-foreground"
-              >
-                superseded
-              </span>
-            )}
-            <span className="text-[10px] text-muted-foreground/70 shrink-0">
-              {formatModelName(annotation.provenance.model)}
-            </span>
-            <span className="text-[10px] text-muted-foreground/50 shrink-0 ml-auto">
-              {formatAge(annotation.createdAt)}
-            </span>
-          </div>
-
-          {/* Content snippet */}
-          <p className="text-xs text-foreground/80 leading-snug break-words line-clamp-2 font-mono">
-            {snippet}
-            {isLong && <span className="text-muted-foreground/50">…</span>}
-          </p>
-
-          {/* Explanation */}
-          {annotation.explanation && (
-            <p className="mt-0.5 text-[10px] text-muted-foreground leading-snug line-clamp-2 italic">
-              {annotation.explanation}
-            </p>
-          )}
-        </div>
-
-        {/* Right: jump affordance (hidden for detached) + remove (on hover) */}
-        <div className="flex items-center gap-1 shrink-0">
-          {!detached && (
-            <LocateFixed
-              aria-hidden="true"
-              className="h-3.5 w-3.5 text-muted-foreground/50 group-hover:text-foreground transition-colors"
-            />
-          )}
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onRemove(annotation.id)
-                }}
-                className="p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-muted text-muted-foreground hover:text-destructive transition-all"
-                aria-label="Remove AI marking"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="left">Remove AI marking (keeps the text)</TooltipContent>
-          </Tooltip>
-        </div>
+      {/* Meta row: type badge · model · age · jump/remove */}
+      <div className="flex items-center gap-2 mb-2">
+        <TypeBadge type={annotation.type} />
+        {detached && (
+          <span
+            data-testid="annotation-detached-badge"
+            className="inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider bg-muted text-muted-foreground"
+          >
+            superseded
+          </span>
+        )}
+        <span className="min-w-0 truncate text-xs text-muted-foreground">
+          {formatModelName(annotation.provenance.model)}
+        </span>
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground/60">
+          {formatAge(annotation.createdAt)}
+        </span>
+        {!detached && (
+          <Crosshair
+            aria-hidden="true"
+            className="h-4 w-4 shrink-0 text-primary/60 group-hover:text-primary transition-colors"
+          />
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onRemove(annotation.id)
+              }}
+              className="shrink-0 rounded p-0.5 opacity-0 group-hover:opacity-100 hover:bg-muted text-muted-foreground hover:text-destructive transition-all"
+              aria-label="Remove AI marking"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">Remove AI marking (keeps the text)</TooltipContent>
+        </Tooltip>
       </div>
+
+      {/* Title: the edited content */}
+      <p className="text-[15px] leading-snug text-foreground break-words line-clamp-2">
+        {snippet}
+        {isLong && <span className="text-muted-foreground/50">…</span>}
+      </p>
+
+      {/* Explanation */}
+      {annotation.explanation && (
+        <p className="mt-1.5 text-xs italic text-muted-foreground leading-snug line-clamp-2">
+          {annotation.explanation}
+        </p>
+      )}
     </div>
   )
 }
@@ -272,15 +239,15 @@ function HistoryEntryRow({ annotation, onJump, onRemove }: HistoryEntryRowProps)
 function TypeBadge({ type }: { type: AnnotationType }) {
   const palette =
     type === 'insertion'
-      ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
       : type === 'deletion'
-        ? 'bg-rose-500/10 text-rose-700 dark:text-rose-400'
-        : 'bg-amber-500/10 text-amber-700 dark:text-amber-400'
+        ? 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400'
+        : 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400'
   const symbol = type === 'insertion' ? '+' : type === 'deletion' ? '−' : '~'
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider',
+        'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
         palette
       )}
     >

--- a/src/renderer/components/editor/AIEditsHistoryPanel.tsx
+++ b/src/renderer/components/editor/AIEditsHistoryPanel.tsx
@@ -11,8 +11,8 @@
  * toggle in the ChatPanel header.
  */
 
-import { useCallback, useMemo } from 'react'
-import { Wand2, LocateFixed, X, Eye, EyeOff } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { Wand2, LocateFixed, X, Eye, EyeOff, ListFilter } from 'lucide-react'
 import { useAnnotationStore } from '../../extensions/ai-annotations/store'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
@@ -26,10 +26,23 @@ export function AIEditsHistoryPanel() {
   const removeAnnotation = useAnnotationStore((s) => s.removeAnnotation)
   const editor = useEditorInstanceStore((s) => s.editor)
 
+  // Filter out superseded (detached) entries — those whose annotated text was
+  // replaced by a later edit (#674). Local UI state; resets when the panel
+  // unmounts. The toggle only surfaces when there's something to filter.
+  const [hideSuperseded, setHideSuperseded] = useState(false)
+  const supersededCount = useMemo(
+    () => annotations.reduce((n, a) => (a.detached ? n + 1 : n), 0),
+    [annotations]
+  )
+  const visibleAnnotations = useMemo(
+    () => (hideSuperseded ? annotations.filter((a) => !a.detached) : annotations),
+    [annotations, hideSuperseded]
+  )
+
   // Newest first, grouped by calendar day.
   const groups = useMemo(
-    () => groupAnnotationsByDate([...annotations].sort((a, b) => b.createdAt - a.createdAt)),
-    [annotations]
+    () => groupAnnotationsByDate([...visibleAnnotations].sort((a, b) => b.createdAt - a.createdAt)),
+    [visibleAnnotations]
   )
 
   const handleJump = useCallback(
@@ -52,10 +65,38 @@ export function AIEditsHistoryPanel() {
 
   return (
     <div className="flex flex-col h-full">
+      {/* Header: filter superseded toggle — only when there's something to filter */}
+      {supersededCount > 0 && (
+        <div className="flex items-center justify-end border-b border-border/40 px-3 py-1.5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setHideSuperseded((v) => !v)}
+                aria-pressed={hideSuperseded}
+                aria-label={hideSuperseded ? 'Show superseded edits' : 'Hide superseded edits'}
+                className={cn(
+                  'flex items-center justify-center h-6 w-6 rounded transition-colors',
+                  hideSuperseded
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-muted'
+                )}
+              >
+                <ListFilter className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              {hideSuperseded ? 'Show superseded' : 'Hide superseded'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+
       {/* Content */}
       <div className="flex-1 min-h-0 overflow-y-auto">
         {annotations.length === 0 ? (
           <EmptyState />
+        ) : visibleAnnotations.length === 0 ? (
+          <FilteredEmptyState onShowAll={() => setHideSuperseded(false)} />
         ) : (
           <div className="py-1">
             {groups.map((group) => (
@@ -88,6 +129,22 @@ function EmptyState() {
         AI-applied edits to this document will appear here. Remove one to clear its
         AI-authored marking — the text stays.
       </p>
+    </div>
+  )
+}
+
+/** Shown when the superseded filter is on and every remaining entry is superseded. */
+function FilteredEmptyState({ onShowAll }: { onShowAll: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-6 text-center gap-2">
+      <ListFilter className="h-8 w-8 text-muted-foreground/30" />
+      <p className="text-xs text-muted-foreground">All edits are superseded</p>
+      <button
+        onClick={onShowAll}
+        className="text-[10px] text-muted-foreground/80 underline-offset-2 hover:underline"
+      >
+        Show all
+      </button>
     </div>
   )
 }

--- a/src/renderer/components/editor/AIEditsHistoryPanel.tsx
+++ b/src/renderer/components/editor/AIEditsHistoryPanel.tsx
@@ -7,8 +7,9 @@
  * annotation (un-marks the AI authorship; the text itself is left untouched), and
  * un-marking in the document removes the row. Fully idempotent in both directions.
  *
- * Surface: rendered inside the chat sidebar when the user selects the History
- * toggle in the ChatPanel header.
+ * Surface: rendered inside the chat sidebar when the user selects the Activity
+ * tab in the ChatPanel header. The superseded filter lives in that tab header;
+ * this panel receives the resulting `hideSuperseded` flag as a prop.
  */
 
 import { useCallback, useMemo } from 'react'


### PR DESCRIPTION
## Summary

Reworks the chat sidebar's AI-edit-history surface to match the supplied Claude Design mocks. (Started as the "filter superseded" toggle #684; the mocks evolved it into a fuller redesign, so this PR now covers both.)

### Changes
- **"History" → "Activity"** — text tabs (Chat | Activity) with an amber underline on the active tab, replacing the icon-button toggles. Internal `sidebarMode` renamed `history` → `activity`.
- **Count badge** on the Activity tab reflects the **visible** count: total when including superseded, current-only when filtered (9 → 2 in the mocks).
- **Filter funnel** (lucide `Filter`) moves into the tab header beside the badge; surfaces only when there's something to filter. State lifted to `ChatPanel`. Stateful tooltip — *"Hide superseded edits"* / *"Showing current edits · click to include superseded"*.
- **Entry card redesign**: bordered `~ REPLACEMENT` type pill · model name · right-aligned age · crosshair jump affordance · **larger title** for the edited content · italic muted explanation. Remove (X) on hover; superseded rows stay dimmed with the badge.

UI-only — the filter logic (hide `detached`) is unchanged, now driven by the lifted `hideSuperseded` flag.

### Verification
- Full build green; types clean; HMR-verified live.
- **e2e regression coverage to follow once the visual design is locked** (deliberately holding off — the design is iterative and may shift on review feedback re: icon choice / spacing).

### Notes
- Branched off `main` (independent of node-ids #682).
- Funnel icon is lucide `Filter`; jump affordance is `Crosshair` (the reticle in the mock). Easy to swap if either isn't the intended glyph.

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)