### PR TITLE
fix(chat): keep chat actions visible on the Activity tab

### DIFF
--- a/e2e/electron.activity-panel.spec.ts
+++ b/e2e/electron.activity-panel.spec.ts
@@ -130,4 +130,15 @@ test.describe('Electron — Activity panel', () => {
     await expect(badge).toHaveText('2')
     await expect(page.getByTestId('annotation-detached-badge')).toBeVisible()
   })
+
+  test('chat actions stay visible on the Activity tab (#688)', async () => {
+    // On the Activity tab, the chat action cluster must NOT disappear.
+    await page.getByRole('button', { name: /Activity/ }).click()
+    await expect(page.getByRole('button', { name: 'Document info' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'New chat' })).toBeVisible()
+
+    // Invoking New chat from Activity switches to the chat view (input appears).
+    await page.getByRole('button', { name: 'New chat' }).click()
+    await expect(page.locator('textarea').first()).toBeVisible({ timeout: 5_000 })
+  })
 })

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -149,10 +149,14 @@ export function ChatPanel() {
   }, [messages, sendMessage])
 
   const handleNewChat = () => {
+    // Land in the chat view so the new conversation is visible, even if the
+    // action was invoked from the Activity tab.
+    setSidebarMode('chat')
     addConversation(documentId)
   }
 
   const handleSelectConversation = (conversationId: string) => {
+    setSidebarMode('chat')
     selectConversation(conversationId)
   }
 
@@ -237,16 +241,25 @@ export function ChatPanel() {
           )}
         </div>
 
-        {/* Chat-mode actions */}
-        {sidebarMode === 'chat' && (
-          <div className="flex items-center gap-0.5">
+        {/* Chat actions — always visible (independent of the active tab).
+            Actions whose effect lives in the chat view switch back to it. */}
+        <div className="flex items-center gap-0.5">
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className={cn("h-7 w-7", infoOpen && "bg-accent text-accent-foreground")}
-                  onClick={() => setInfoOpen(!infoOpen)}
+                  className={cn("h-7 w-7", sidebarMode === 'chat' && infoOpen && "bg-accent text-accent-foreground")}
+                  onClick={() => {
+                    // The info/summary panel only renders in the chat view —
+                    // switch to it (opening info) when invoked from Activity.
+                    if (sidebarMode !== 'chat') {
+                      setSidebarMode('chat')
+                      setInfoOpen(true)
+                    } else {
+                      setInfoOpen(!infoOpen)
+                    }
+                  }}
                   aria-label="Document info"
                 >
                   <Info className="h-3.5 w-3.5" />
@@ -331,7 +344,10 @@ export function ChatPanel() {
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7"
-                    onClick={clearMessages}
+                    onClick={() => {
+                      setSidebarMode('chat')
+                      clearMessages()
+                    }}
                     aria-label="Clear chat"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
@@ -340,8 +356,7 @@ export function ChatPanel() {
                 <TooltipContent>Clear messages</TooltipContent>
               </Tooltip>
             )}
-          </div>
-        )}
+        </div>
       </div>
 
       {sidebarMode === 'activity' ? (


### PR DESCRIPTION
## Summary

After the Activity redesign (#685), the right-side chat action cluster — **Document info**, **Chat history**, **New chat**, **Clear** — was gated behind `sidebarMode === 'chat'`, so it disappeared when you switched to the Activity tab. The Claude Design mock (image 4) shows those actions present alongside the Activity tab + funnel.

## Fix

- Render the action cluster **regardless of tab**.
- Actions whose effect lives in the chat view **switch back to it** when invoked from Activity, so the result is visible:
  - New chat / select-conversation / clear → `setSidebarMode('chat')`
  - Document info → switch to chat and open the info panel (its summary only renders in the chat view). The active highlight now also requires `sidebarMode === 'chat'` so it doesn't light up off-tab.

## Verification

`electron.activity-panel.spec.ts` gains a case (`#688`) asserting Document info + New chat stay visible on the Activity tab and that New chat switches to the chat view. **2/2 green** locally.

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)