### PR TITLE
chore(mas): bump buildVersion to 29

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -14,7 +14,7 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
 
 - **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
   automation edge; clicking "Submit for Review" is always a human decision and action.
-- **`buildVersion` is global-monotonic.** Currently `"28"` in `electron-builder.yml`.
+- **`buildVersion` is global-monotonic.** Currently `"29"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
   **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.2`).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "28"
+buildVersion: "29"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
Bumps `buildVersion` 28 → 29 to refresh the MAS/TestFlight build from final `main` (v1.6.2), carrying the merged README revamp (#692), App Store copy (#693), and the screenshot generator + `__prose_chat` test seam (#694).

buildVersion is global monotonic — 28 is consumed on App Store Connect.

Refs #612