### PR TITLE
chore(mas): bump buildVersion to 26 for TestFlight

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -14,7 +14,7 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
 
 - **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
   automation edge; clicking "Submit for Review" is always a human decision and action.
-- **`buildVersion` is global-monotonic.** Currently `"25"` in `electron-builder.yml`.
+- **`buildVersion` is global-monotonic.** Currently `"26"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
   **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.1`).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "25"
+buildVersion: "26"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
## Summary

Bumps `buildVersion` 25 → 26. **Build 26 = v1.6.1 + the full AI-editing + Activity tranche** now on `main`:

- **AI markdown hardening** — inline-markdown accept #671, instrumentation #675, block-type conversion + .txt/table guards #676, annotation robustness (detach-don't-delete) #677
- **node-ids dedup on splits** #681 / #682 (fixed the duplicate-`nodeId` → wrong-target bug found in build-25 QA)
- **Activity panel redesign + superseded filter** #684 / #685

buildVersion is global monotonic — 25 is consumed on App Store Connect.

Part of the Wave 0.5 TestFlight iteration loop: merge → cut build → upload → human QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)