### PR TITLE
Quick Wins batch: review/chat panel widths + Chat/Activity a11y (#704, #696, #686)

### DIFF
--- a/e2e/electron.activity-panel.spec.ts
+++ b/e2e/electron.activity-panel.spec.ts
@@ -106,7 +106,7 @@ test.describe('Electron — Activity panel', () => {
   test('Activity tab + badge + superseded filter', async () => {
     // Open the chat sidebar and switch to the Activity tab.
     await page.keyboard.press('ControlOrMeta+Shift+L')
-    const activityTab = page.getByRole('button', { name: /Activity/ })
+    const activityTab = page.getByRole('tab', { name: /Activity/ })
     await activityTab.waitFor({ state: 'visible', timeout: 5_000 })
     await activityTab.click()
 
@@ -133,7 +133,7 @@ test.describe('Electron — Activity panel', () => {
 
   test('chat actions stay visible on the Activity tab (#688)', async () => {
     // On the Activity tab, the chat action cluster must NOT disappear.
-    await page.getByRole('button', { name: /Activity/ }).click()
+    await page.getByRole('tab', { name: /Activity/ }).click()
     await expect(page.getByRole('button', { name: 'Document info' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'New chat' })).toBeVisible()
 

--- a/e2e/electron.screenshots.spec.ts
+++ b/e2e/electron.screenshots.spec.ts
@@ -252,7 +252,7 @@ test('04 edits history — activity (dark)', async () => {
   // Open chat, switch to the Activity tab.
   const showChat = page.locator('[aria-label="Show chat"]')
   if (await showChat.isVisible({ timeout: 1_000 }).catch(() => false)) await showChat.click()
-  await page.getByRole('button', { name: /Activity/ }).click()
+  await page.getByRole('tab', { name: /Activity/ }).click()
   await page.waitForTimeout(700)
   await page.screenshot({ path: join(SHOTS, '04-edits-history.png') })
 })

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -181,38 +181,46 @@ export function ChatPanel() {
       {/* Tab header (Chat | Activity) with the Activity count badge + filter */}
       <div className="flex items-center justify-between border-b border-border px-3 py-1">
         <div className="flex items-center gap-3">
-          <button
-            onClick={() => setSidebarMode('chat')}
-            aria-pressed={sidebarMode === 'chat'}
-            className={cn(
-              'text-sm border-b-2 pb-1 -mb-px transition-colors',
-              sidebarMode === 'chat'
-                ? 'text-foreground border-primary font-medium'
-                : 'text-muted-foreground border-transparent hover:text-foreground'
-            )}
-          >
-            Chat
-          </button>
-          <button
-            onClick={() => setSidebarMode('activity')}
-            aria-pressed={sidebarMode === 'activity'}
-            className={cn(
-              'flex items-center gap-1.5 text-sm border-b-2 pb-1 -mb-px transition-colors',
-              sidebarMode === 'activity'
-                ? 'text-foreground border-primary font-medium'
-                : 'text-muted-foreground border-transparent hover:text-foreground'
-            )}
-          >
-            Activity
-            {activityCount > 0 && (
-              <span
-                data-testid="activity-count-badge"
-                className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary leading-none"
-              >
-                {activityCount > 99 ? '99+' : activityCount}
-              </span>
-            )}
-          </button>
+          <div role="tablist" aria-label="Chat panel views" className="flex items-center gap-3">
+            <button
+              role="tab"
+              aria-selected={sidebarMode === 'chat'}
+              aria-controls="chat-tabpanel"
+              id="chat-tab-chat"
+              onClick={() => setSidebarMode('chat')}
+              className={cn(
+                'text-sm border-b-2 pb-1 -mb-px transition-colors',
+                sidebarMode === 'chat'
+                  ? 'text-foreground border-primary font-medium'
+                  : 'text-muted-foreground border-transparent hover:text-foreground'
+              )}
+            >
+              Chat
+            </button>
+            <button
+              role="tab"
+              aria-selected={sidebarMode === 'activity'}
+              aria-controls="chat-tabpanel"
+              id="chat-tab-activity"
+              onClick={() => setSidebarMode('activity')}
+              className={cn(
+                'flex items-center gap-1.5 text-sm border-b-2 pb-1 -mb-px transition-colors',
+                sidebarMode === 'activity'
+                  ? 'text-foreground border-primary font-medium'
+                  : 'text-muted-foreground border-transparent hover:text-foreground'
+              )}
+            >
+              Activity
+              {activityCount > 0 && (
+                <span
+                  data-testid="activity-count-badge"
+                  className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary leading-none"
+                >
+                  {activityCount > 99 ? '99+' : activityCount}
+                </span>
+              )}
+            </button>
+          </div>
 
           {/* Filter: hide/show superseded — only when there's something to filter */}
           {sidebarMode === 'activity' && supersededCount > 0 && (
@@ -359,109 +367,116 @@ export function ChatPanel() {
         </div>
       </div>
 
-      {sidebarMode === 'activity' ? (
-        <AIEditsHistoryPanel
-          hideSuperseded={hideSuperseded}
-          onShowAll={() => setHideSuperseded(false)}
-        />
-      ) : (
-        <>
-          {/* Collapsible summary panel */}
-          <div className={cn(
-            "overflow-hidden transition-all duration-200 ease-in-out",
-            infoOpen ? "max-h-60 border-b border-border" : "max-h-0"
-          )}>
-            <div className="mx-2 my-2 rounded-md bg-muted/50 border border-border/60 px-3 py-2">
-              <div className="flex items-center justify-between mb-1.5">
-                <h3 className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Summary</h3>
-                <span className="text-[10px] text-muted-foreground/70">~{readingTime} min read</span>
-              </div>
-              {isGenerating ? (
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                  <span>Generating...</span>
+      <div
+        role="tabpanel"
+        id="chat-tabpanel"
+        aria-labelledby={sidebarMode === 'activity' ? 'chat-tab-activity' : 'chat-tab-chat'}
+        className="flex-1 min-h-0 flex flex-col"
+      >
+        {sidebarMode === 'activity' ? (
+          <AIEditsHistoryPanel
+            hideSuperseded={hideSuperseded}
+            onShowAll={() => setHideSuperseded(false)}
+          />
+        ) : (
+          <>
+            {/* Collapsible summary panel */}
+            <div className={cn(
+              "overflow-hidden transition-all duration-200 ease-in-out",
+              infoOpen ? "max-h-60 border-b border-border" : "max-h-0"
+            )}>
+              <div className="mx-2 my-2 rounded-md bg-muted/50 border border-border/60 px-3 py-2">
+                <div className="flex items-center justify-between mb-1.5">
+                  <h3 className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Summary</h3>
+                  <span className="text-[10px] text-muted-foreground/70">~{readingTime} min read</span>
                 </div>
-              ) : error ? (
-                <p className="text-xs text-destructive">{error}</p>
-              ) : summary ? (
-                <p className="text-xs leading-relaxed">{summary}</p>
-              ) : (
-                <p className="text-xs text-muted-foreground">No summary yet</p>
-              )}
-            </div>
-          </div>
-
-          {/* Messages */}
-          <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto">
-            {visibleMessages.length === 0 ? (
-              <div className="flex items-center justify-center p-8 py-16">
-                <div className="text-center">
-                  <MessageSquare className="mx-auto h-12 w-12 text-muted-foreground/30" />
-                  <p className="mt-4 text-sm text-muted-foreground">
-                    No messages yet
-                  </p>
-                  <p className="mt-2 text-xs text-muted-foreground/60">
-                    Select text and press{' '}
-                    <kbd className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
-                      ⌘⇧K
-                    </kbd>{' '}
-                    to add context
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <div className="divide-y divide-border/50">
-                {visibleMessages.map((message, index) => (
-                  <ChatMessage
-                    key={message.id}
-                    message={message}
-                    isStreaming={
-                      isStreaming &&
-                      index === visibleMessages.length - 1 &&
-                      message.role === 'assistant'
-                    }
-                    onRetry={message.isError ? () => handleRetry(message.id) : undefined}
-                  />
-                ))}
-                {/* Show "Thinking..." only when loading but not yet streaming */}
-                {isLoading && !isStreaming && (
-                  <div className="flex gap-3 p-4 bg-muted/30">
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/20">
-                      <div className="h-4 w-4 animate-pulse rounded-full bg-primary/50" />
-                    </div>
-                    <div className="flex items-center">
-                      <span className="text-sm text-muted-foreground">
-                        Thinking...
-                      </span>
-                    </div>
+                {isGenerating ? (
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    <span>Generating...</span>
                   </div>
+                ) : error ? (
+                  <p className="text-xs text-destructive">{error}</p>
+                ) : summary ? (
+                  <p className="text-xs leading-relaxed">{summary}</p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No summary yet</p>
                 )}
               </div>
-            )}
-          </div>
-
-          {/* Suggestion review chip */}
-          {suggestionCount > 0 && (
-            <div className="px-4 py-3">
-              <button
-                onClick={() => useReviewStore.getState().setReviewMode('quick')}
-                className="w-full flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium bg-violet-500/10 hover:bg-violet-500/20 border border-violet-500/30 text-violet-600 dark:text-violet-400 transition-colors"
-              >
-                <Sparkles className="h-3 w-3" />
-                Review {suggestionCount} suggestion{suggestionCount !== 1 ? 's' : ''}
-              </button>
             </div>
-          )}
 
-          {/* Input */}
-          <ChatInput
-            onSend={sendMessage}
-            isLoading={isLoading}
-            isStreaming={isStreaming}
-            onStop={stopGeneration}
-          />
-        </>
-      )}
+            {/* Messages */}
+            <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto">
+              {visibleMessages.length === 0 ? (
+                <div className="flex items-center justify-center p-8 py-16">
+                  <div className="text-center">
+                    <MessageSquare className="mx-auto h-12 w-12 text-muted-foreground/30" />
+                    <p className="mt-4 text-sm text-muted-foreground">
+                      No messages yet
+                    </p>
+                    <p className="mt-2 text-xs text-muted-foreground/60">
+                      Select text and press{' '}
+                      <kbd className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                        ⌘⇧K
+                      </kbd>{' '}
+                      to add context
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="divide-y divide-border/50">
+                  {visibleMessages.map((message, index) => (
+                    <ChatMessage
+                      key={message.id}
+                      message={message}
+                      isStreaming={
+                        isStreaming &&
+                        index === visibleMessages.length - 1 &&
+                        message.role === 'assistant'
+                      }
+                      onRetry={message.isError ? () => handleRetry(message.id) : undefined}
+                    />
+                  ))}
+                  {/* Show "Thinking..." only when loading but not yet streaming */}
+                  {isLoading && !isStreaming && (
+                    <div className="flex gap-3 p-4 bg-muted/30">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/20">
+                        <div className="h-4 w-4 animate-pulse rounded-full bg-primary/50" />
+                      </div>
+                      <div className="flex items-center">
+                        <span className="text-sm text-muted-foreground">
+                          Thinking...
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Suggestion review chip */}
+            {suggestionCount > 0 && (
+              <div className="px-4 py-3">
+                <button
+                  onClick={() => useReviewStore.getState().setReviewMode('quick')}
+                  className="w-full flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium bg-violet-500/10 hover:bg-violet-500/20 border border-violet-500/30 text-violet-600 dark:text-violet-400 transition-colors"
+                >
+                  <Sparkles className="h-3 w-3" />
+                  Review {suggestionCount} suggestion{suggestionCount !== 1 ? 's' : ''}
+                </button>
+              </div>
+            )}
+
+            {/* Input */}
+            <ChatInput
+              onSend={sendMessage}
+              isLoading={isLoading}
+              isStreaming={isStreaming}
+              onStop={stopGeneration}
+            />
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -62,7 +62,7 @@ import { extractFirstH1 } from '../../lib/markdown'
 import type { DraftState, SessionState } from '../../lib/persistence'
 import { executeTool } from '../../lib/tools'
 import { useReviewMode, useWasChatOpenBeforeReview, usePreviousChatWidth, useReviewStore, type ReviewMode } from '../../stores/reviewStore'
-import { CHAT_DEFAULT_PCT, QUICK_REVIEW_DEFAULT_PX } from '../../hooks/usePanelLayout'
+import { QUICK_REVIEW_DEFAULT_PX, chatOpenDefaultPct } from '../../hooks/usePanelLayout'
 
 export function App() {
   useChat() // Initialize stream listeners
@@ -112,7 +112,7 @@ export function App() {
   const prevReviewMode = useRef<ReviewMode | null>(null)
   const prevTabId = useRef(activeTabId)
 
-  // Quick review target: ~330px as a percentage of window width.
+  // Quick review target: ~370px as a percentage of window width.
   // Above CHAT_MIN_PX (280) so cards have breathing room; user can still drag smaller.
   const quickReviewPct = (QUICK_REVIEW_DEFAULT_PX / window.innerWidth) * 100
 
@@ -138,7 +138,7 @@ export function App() {
       if (reviewMode === 'side-by-side') {
         chatPanelRef.current?.resize(60)
       } else {
-        // Quick mode: compact sidebar at ~330px
+        // Quick mode: compact sidebar at ~370px
         chatPanelRef.current?.resize(quickReviewPct)
       }
     } else if (!reviewMode && prev) {
@@ -148,7 +148,10 @@ export function App() {
       } else if (previousChatWidth !== null) {
         chatPanelRef.current?.resize(previousChatWidth)
       } else {
-        chatPanelRef.current?.resize(CHAT_DEFAULT_PCT)
+        const fileListPct = isFileListOpen ? (fileListPanelRef.current?.getSize() ?? 0) : 0
+        chatPanelRef.current?.resize(
+          chatOpenDefaultPct({ fileListPct, chatMin: panelSizes.chatMin, chatMax: panelSizes.chatMax })
+        )
       }
     }
   }, [reviewMode, activeTabId, wasChatOpenBeforeReview, previousChatWidth, setChatOpen, chatPanelRef, setPreviousChatWidth, quickReviewPct])

--- a/src/renderer/components/review/SideBySideDiffPanel.tsx
+++ b/src/renderer/components/review/SideBySideDiffPanel.tsx
@@ -115,10 +115,10 @@ export function SideBySideDiffPanel() {
           <h2 className="text-sm font-medium shrink-0">Side-by-Side Diff</h2>
           <button
             onClick={() => setReviewMode('quick')}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors truncate"
           >
             <ArrowLeftRight className="h-3 w-3 shrink-0" />
-            <span>Quick review</span>
+            <span className="truncate">Quick review</span>
           </button>
         </div>
 

--- a/src/renderer/hooks/usePanelLayout.ts
+++ b/src/renderer/hooks/usePanelLayout.ts
@@ -23,8 +23,7 @@ const CHAT_MAX_PX = 610
 const EDITOR_MIN_PX = 360
 const BOTH_PANELS_MIN_WIDTH = 1000
 const FILE_LIST_DEFAULT_PCT = 20
-export const CHAT_DEFAULT_PCT = 50
-export const QUICK_REVIEW_DEFAULT_PX = 330
+export const QUICK_REVIEW_DEFAULT_PX = 370
 
 // --- Types ---
 
@@ -69,6 +68,14 @@ function calcPanelSizes(windowWidth: number): PanelSizes {
     chatMin: (CHAT_MIN_PX / windowWidth) * 100,
     chatMax: (CHAT_MAX_PX / windowWidth) * 100
   }
+}
+
+// Default chat width on open: split the space left after the file explorer evenly
+// with the editor (so the editor isn't squeezed when the explorer is also open),
+// clamped to the chat panel's min/max. With the explorer closed this returns 50.
+export function chatOpenDefaultPct(opts: { fileListPct: number; chatMin: number; chatMax: number }): number {
+  const pct = (100 - opts.fileListPct) / 2
+  return Math.min(Math.max(pct, opts.chatMin), opts.chatMax)
 }
 
 // --- Hook ---
@@ -130,7 +137,10 @@ export function usePanelLayout({ fileListPanelRef, chatPanelRef }: UsePanelLayou
   useLayoutEffect(() => {
     if (isChatOpen !== prevChatOpen.current) {
       if (isChatOpen) {
-        chatPanelRef.current?.resize(CHAT_DEFAULT_PCT)
+        const fileListPct = isFileListOpen ? (fileListPanelRef.current?.getSize() ?? 0) : 0
+        chatPanelRef.current?.resize(
+          chatOpenDefaultPct({ fileListPct, chatMin: panelSizes.chatMin, chatMax: panelSizes.chatMax })
+        )
       } else {
         chatPanelRef.current?.resize(0)
       }
@@ -146,7 +156,7 @@ export function usePanelLayout({ fileListPanelRef, chatPanelRef }: UsePanelLayou
 
     prevChatOpen.current = isChatOpen
     prevFileListOpen.current = isFileListOpen
-  }, [isChatOpen, isFileListOpen, chatPanelRef, fileListPanelRef])
+  }, [isChatOpen, isFileListOpen, chatPanelRef, fileListPanelRef, panelSizes])
 
   // --- Mount: force panels to match store state ---
   // react-resizable-panels restores persisted sizes from localStorage


### PR DESCRIPTION
## Summary

A tight batch of three pure-renderer Quick Wins, bundled to ship together in the next MAS build (v1.6.3). No main-process / IPC / sandbox surface — safe for the App Store build.

Closes #704
Closes #686
Closes #696

## Changes

**#704 — quick-review default width + truncate symmetry**
- `QUICK_REVIEW_DEFAULT_PX` 330 → 370 so the Quick Review header ("Quick Review" + ⇄ + "Full diff") fits at the default width.
- Added `truncate` to the Side-by-Side panel's "Quick review" cross-link (the sibling Quick Review panel already had it) so it degrades gracefully at narrow widths.

**#696 — chat default width = 50% of the space *after* the file explorer**
- Previously opening chat always resized to 50% of the **whole window**, squeezing the editor to ~30% when the explorer was also open.
- New `chatOpenDefaultPct({ fileListPct, chatMin, chatMax })` helper splits the post-explorer space evenly (clamped to chat min/max; returns 50 when the explorer is closed). Used at both the open path (`usePanelLayout.ts`) and the review-exit fallback (`App.tsx`). The now-dead `CHAT_DEFAULT_PCT` constant + import were removed.

**#686 — a11y: Chat/Activity tabs are real tabs, not toggle buttons**
- The tab buttons used `aria-pressed` (announced as a toggle). Now a `role="tablist"` wrapping two `role="tab"` + `aria-selected` buttons, with the content region as a `role="tabpanel"` (`aria-labelledby` keyed to the active tab). The Filter button's own `aria-pressed` is left alone (it's a genuine toggle). No visible styling change; the tabpanel wrapper preserves `flex-1 min-h-0 flex flex-col` so height/scroll are unchanged.
- Updated 3 e2e selectors (`getByRole('button', { name: /Activity/ })` → `getByRole('tab', …)`) in `activity-panel` + `screenshots` specs — the role change would otherwise have failed them.

## Verification

- **Full production build** (`npm run build`) — renderer bundled clean through Rollup; every import resolves.
- **#686 e2e** (`electron.activity-panel.spec.ts`) — **2/2 passed** against the built app (tabs work as `role=tab`, tabpanel renders, badge + superseded filter function, tab-switching intact). The test also opens the chat panel, incidentally exercising #696's new open-path.
- Local QA in an isolated dev instance (`PROSE_USER_DATA_DIR`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
