### PR TITLE
test: verify ci-gate author-trust chain (do not merge)

### DIFF
--- a/docs/issues/726/ci-verify.md
+++ b/docs/issues/726/ci-verify.md
@@ -1,0 +1,6 @@
+# Post-merge verification scratch (PR #730 / #726)
+
+Throwaway file to open a same-repo PR that exercises the new author-trust gate:
+E2E → ci-gate "Check PR author trust" (expect `trusted=true`) → `/review` posted →
+auto-review fires. This PR is **not** meant to be merged — close + delete after the
+ci-gate run confirms the legit chain still works.


### PR DESCRIPTION
Post-merge verification for #726/#730. Confirms E2E → ci-gate trust step (`trusted=true` for a MEMBER author) → `/review` → auto-review chain still fires. **Do not merge — will be closed after the ci-gate run.**