### PR TITLE
ci: gate AI review pipeline on maintainer trust (#726)

### DIFF
--- a/.claude/skills/pipeline-eng/SKILL.md
+++ b/.claude/skills/pipeline-eng/SKILL.md
@@ -26,7 +26,7 @@ The full workflow chain, trigger to output:
 |----------|---------|---------------|-----------------|---------------|
 | `e2e.yml` | `pull_request`, `/test` comment | — | — (artifact: `e2e-results`) | — |
 | `web-e2e.yml` | `pull_request` (with `accelerated` label), `/test` comment | — | — | — |
-| `ci-gate.yml` | `workflow_run` on "E2E Tests" | `<!-- e2e-fix-attempt:`, `<!-- agent-fix-attempt:`, `<!-- ci-gate-sha:` | Posts `/review <!-- ci-gate-sha: ... -->` comment; `<!-- e2e-fix-escalation -->` | `claude.yml` (via `/review` comment) |
+| `ci-gate.yml` | `workflow_run` on "E2E Tests" | `<!-- e2e-fix-attempt:`, `<!-- agent-fix-attempt:`, `<!-- ci-gate-sha:` | Posts `/review <!-- ci-gate-sha: ... -->` comment; `<!-- e2e-fix-escalation -->` | `claude.yml` (via `/review` comment) — **only when the PR author is OWNER/MEMBER/COLLABORATOR** (see Author Trust Gating) |
 | `claude.yml` (auto-review) | `/review` comment on PR | — | `<!-- review-verdict: clean -->` or `<!-- review-verdict: issues-found -->` | — |
 | `review-feedback.yml` (clean-gate) | `issue_comment` with `<!-- review-verdict: clean -->` | `<!-- review-verdict: clean -->`, absence of `<!-- review-feedback-analysis -->` | `<!-- review-feedback-analysis -->` | — |
 | `review-feedback.yml` (analyze) | `issue_comment` with `## Code Review` (no verdict trailer) | absence of `<!-- review-feedback-analysis -->`, `<!-- review-verdict: clean -->`, `<!-- review-verdict: issues-found -->` | `<!-- review-feedback-analysis -->`, `<!-- pipeline-bypass-warning -->` | — |
@@ -131,6 +131,36 @@ if: >-
 ### `contains()` through backticks
 
 In GitHub Actions `if:` expressions, sentinel strings inside `contains()` must be wrapped in single quotes. If the sentinel itself contains single quotes, you'll need to use a different guard strategy (e.g., shell step with `grep`).
+
+---
+
+## Author Trust Gating
+
+To stop untrusted/fork PRs and stranger comments from running up Anthropic spend (#726), the pipeline gates its expensive entry points on GitHub's `author_association`. Trusted = `OWNER`, `MEMBER`, `COLLABORATOR`. Everything else (`CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `MANNEQUIN`, `NONE`) is untrusted.
+
+**Layered model:**
+- **Layer 1 (repo setting):** the native fork-PR approval policy is `all_external_contributors` — a maintainer must click "Approve and run" before *any* workflow runs for an external-contributor PR. Since the whole spend chain is rooted in E2E running, this is the primary cut-off. (View/set: `gh api .../actions/permissions/fork-pr-contributor-approval`.)
+- **Layer 2a — `ci-gate.yml` (load-bearing):** `trigger-review` calls `pulls.get` for the PR and gates the "Trigger auto-review" step on `steps.trust.outputs.trusted == 'true'`. **This is the gate that actually stops fork-PR auto-review** — the `/review` comment is posted as the `PROJECT_TOKEN` owner (always trusted), so gating the *comment* author can't help; the **PR author** must be checked. Works for same-repo and SHA-fallback (fork) PR numbers.
+- **Layer 2b — job-level pre-filters:** `claude.yml` (`auto-review` + `claude`), `dispatch.yml`, and the `/test` branch of `e2e.yml`/`web-e2e.yml` add `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), <association>)` so untrusted callers don't even allocate a runner. The runtime `getCollaboratorPermissionLevel` steps are kept as a precise secondary gate.
+- **`pipeline-fix.yml` fork guard:** auto-fix checks out the PR branch by name and runs an agent with `ANTHROPIC_API_KEY`; a `pulls.get` fork check skips forks deterministically (`is_fork`).
+
+**`author_association` field path by event type:**
+
+| Event | Field path |
+|-------|------------|
+| `issue_comment` | `github.event.comment.author_association` |
+| `pull_request_review_comment` | `github.event.comment.author_association` |
+| `pull_request_review` | `github.event.review.author_association` |
+| `issues` | `github.event.issue.author_association` |
+| (ci-gate / pipeline-fix runtime) | `pr.author_association` from `pulls.get` |
+
+Use the `contains(fromJSON('[...]'), x)` idiom (already used in `notify.yml`) in `if:` expressions and `['OWNER','MEMBER','COLLABORATOR'].includes(x)` in `github-script` JS.
+
+**Critical — ci-gate's post is `MEMBER`:** the "Trigger auto-review" step posts `/review` via `secrets.PROJECT_TOKEN`, so the comment author is `mrangelmarino` (User type, `author_association: MEMBER`). The `claude.yml` `auto-review` gate **must** include `MEMBER` or the auto-review chain silently stops. The `["OWNER","MEMBER","COLLABORATOR"]` list satisfies this.
+
+**Sync hazard:** the trusted-association list is duplicated across `claude.yml`, `dispatch.yml`, `e2e.yml`, `web-e2e.yml` (`if:` expressions) and `ci-gate.yml` / `pipeline-fix.yml` (JS `.includes`). Keep them identical. `validate-pipeline.sh` invariants **#21** (claude.yml has the list), **#22** (ci-gate has `steps.trust.outputs.trusted` + `author_association`), and **#23** (pipeline-fix has the `is_fork` guard) enforce presence.
+
+**Not addressed by trust gating:** a maintainer (OWNER/MEMBER) opening an issue whose body literally contains `@claude` will still fire the `claude` job — that's intended. Avoid the accidental self-trigger by not writing a bare `@claude` in issue prose.
 
 ---
 

--- a/.github/scripts/validate-pipeline.sh
+++ b/.github/scripts/validate-pipeline.sh
@@ -269,6 +269,47 @@ else
 fi
 echo ""
 
+# 21. Author-trust gate present in claude.yml (#726)
+# auto-review and @claude jobs must gate on the trusted author_association list
+echo "--- Check: claude.yml author-trust gate ---"
+if grep -q 'OWNER","MEMBER","COLLABORATOR' .github/workflows/claude.yml; then
+  echo "PASS"
+else
+  echo "FAIL: claude.yml missing author_association trust gate (fromJSON OWNER/MEMBER/COLLABORATOR)"
+  ERRORS=$((ERRORS + 1))
+fi
+echo ""
+
+# 22. ci-gate PR-author trust gate before posting /review (#726)
+# trigger-review must check the PR author's association before the Anthropic-spending review
+echo "--- Check: ci-gate PR-author trust gate ---"
+CI_GATE_TRUST_OK=true
+if ! grep -q "steps.trust.outputs.trusted" .github/workflows/ci-gate.yml; then
+  echo "FAIL: ci-gate.yml missing steps.trust.outputs.trusted gate on Trigger auto-review"
+  CI_GATE_TRUST_OK=false
+  ERRORS=$((ERRORS + 1))
+fi
+if ! grep -q "author_association" .github/workflows/ci-gate.yml; then
+  echo "FAIL: ci-gate.yml missing author_association trust check"
+  CI_GATE_TRUST_OK=false
+  ERRORS=$((ERRORS + 1))
+fi
+if $CI_GATE_TRUST_OK; then
+  echo "PASS"
+fi
+echo ""
+
+# 23. pipeline-fix fork guard (#726)
+# auto-fix checks out the PR branch and runs an agent with the API key — must skip forks
+echo "--- Check: pipeline-fix fork guard ---"
+if grep -q "is_fork" .github/workflows/pipeline-fix.yml; then
+  echo "PASS"
+else
+  echo "FAIL: pipeline-fix.yml missing fork guard (is_fork)"
+  ERRORS=$((ERRORS + 1))
+fi
+echo ""
+
 # Summary
 echo "==========================="
 if [ "$ERRORS" -eq 0 ]; then

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -76,8 +76,34 @@ jobs:
 
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Trigger auto-review
+      - name: Check PR author trust
+        id: trust
         if: steps.pr.outputs.number && steps.dedup.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            // Only trusted PR authors (OWNER/MEMBER/COLLABORATOR) trigger the
+            // Anthropic-spending auto-review. A fork PR from an untrusted author is
+            // skipped here even though E2E ran — the /review below is posted as the
+            // PROJECT_TOKEN owner (always trusted), so the PR *author* must be checked.
+            // See pipeline-eng SKILL.md "Author Trust Gating".
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            const assoc = pr.author_association;
+            const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
+            core.setOutput('trusted', String(trusted));
+            core.setOutput('association', assoc);
+            if (!trusted) {
+              core.notice(`PR #${process.env.PR_NUMBER} author_association='${assoc}' — skipping auto-review (untrusted author)`);
+            }
+
+      - name: Trigger auto-review
+        if: steps.pr.outputs.number && steps.dedup.outputs.skip != 'true' && steps.trust.outputs.trusted == 'true'
         env:
           # PROJECT_TOKEN required: github.token events don't trigger downstream
           # issue_comment workflows. claude.yml checks body content, not author.
@@ -90,6 +116,11 @@ jobs:
             --body "/review <!-- ci-gate-sha: $HEAD_SHA -->
 
           *Auto-triggered after E2E tests passed.*"
+
+      - name: Notice — auto-review skipped (untrusted author)
+        if: steps.pr.outputs.number && steps.dedup.outputs.skip != 'true' && steps.trust.outputs.trusted != 'true'
+        run: |
+          echo "::notice::Auto-review skipped for PR #${{ steps.pr.outputs.number }}: author_association=${{ steps.trust.outputs.association }} (not OWNER/MEMBER/COLLABORATOR)"
 
   e2e-auto-fix:
     # E2E failed on a PR → post @claude fix request

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,8 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/review')
+      contains(github.event.comment.body, '/review') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -169,10 +170,10 @@ jobs:
   # Manual invocation via @claude mentions
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/review')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/review') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     # Per-issue serialization: runs on the same issue/PR queue; runs on different
     # issues execute concurrently. Each cloud agent works on its own per-issue branch,

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -14,6 +14,7 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot' &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       !contains(github.event.comment.body, '@claude') &&
       !contains(github.event.comment.body, '<!-- dispatch-generated -->') &&
       (

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,8 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '/test') &&
-        !contains(github.event.comment.body, '@claude')
+        !contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/pipeline-fix.yml
+++ b/.github/workflows/pipeline-fix.yml
@@ -62,8 +62,31 @@ jobs:
             exit 0
           fi
 
-      - name: Resolve PR branch
+      - name: Check if fork PR
         if: steps.guard.outputs.attempts == '0'
+        id: fork
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            // auto-fix checks out the PR branch by name (no `repository:`) and runs an
+            // agent with ANTHROPIC_API_KEY. A fork PR would misfire (the branch name
+            // resolves against the base repo). Skip forks deterministically rather than
+            // relying on a checkout failure. See pipeline-eng SKILL.md "Author Trust Gating".
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+            core.setOutput('is_fork', String(isFork));
+            if (isFork) {
+              core.notice(`PR #${process.env.PR_NUMBER} is from a fork — skipping auto-fix`);
+            }
+
+      - name: Resolve PR branch
+        if: steps.guard.outputs.attempts == '0' && steps.fork.outputs.is_fork != 'true'
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,14 +97,14 @@ jobs:
           echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR branch
-        if: steps.guard.outputs.attempts == '0'
+        if: steps.guard.outputs.attempts == '0' && steps.fork.outputs.is_fork != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.resolve.outputs.branch }}
           fetch-depth: 0
 
       - name: Gather context for fix
