### PR TITLE
chore(mas): bump buildVersion to 32 for TestFlight

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: ist.solo.prose
 productName: Prose
-buildVersion: "31"
+buildVersion: "32"
 directories:
   buildResources: build
   output: dist


### PR DESCRIPTION
## Summary

Bump MAS `buildVersion` 31 → 32 for the next TestFlight build.

**Build 32** (`v1.6.3`, `CFBundleVersion` 32) bundles the Quick Wins batch — #704 (quick-review width), #696 (chat default width), #686 (Chat/Activity tab a11y) — on top of a clean-deps `main` (0 open Dependabot alerts; the `hono` fix #680 already landed).

## Status

- ✅ `npm run build:mas` — signed (`Apple Distribution` + `3rd Party Mac Developer Installer`, team `8PT2Y7QQ2F`, Distribution profile embedded).
- ✅ Uploaded to App Store Connect via iTMSTransporter (177 MB, delivery committed).
- ⏳ ASC processing → VALID (confirming), then TestFlight QA.
- App Store **review submission stays a human action** — not automated.

Next `buildVersion` = 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
