### PR TITLE
chore(release): v1.6.2 (build 28)

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -14,9 +14,9 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
 
 - **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
   automation edge; clicking "Submit for Review" is always a human decision and action.
-- **`buildVersion` is global-monotonic.** Currently `"27"` in `electron-builder.yml`.
+- **`buildVersion` is global-monotonic.** Currently `"28"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
-  **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.1`).
+  **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.2`).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS
   entitlements without re-validating against the provisioning profile.
 - The `mas` target force-disables reMarkable (credentials/OCR not App-Store-ready) and blocks

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "27"
+buildVersion: "28"
 directories:
   buildResources: build
   output: dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prose",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prose",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A minimal markdown editor with AI chat",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Bumps the shared marketing version **1.6.1 → 1.6.2** + buildVersion **27 → 28**, cutting v1.6.2 across **both** channels (GitHub DMG/ZIP + MAS/TestFlight). Captures the cross-platform editor/UI work merged since v1.6.1 — desktop DMG users are currently on 1.6.1 (with the project-nav bug and none of these fixes):

- **AI markdown hardening** — inline-md accept #671, instrumentation #675, block-type conversion + .txt/table guards #676, annotation detach-don't-delete #677
- **node-ids dedup on splits** #681 / #682
- **Activity panel redesign + superseded filter** #684 / #685
- **chat actions stay visible on Activity** #688 / #689

## Follow-on (after merge)
1. MAS **build 28** at 1.6.2 → TestFlight (aligning the App Store track to 1.6.2)
2. Tag **v1.6.2** → `release.yml` builds the notarized DMG/ZIP draft for hand-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)