### PR TITLE
fix(projects): keep the base root's MAS bookmark out of project switches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,9 +188,9 @@ When running as Electron:
 
 ### IPC Channels
 
-Most handlers live in `src/main/ipc.ts` (74 across 14 namespaces). A few sit closer to their feature: `sentry:setEnabled` and `renderer:ready` in `src/main/index.ts`, `updater:*` (3) in `src/main/updater.ts`, `file:watch:start` and `file:watch:stop` in `src/main/fileWatcher.ts`, and `mcp:tool:result` (via `ipcMain.on`, not `handle`) in `src/main/mcp/bridge.ts`.
+Most handlers live in `src/main/ipc.ts` (75 across 14 namespaces). A few sit closer to their feature: `sentry:setEnabled` and `renderer:ready` in `src/main/index.ts`, `updater:*` (3) in `src/main/updater.ts`, `file:watch:start` and `file:watch:stop` in `src/main/fileWatcher.ts`, and `mcp:tool:result` (via `ipcMain.on`, not `handle`) in `src/main/mcp/bridge.ts`.
 
-- `file:*` (21) - File operations (open, save, read, rename, delete, trash, duplicate, watch, export HTML, etc.) — 19 handlers in `ipc.ts`, plus `file:watch:start` and `file:watch:stop` in `fileWatcher.ts`
+- `file:*` (22) - File operations (open, save, read, rename, delete, trash, duplicate, watch, export HTML, MAS bookmark activation, etc.) — 20 handlers in `ipc.ts`, plus `file:watch:start` and `file:watch:stop` in `fileWatcher.ts`
 - `settings:*` (4) - Settings persistence, secure storage check, API key test
 - `llm:chat`, `llm:fetchModels`, `llm:stream`, `llm:stream:abort` - LLM API calls (streaming via Anthropic SDK)
 - `remarkable:*` (20) - reMarkable tablet sync (register, validate, sync, sync:abort, OCR, folder move, etc.)

