### PR TITLE
chore(mas): bump buildVersion to 27 for TestFlight

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -14,7 +14,7 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
 
 - **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
   automation edge; clicking "Submit for Review" is always a human decision and action.
-- **`buildVersion` is global-monotonic.** Currently `"26"` in `electron-builder.yml`.
+- **`buildVersion` is global-monotonic.** Currently `"27"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
   **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.1`).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "26"
+buildVersion: "27"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
## Summary

Bumps `buildVersion` 26 → 27. **Build 27 = build 26 + the chat-actions-always-visible fix** (#688 / #689): the Document info / Chat history / New chat / Clear cluster no longer disappears when you switch to the Activity tab.

buildVersion is global monotonic — 26 is consumed on App Store Connect.

Part of the Wave 0.5 TestFlight iteration loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)