-        if: steps.guard.outputs.attempts == '0'
+        if: steps.guard.outputs.attempts == '0' && steps.fork.outputs.is_fork != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -96,7 +119,7 @@ jobs:
             ) | .body' > /tmp/pipeline-context.txt
 
       - name: Load pipeline context into env
-        if: steps.guard.outputs.attempts == '0'
+        if: steps.guard.outputs.attempts == '0' && steps.fork.outputs.is_fork != 'true'
         run: |
           {
             echo "PIPELINE_CONTEXT<<PIPELINE_EOF"
@@ -105,7 +128,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Run Claude Code Fix
-        if: steps.guard.outputs.attempts == '0'
+        if: steps.guard.outputs.attempts == '0' && steps.fork.outputs.is_fork != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -140,7 +163,7 @@ jobs:
             Then summarize what you fixed in a brief list.
 
       - name: Request human verification
-        if: steps.guard.outputs.attempts == '0'
+        if: steps.guard.outputs.attempts == '0' && steps.fork.outputs.is_fork != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -26,7 +26,8 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '/test') &&
-        !contains(github.event.comment.body, '@claude')
+        !contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes #726.

Gates the Claude-assisted review pipeline on maintainer trust so untrusted/fork PRs and stranger comments can't run up the Anthropic API bill — using idiomatic GitHub mechanisms.