--- a/docs/issues/654/plan.md
+++ b/docs/issues/654/plan.md
@@ -1,0 +1,65 @@
+# #654 — MAS bookmark architecture: base-root preservation + in-session activation
+
+## Root-cause chain (verified against `main` @ v1.6.2)
+
+1. **Persistent base-root bookmark loss (the headline bug).**
+   `projectsStore.addProjectFromPicker` (≈L142) and `switchToProject` (≈L205) sync the
+   project's bookmark into the legacy single slot `settings.masDirectoryBookmark` — but
+   that slot originally held the **base root's** (defaultSaveDirectory's) bookmark, which
+   is stored nowhere else. The overwrite persists to disk: after relaunch the base root
+   has no bookmark anywhere → its listing fails silently until the user re-picks it.
+2. **In-session base-root loss.** `file:selectFolder` (ipc.ts ≈L282) stops the live
+   base-root claim (`stopAccessingBookmark`) on *any* folder pick — so adding a
+   project/favorite revokes base-root access immediately, before any relaunch.
+3. **No in-session activation path** (original issue body): bookmarks added after launch
+   are never registered into the per-id stop-fn maps (`projectBookmarkStopFns`) until the
+   next launch; the only in-session claim lives in the single slot, where (2) tramples it.
+
+Context that narrows the original issue body: the #651 restore loop already activates
+every `projects[]`/`favorites[]` bookmark at startup, and Powerbox grants session access
+to freshly picked folders — so the *switch* path mostly worked in-session. The damage was
+the slot overwrite (1) + the claim clobber (2).
+
+## Fix (per Angel's 2026-06-04 comment on #654)
+
+- **`masDirectoryBookmark` belongs exclusively to the base root.**
+  Remove both sync blocks in `projectsStore`. Startup activation of project/favorite
+  bookmarks is owned by the settings:load restore loops.
+- **`file:activateBookmark` IPC** (`src/main/ipc.ts`): activates a project/favorite
+  bookmark on demand (MAS-gated; non-MAS returns success no-op), releasing any prior
+  claim for that id and registering the stop-fn in the per-id map so the existing
+  settings:save reconciliation manages its lifecycle. Exposed via preload + ElectronAPI
+  (optional member) + browserApi no-op. Called from `addProjectFromPicker`,
+  `addFavoriteFromPicker`, and `switchToProject`.
+- **Stop the selectFolder clobber**: picks activate into an ephemeral claims list held
+  for the process lifetime; `stopAccessingBookmark` is only managed by settings:load.
+- **UX guard (the "+UX guard" in the title)**: on MAS, switching to a project with no
+  stored bookmark (or a failed activation) raises a toast (notificationStore) telling the
+  user to remove + re-add the project to re-grant access — instead of silent file-op failure.
+- **Healing migration** (`settingsStore.migrateOnDiskSettings`): users on v1.6.0–v1.6.2
+  have a poisoned slot (`masDirectoryBookmark` === some project/favorite bookmark) and
+  their true base-root bookmark is unrecoverable. Detect by bookmark equality, clear
+  `masDirectoryBookmark` + `defaultSaveDirectory` → the existing folder-picker empty
+  state takes over and the next explicit pick re-establishes both. Persisted via the
+  existing migration write-back branch (condition extended to bookmark changes).
+
+## Out of scope
+
+- Startup explorer-root/activeProjectId reconciliation: session restore (IndexedDB
+  drafts) already reinstates `rootPath` + `viewMode`; the pre-#669 mismatch scenario no
+  longer reproduces. Revisit only if QA shows a no-session-draft edge.
+- Multi-slot redesign of the base-root bookmark (arrays) — unnecessary once the slot's
+  ownership is exclusive.
+
+## Verification
+
+- **e2e (deterministic, isolated `PROSE_USER_DATA_DIR`)** — `e2e/electron.mas-bookmarks.spec.ts`:
+  1. *Heal*: seed `masDirectoryBookmark` identical to `projects[0].bookmark` → launch →
+     poll settings.json until both `masDirectoryBookmark` and `defaultSaveDirectory` are
+     cleared.
+  2. *No-clobber (negative control vs `main`)*: seed distinct base bookmark + project
+     bookmark → switch project via the Projects panel UI → assert settings.json still
+     holds the base bookmark. Fails on current `main` (sync block overwrites it).
+- **MAS sandbox behavior** (`startAccessingSecurityScopedResource` semantics) is not
+  testable on the desktop build: verified on TestFlight build 30 (or locally via masDev
+  once #487's provisioning steps land).

--- a/e2e/electron.mas-bookmarks.spec.ts
+++ b/e2e/electron.mas-bookmarks.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * #654 — MAS bookmark architecture regression tests (desktop-runnable slice).
+ *
+ * The MAS sandbox itself (startAccessingSecurityScopedResource) can't run on
+ * the desktop build; what IS testable deterministically is the settings-level
+ * contract the fix establishes:
+ *
+ *  1. Switching projects must NOT write the project's bookmark into the legacy
+ *     masDirectoryBookmark slot — that slot belongs exclusively to the base
+ *     root, and the v1.6.0–v1.6.2 sync destroyed the base root's only bookmark
+ *     (negative control: fails on the pre-#654 code).
+ *  2. A profile poisoned by that sync (masDirectoryBookmark === a project's
+ *     bookmark) is healed on load: the slot and the now-inaccessible
+ *     defaultSaveDirectory are cleared, and the heal is persisted.
+ *
+ * Isolated PROSE_USER_DATA_DIR profile per test.
+ */
+
+import { test, expect, _electron as electron } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { waitForAppReady, dismissOnboarding, dismissOverlay } from './helpers'
+
+// Launch out/main/index.js directly (the electron.screenshots pattern) instead
+// of helpers.launchApp — launchApp prefers a packaged build under dist/, which
+// locally can be a months-stale app that doesn't contain the code under test.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO = resolve(__dirname, '..')
+
+const BASE_BOOKMARK = 'QkFTRS1CT09LTUFSSw=='    // "BASE-BOOKMARK"
+const PROJECT_BOOKMARK = 'UFJPSi1CT09LTUFSSw==' // "PROJ-BOOKMARK"
+const PROJECT_ID = '00000000-0000-4000-8000-000000000001'
+
+let app: ElectronApplication | undefined
+let page: Page
+let profile: string
+let docsDir: string
+
+function seedProfile(settings: object): void {
+  profile = mkdtempSync(join(tmpdir(), 'prose-654-profile-'))
+  writeFileSync(join(profile, 'settings.json'), JSON.stringify(settings, null, 2))
+}
+
+function readSettings(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(profile, 'settings.json'), 'utf8'))
+}
+
+async function launch(): Promise<void> {
+  app = await electron.launch({
+    args: [join(REPO, 'out/main/index.js')],
+    env: { ...(process.env as Record<string, string>), PROSE_USER_DATA_DIR: profile }
+  })
+  page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+}
+
+/** Reveal the files panel (hidden by default in a fresh profile) and open the
+ *  Projects view — direct toggle first, overflow menu fallback at narrow widths
+ *  (same locators as electron.screenshots.spec.ts). */
+async function openProjectsView(): Promise<void> {
+  const show = page.locator('[aria-label="Show files"]')
+  if (await show.isVisible({ timeout: 1_000 }).catch(() => false)) await show.click()
+  await page.waitForTimeout(300)
+
+  const btn = page.locator('[aria-label="Projects"]')
+  if (await btn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await btn.click()
+  } else {
+    await page.locator('[aria-label="More views"]').click()
+    await page.getByRole('menuitem', { name: 'Projects' }).click()
+  }
+  await page.waitForTimeout(400)
+}
+
+test.afterEach(async () => {
+  await app?.close()
+  app = undefined
+  rmSync(profile, { recursive: true, force: true })
+  rmSync(docsDir, { recursive: true, force: true })
+})
+
+test('switching projects leaves the base-root bookmark slot untouched', async () => {
+  docsDir = mkdtempSync(join(tmpdir(), 'prose-654-docs-'))
+  const baseDir = join(docsDir, 'Base')
+  const projDir = join(docsDir, 'Essays')
+  mkdirSync(baseDir, { recursive: true })
+  mkdirSync(projDir, { recursive: true })
+  writeFileSync(join(projDir, 'Draft.md'), '# Draft\n')
+
+  seedProfile({
+    appearance: { color: 'mono', mode: 'dark', icon: 'pilcrow', migrationToastShown: true },
+    defaultSaveDirectory: baseDir,
+    masDirectoryBookmark: BASE_BOOKMARK,
+    projects: [
+      {
+        id: PROJECT_ID,
+        name: 'Essays',
+        path: projDir,
+        bookmark: PROJECT_BOOKMARK,
+        createdAt: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  await launch()
+
+  // Open the Projects view and switch into the seeded project.
+  await openProjectsView()
+  await page.getByRole('button', { name: /Essays/ }).first().click()
+
+  // switchToProject persists lastOpenedAt — wait for that write to land…
+  await expect
+    .poll(
+      () => {
+        const projects = readSettings().projects as Array<{ lastOpenedAt?: string }> | undefined
+        return projects?.[0]?.lastOpenedAt ?? null
+      },
+      { timeout: 10_000 },
+    )
+    .not.toBeNull()
+
+  // …then assert the base root's bookmark survived the switch. The pre-#654
+  // sync overwrote it with PROJECT_BOOKMARK at exactly this point.
+  const settings = readSettings()
+  expect(settings.masDirectoryBookmark).toBe(BASE_BOOKMARK)
+  expect(settings.defaultSaveDirectory).toBe(baseDir)
+  expect(settings.activeProjectId).toBe(PROJECT_ID)
+})
+
+test('a poisoned bookmark slot (project bookmark in masDirectoryBookmark) is healed on load', async () => {
+  docsDir = mkdtempSync(join(tmpdir(), 'prose-654-docs-'))
+  const baseDir = join(docsDir, 'Base')
+  const projDir = join(docsDir, 'Essays')
+  mkdirSync(baseDir, { recursive: true })
+  mkdirSync(projDir, { recursive: true })
+
+  seedProfile({
+    appearance: { color: 'mono', mode: 'dark', icon: 'pilcrow', migrationToastShown: true },
+    // The v1.6.0–v1.6.2 clobber state: the slot holds the project's bookmark
+    // and the base root's own bookmark is gone (unrecoverable).
+    defaultSaveDirectory: baseDir,
+    masDirectoryBookmark: PROJECT_BOOKMARK,
+    activeProjectId: PROJECT_ID,
+    projects: [
+      {
+        id: PROJECT_ID,
+        name: 'Essays',
+        path: projDir,
+        bookmark: PROJECT_BOOKMARK,
+        createdAt: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  await launch()
+
+  // loadSettings detects the poisoned slot, clears it plus the inaccessible
+  // base-root path, and persists the heal (JSON.stringify drops undefined).
+  await expect
+    .poll(() => 'masDirectoryBookmark' in readSettings(), { timeout: 10_000 })
+    .toBe(false)
+
+  const settings = readSettings()
+  expect(settings.defaultSaveDirectory).toBeUndefined()
+  // The project itself is untouched — only the legacy slot is healed.
+  const projects = settings.projects as Array<{ bookmark?: string }>
+  expect(projects[0].bookmark).toBe(PROJECT_BOOKMARK)
+})

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -76,6 +76,13 @@ let stopAccessingBookmark: (() => void) | null = null
 const projectBookmarkStopFns = new Map<string, () => void>()
 const favoriteBookmarkStopFns = new Map<string, () => void>()
 
+// In-session claims from folder picks (file:selectFolder), held for the life
+// of the process. Deliberately never tied to `stopAccessingBookmark` —
+// replacing the single base-root claim on every pick revoked base-root access
+// whenever a project/favorite folder was chosen (#654). Bounded by picks per
+// session; macOS releases all claims at process exit.
+const pickerBookmarkStopFns: Array<() => void> = []
+
 /**
  * Activate a security-scoped bookmark (MAS only) and return the stop function.
  * Returns null if not a MAS build or bookmark is missing.
@@ -85,7 +92,7 @@ function activateBookmark(bookmark: string | undefined, label: string): (() => v
   try {
     return app.startAccessingSecurityScopedResource(bookmark) as () => void
   } catch (err) {
-    console.warn(`[settings:load] Security-scoped bookmark invalid (${label}):`, err)
+    console.warn(`[bookmarks] Security-scoped bookmark invalid (${label}):`, err)
     return null
   }
 }
@@ -278,13 +285,13 @@ export function setupIpcHandlers(): void {
     const path = result.filePaths[0]
     const bookmark = IS_MAS_BUILD ? (result.bookmarks?.[0] ?? null) : null
 
-    // Activate bookmark access immediately for this session
+    // Activate bookmark access immediately for this session. Deliberately does
+    // NOT touch stopAccessingBookmark — that claim belongs to the base root
+    // (masDirectoryBookmark, activated in settings:load). Stopping it here
+    // revoked base-root access whenever a project/favorite folder was picked (#654).
     if (IS_MAS_BUILD && bookmark) {
-      if (stopAccessingBookmark) {
-        stopAccessingBookmark()
-      }
       try {
-        stopAccessingBookmark = app.startAccessingSecurityScopedResource(bookmark)
+        pickerBookmarkStopFns.push(app.startAccessingSecurityScopedResource(bookmark))
       } catch (err) {
         console.warn('[file:selectFolder] Could not activate bookmark:', err)
       }
@@ -292,6 +299,37 @@ export function setupIpcHandlers(): void {
 
     return { path, bookmark }
   })
+
+  // File: Activate a security-scoped bookmark in-session (MAS only) — #654.
+  // Lets the renderer activate a project/favorite bookmark the moment it's
+  // added or switched to, instead of waiting for the next settings:load. The
+  // claim registers under the entry's id so the settings:save reconciliation
+  // releases it promptly if the entry is removed. Non-MAS builds report
+  // success so call sites stay unconditional.
+  ipcMain.handle(
+    'file:activateBookmark',
+    async (_event, kind: 'project' | 'favorite', id: string, bookmark: string) => {
+      if (!IS_MAS_BUILD) return true
+      if (
+        (kind !== 'project' && kind !== 'favorite') ||
+        typeof id !== 'string' || !id || id.length > 128 ||
+        typeof bookmark !== 'string' || !bookmark || bookmark.length > 65536
+      ) {
+        return false
+      }
+      const stopFns = kind === 'project' ? projectBookmarkStopFns : favoriteBookmarkStopFns
+      // Release any prior claim for this id before re-activating
+      const prior = stopFns.get(id)
+      if (prior) {
+        try { prior() } catch { /* best effort */ }
+        stopFns.delete(id)
+      }
+      const stop = activateBookmark(bookmark, `${kind}:${id}`)
+      if (!stop) return false
+      stopFns.set(id, stop)
+      return true
+    }
+  )
 
   // File: Save to folder with filename
   ipcMain.handle(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,6 +203,7 @@ export interface ElectronAPI {
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
   // Folder operations for quick save
   selectFolder: (defaultPath?: string, message?: string) => Promise<{ path: string; bookmark: string | null } | null>
+  activateBookmark: (kind: 'project' | 'favorite', id: string, bookmark: string) => Promise<boolean>
   saveToFolder: (folder: string, filename: string, content: string) => Promise<string>
   getDocumentsPath: () => Promise<string>
   fileExists: (path: string) => Promise<boolean>
@@ -384,6 +385,8 @@ const api: ElectronAPI = {
   llmAbortStream: (streamId: string) => ipcRenderer.invoke('llm:stream:abort', streamId),
   // Folder operations for quick save
   selectFolder: (defaultPath?: string, message?: string) => ipcRenderer.invoke('file:selectFolder', defaultPath, message),
+  activateBookmark: (kind: 'project' | 'favorite', id: string, bookmark: string) =>
+    ipcRenderer.invoke('file:activateBookmark', kind, id, bookmark),
   saveToFolder: (folder: string, filename: string, content: string) =>
     ipcRenderer.invoke('file:saveToFolder', folder, filename, content),
   getDocumentsPath: () => ipcRenderer.invoke('file:documentsPath'),

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -308,6 +308,11 @@ export const browserApi: ElectronAPI = {
     return null
   },
 
+  activateBookmark: async (_kind: 'project' | 'favorite', _id: string, _bookmark: string): Promise<boolean> => {
+    // No sandbox in browser mode — nothing to activate
+    return true
+  },
+
   saveToFolder: async (_folder: string, filename: string, content: string): Promise<string> => {
     // Fall back to download
     await browserApi.saveFile(filename, content)

--- a/src/renderer/stores/projectsStore.ts
+++ b/src/renderer/stores/projectsStore.ts
@@ -18,6 +18,7 @@ import { subscribeWithSelector } from 'zustand/middleware'
 import type { Favorite, Project } from '../types'
 import { getApi } from '../lib/browserApi'
 import { useSettingsStore } from './settingsStore'
+import { useNotificationStore } from './notificationStore'
 
 // Stable empty-array references for the selector hooks below. Returning a fresh
 // `[]` from a Zustand selector on every call makes useSyncExternalStore treat the
@@ -137,12 +138,13 @@ export const useProjectsStore = create<ProjectsState>()(
           // back into the project, trapping navigation inside it (TestFlight
           // v1.6.1 report). Projects are additive pointers over the base root,
           // same contract as switchToProject below.
-          // Persist bookmark in the legacy single-bookmark slot too so the
-          // existing settings:load bookmark restoration still works.
+          // Register the project's bookmark claim under its own id (#654). The
+          // legacy masDirectoryBookmark slot belongs exclusively to the base
+          // root — syncing project bookmarks into it destroyed the base root's
+          // only bookmark on disk. Next-launch activation is owned by the
+          // settings:load projects[] restore loop.
           if (project.bookmark) {
-            useSettingsStore.setState((state) => ({
-              settings: { ...state.settings, masDirectoryBookmark: project.bookmark }
-            }))
+            void api.activateBookmark?.('project', project.id, project.bookmark)
           }
           useSettingsStore.getState().saveSettings()
         }
@@ -180,6 +182,12 @@ export const useProjectsStore = create<ProjectsState>()(
         }
 
         useSettingsStore.getState().addFavorite(favorite)
+        // Register the claim under the favorite's id so the settings:save
+        // reconciliation owns its lifecycle (#654). Next launch is covered by
+        // the settings:load favorites[] restore loop.
+        if (favorite.bookmark) {
+          void api.activateBookmark?.('favorite', favorite.id, favorite.bookmark)
+        }
         set({ isAddingFavorite: false })
         return favorite
       } catch (err) {
@@ -200,12 +208,28 @@ export const useProjectsStore = create<ProjectsState>()(
       // changed here — it stays stable as the base the Back button returns to.
       // Projects are additive pointers layered over the selected root.
 
-      // Sync the legacy single-bookmark slot so the existing startAccessingSecurityScopedResource
-      // call in settings:load still works on the next launch.
+      // Activate this project's bookmark claim in-session (#654). Startup
+      // claims come from the settings:load projects[] restore loop; this
+      // covers bookmarks added since launch. The legacy masDirectoryBookmark
+      // slot is deliberately NOT written — it belongs exclusively to the base
+      // root, and syncing the project bookmark into it destroyed the base
+      // root's only bookmark on disk.
+      const api = getApi()
       if (project.bookmark) {
-        useSettingsStore.setState((state) => ({
-          settings: { ...state.settings, masDirectoryBookmark: project.bookmark }
-        }))
+        const activated = await api.activateBookmark?.('project', project.id, project.bookmark)
+        if (activated === false) {
+          useNotificationStore.getState().notify({
+            id: 'mas-project-access',
+            message: `Prose couldn't restore permission for "${project.name}". If its files fail to load, remove and re-add the project to grant access again.`
+          })
+        }
+      } else if (api.isMasBuild) {
+        // MAS with no stored bookmark (e.g. cleared as stale at startup): file
+        // ops would fail silently — surface the re-grant path instead (#654).
+        useNotificationStore.getState().notify({
+          id: 'mas-project-access',
+          message: `Prose doesn't have saved permission for "${project.name}". Remove and re-add the project to grant access.`
+        })
       }
       useSettingsStore.getState().saveSettings()
 

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -159,7 +159,23 @@ function migrateOnDiskSettings(raw: SettingsOnDisk): Settings {
     defaultSaveDirectory = undefined
   }
 
-  return { ...rest, defaultSaveDirectory, appearance: resolved }
+  // Heal a base-root bookmark clobbered by addProjectFromPicker/switchToProject
+  // in v1.6.0–v1.6.2 (#654), which synced the active project's bookmark into
+  // the legacy masDirectoryBookmark slot — destroying the base root's only
+  // bookmark. If the slot holds a project/favorite bookmark it is the clobber
+  // artifact, not the base root's: clear it and the now-inaccessible base-root
+  // path so the Files panel falls back to the folder picker; the next explicit
+  // pick re-establishes both.
+  let masDirectoryBookmark = rest.masDirectoryBookmark
+  if (
+    masDirectoryBookmark &&
+    [...(rest.projects ?? []), ...(rest.favorites ?? [])].some((e) => e.bookmark === masDirectoryBookmark)
+  ) {
+    masDirectoryBookmark = undefined
+    defaultSaveDirectory = undefined
+  }
+
+  return { ...rest, defaultSaveDirectory, masDirectoryBookmark, appearance: resolved }
 }
 
 // Single tracked cleanup for the prefers-color-scheme listener. Stored at
@@ -248,9 +264,14 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
       window.api.setAppIcon?.(migrated.appearance.icon)
 
       // If we migrated a legacy theme field or healed a project-clobbered
-      // base root, persist the cleaned shape so the next launch reads the
-      // new values and the migration code path becomes a no-op for this user.
-      if (raw.theme || raw.defaultSaveDirectory !== migrated.defaultSaveDirectory) {
+      // base root / bookmark slot, persist the cleaned shape so the next
+      // launch reads the new values and the migration code path becomes a
+      // no-op for this user.
+      if (
+        raw.theme ||
+        raw.defaultSaveDirectory !== migrated.defaultSaveDirectory ||
+        raw.masDirectoryBookmark !== migrated.masDirectoryBookmark
+      ) {
         get().saveSettings().catch((err) => {
           console.warn('[settings] failed to persist migrated appearance:', err)
         })

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -477,6 +477,9 @@ export interface ElectronAPI {
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
   // Folder operations for quick save
   selectFolder: (defaultPath?: string, message?: string) => Promise<{ path: string; bookmark: string | null } | null>
+  /** Activate a MAS security-scoped bookmark in-session (#654). Optional: older
+   *  preloads lack it — call sites use `?.` and treat undefined as inert. */
+  activateBookmark?: (kind: 'project' | 'favorite', id: string, bookmark: string) => Promise<boolean>
   saveToFolder: (folder: string, filename: string, content: string) => Promise<string>
   getDocumentsPath: () => Promise<string>
   saveImage: (documentDir: string, base64Data: string, mimeType: string, originalName?: string) => Promise<{ relativePath: string; localFileUrl: string }>


### PR DESCRIPTION
## Summary

Fixes the MAS base-root bookmark loss behind #654 — the bug we wished had made the 1.6.2 submission. Ships as the fast-follow for build 30.

### Root cause (two halves)

1. **On-disk destruction**: `addProjectFromPicker` and `switchToProject` synced the active project's bookmark into the legacy `masDirectoryBookmark` slot — but that slot holds the **base root's** (`defaultSaveDirectory`'s) security-scoped bookmark, its *only* copy. After *add/switch → relaunch*, the base root had no active scope and its listing failed silently until the user re-picked the folder.
2. **In-session revocation**: `file:selectFolder` stopped the live base-root claim on *every* folder pick, so adding a project/favorite revoked base-root access immediately, before any relaunch.

### Fix

- **`masDirectoryBookmark` now belongs exclusively to the base root.** The two sync blocks in `projectsStore` are gone; project/favorite claims register under their own ids via a new `file:activateBookmark` IPC (MAS-gated, input-validated, lifecycle reconciled by the existing `settings:save` cleanup). Startup activation stays with the #651 restore loops.
- **`file:selectFolder`** activates picks into ephemeral process-lifetime claims instead of replacing the base-root claim.
- **Healing migration** for profiles poisoned by v1.6.0–v1.6.2: if the slot holds a project/favorite bookmark (the clobber artifact — detected by bookmark equality), it and the now-inaccessible base path are cleared and persisted; the Files panel falls back to the folder picker for a one-time re-pick.
- **UX guard** (the issue title's "+UX guard"): switching to a MAS project with no stored bookmark, or whose activation fails, raises a toast pointing at remove-and-re-add instead of silent file-op failures.

### Verification

- New e2e spec `electron.mas-bookmarks.spec.ts` (isolated `PROSE_USER_DATA_DIR` profiles, launched from `out/` to dodge stale `dist/` builds):
  - *switch leaves the slot untouched* — **negative-controlled**: with the fix stashed, the test fails with the project bookmark in the slot (the exact #654 signature); with the fix, it passes.
  - *poisoned-slot heal* — seeded clobbered profile is healed on load and the heal persists to `settings.json`.
- Full e2e suite: **40 passed, 0 failed** (5 skipped = SHOOT-gated screenshot specs; 3 pre-existing editor-spec flakes passed on retry).
- True MAS sandbox semantics (`startAccessingSecurityScopedResource`) can't run on the desktop build — verifying on **TestFlight build 30** after merge (local masDev still blocked by #487).

Design doc: `docs/issues/654/plan.md`. Unblocks closing #380 (held on this issue).

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)
