### PR TITLE
chore(mas): bump buildVersion to 30 for TestFlight

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -14,7 +14,7 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
 
 - **Never submit for App Store review.** Upload to **App Store Connect / TestFlight** is the
   automation edge; clicking "Submit for Review" is always a human decision and action.
-- **`buildVersion` is global-monotonic.** Currently `"29"` in `electron-builder.yml`.
+- **`buildVersion` is global-monotonic.** Currently `"30"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
   **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.2`).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "29"
+buildVersion: "30"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
Bumps `buildVersion` 29 → 30 to carry the #654 MAS bookmark fix (#711) to TestFlight: base-root bookmark preservation across project add/switch, poisoned-slot healing, in-session activation IPC, and the no-bookmark UX guard.

buildVersion is global monotonic — 29 is consumed on App Store Connect (approved as v1.6.2). Also syncs the runbook's current-value note.

Refs #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)