## The hole this closes
`ci-gate.yml`'s `trigger-review` posts a `/review` comment (as the `PROJECT_TOKEN` owner — `mrangelmarino`/`MEMBER`) for **any** PR including forks (SHA-fallback explicitly supports forks). That triggers `claude.yml` `auto-review` → spend. Because the comment is posted by the trusted bot identity, gating the *comment* author can't help — only a **PR-author** check can.

## Layers
- **Layer 1 — native fork-PR approval (already applied):** `fork-pr-contributor-approval` raised `first_time_contributors` → **`all_external_contributors`** via the API. Since the whole spend chain is rooted in E2E running, this requires "Approve and run" before any external PR's workflows execute. *Set on the repo as part of this change; not in the diff.*
- **Layer 2a — `ci-gate.yml` (load-bearing):** new `Check PR author trust` step (`pulls.get` → `author_association`) gates "Trigger auto-review" on `trusted == 'true'` (`OWNER`/`MEMBER`/`COLLABORATOR`). Untrusted authors get a log-only `::notice::`, no PR comment.
- **Layer 2b — job-level pre-filters:** `claude.yml` (`auto-review` + `claude`), `dispatch.yml`, and the `/test` branch of `e2e.yml`/`web-e2e.yml` add `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), <association>)` so untrusted callers don't allocate a runner. Runtime `getCollaboratorPermissionLevel` checks kept as a precise secondary gate.
- **`pipeline-fix.yml` fork guard:** deterministic `is_fork` check (it checks out the PR branch and runs an agent with `ANTHROPIC_API_KEY`).
- **`validate-pipeline.sh`:** invariants **#21–#23** enforce the gates (all 23 pass locally).
- **pipeline-eng skill:** new "Author Trust Gating" section.

