### PR TITLE
chore(release): v1.6.3 — MAS fast-follow for the #654 bookmark fix

### DIFF
--- a/docs/launch/wave-0.5-mas-refresh.md
+++ b/docs/launch/wave-0.5-mas-refresh.md
@@ -16,7 +16,11 @@ with the rebrand, drop-to-free pricing, and MAS hardening so the App Store build
   automation edge; clicking "Submit for Review" is always a human decision and action.
 - **`buildVersion` is global-monotonic.** Currently `"30"` in `electron-builder.yml`.
   Every upload to App Store Connect must use a strictly higher integer than any prior upload —
-  **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.2`).
+  **never reset it** when bumping the marketing version (`package.json` `version`, currently `1.6.3`).
+- **An approved version closes its train.** Once a marketing version is approved on the App Store
+  (e.g. 1.6.2), App Store Connect rejects further builds for it (`Invalid Pre-Release Train` /
+  `CFBundleShortVersionString must contain a higher version`). Fast-follow builds must bump
+  `package.json` `version` first — learned on the build-30 upload (2026-06-06).
 - **Never change sandbox flags** (`contextIsolation: true`, `nodeIntegration: false`) or the MAS
   entitlements without re-validating against the provisioning profile.
 - The `mas` target force-disables reMarkable (credentials/OCR not App-Store-ready) and blocks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prose",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prose",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A minimal markdown editor with AI chat",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps the marketing version 1.6.2 → 1.6.3 so build 30 (carrying the #654 MAS bookmark fix, #711) can upload to TestFlight.

**Why:** App Store Connect rejected build 30 under v1.6.2 — an approved version closes its pre-release train (`Invalid Pre-Release Train` + `CFBundleShortVersionString must contain a higher version than the previously approved 1.6.2`). Fast-follows after approval always need a marketing bump; the runbook's hard-boundaries section now records this.

buildVersion stays 30 (the failed upload didn't consume it — validation rejected before registration).

Refs #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)