The critical constraint — `auto-review` **must** allow `MEMBER` so ci-gate's own `/review` post still triggers the legit chain — is satisfied by the `["OWNER","MEMBER","COLLABORATOR"]` list.

## Security audit (done in planning — no separate hole)
Audited fork-PR secret exposure: **zero `pull_request_target`** anywhere; the only fork-code-executing jobs (`e2e`/`web-e2e`) reference **no secrets** (and fork `pull_request` runs get empty secrets regardless); every secret-holding job runs **base-repo** code and is bot/permission-gated; `release.yml` is tag-push only. **No credential-theft path independent of the spend chain.**

## Deliberate posture
`all_external_contributors` requires the maintainer's "Approve and run" for **every** external-contributor workflow run, **indefinitely** (not just first-time). **Zero friction for the owner / org members / collaborators;** ongoing per-PR approval only for genuine outside contributors (rare here). This is an intentional choice.

## Out of scope
- A complementary **Anthropic-Console spend cap / usage alert** (gating is preventive, not a ceiling) was considered and deliberately not tracked here.
- Not de-fanging literal `@claude` in issue prose — a maintainer `@claude` is a legitimate trigger.

## Verification
- **Pre-merge:** `validate-pipeline.yml` runs on this PR — confirm all 23 invariants pass.
- **Post-merge** (these run from `main`, so they can't be exercised on the PR branch): same-repo PR → `trusted=true` → `/review` posts → `auto-review` runs (happy path); untrusted `/review` → `auto-review` **skipped**; fork PR → trust step logs `trusted=false`, auto-review skipped.
- **Rollback:** revert the `&& steps.trust.outputs.trusted == 'true'` clause on "Trigger auto-review" and push to `main` (effective next E2E completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
