### PR TITLE
fix(ci): gate auto-review on repo permission, not author_association

### DIFF
--- a/.claude/skills/pipeline-eng/SKILL.md
+++ b/.claude/skills/pipeline-eng/SKILL.md
@@ -26,7 +26,7 @@ The full workflow chain, trigger to output:
 |----------|---------|---------------|-----------------|---------------|
 | `e2e.yml` | `pull_request`, `/test` comment | — | — (artifact: `e2e-results`) | — |
 | `web-e2e.yml` | `pull_request` (with `accelerated` label), `/test` comment | — | — | — |
-| `ci-gate.yml` | `workflow_run` on "E2E Tests" | `<!-- e2e-fix-attempt:`, `<!-- agent-fix-attempt:`, `<!-- ci-gate-sha:` | Posts `/review <!-- ci-gate-sha: ... -->` comment; `<!-- e2e-fix-escalation -->` | `claude.yml` (via `/review` comment) — **only when the PR author is OWNER/MEMBER/COLLABORATOR** (see Author Trust Gating) |
+| `ci-gate.yml` | `workflow_run` on "E2E Tests" | `<!-- e2e-fix-attempt:`, `<!-- agent-fix-attempt:`, `<!-- ci-gate-sha:` | Posts `/review <!-- ci-gate-sha: ... -->` comment; `<!-- e2e-fix-escalation -->` | `claude.yml` (via `/review` comment) — **only when the PR author has repo write/admin** (see Author Trust Gating) |
 | `claude.yml` (auto-review) | `/review` comment on PR | — | `<!-- review-verdict: clean -->` or `<!-- review-verdict: issues-found -->` | — |
 | `review-feedback.yml` (clean-gate) | `issue_comment` with `<!-- review-verdict: clean -->` | `<!-- review-verdict: clean -->`, absence of `<!-- review-feedback-analysis -->` | `<!-- review-feedback-analysis -->` | — |
 | `review-feedback.yml` (analyze) | `issue_comment` with `## Code Review` (no verdict trailer) | absence of `<!-- review-feedback-analysis -->`, `<!-- review-verdict: clean -->`, `<!-- review-verdict: issues-found -->` | `<!-- review-feedback-analysis -->`, `<!-- pipeline-bypass-warning -->` | — |
@@ -136,31 +136,19 @@ In GitHub Actions `if:` expressions, sentinel strings inside `contains()` must b
 
 ## Author Trust Gating
 
-To stop untrusted/fork PRs and stranger comments from running up Anthropic spend (#726), the pipeline gates its expensive entry points on GitHub's `author_association`. Trusted = `OWNER`, `MEMBER`, `COLLABORATOR`. Everything else (`CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `MANNEQUIN`, `NONE`) is untrusted.
+To stop untrusted/fork PRs and stranger comments from running up Anthropic spend (#726), the pipeline gates its expensive entry points on the author's **effective repository permission** (`write`/`admin`), resolved at runtime via `getCollaboratorPermissionLevel`.
+
+> ⚠️ **Do NOT gate on `author_association`.** `GITHUB_TOKEN` cannot see **private** org membership, so the REST API (`pulls.get`) reports an org `MEMBER` as `CONTRIBUTOR`. Gating on `author_association` therefore silently breaks the legit chain for a private-member maintainer (caught in post-merge verification of #730: ci-gate read `CONTRIBUTOR` for the repo owner and skipped auto-review). `getCollaboratorPermissionLevel` reflects real repo access (direct + team + org base permission) and is token-reliable. A PAT *can* see private membership — so a local `gh api` check may show `MEMBER` while the workflow sees `CONTRIBUTOR`; trust the workflow's view.
 
 **Layered model:**
 - **Layer 1 (repo setting):** the native fork-PR approval policy is `all_external_contributors` — a maintainer must click "Approve and run" before *any* workflow runs for an external-contributor PR. Since the whole spend chain is rooted in E2E running, this is the primary cut-off. (View/set: `gh api .../actions/permissions/fork-pr-contributor-approval`.)
-- **Layer 2a — `ci-gate.yml` (load-bearing):** `trigger-review` calls `pulls.get` for the PR and gates the "Trigger auto-review" step on `steps.trust.outputs.trusted == 'true'`. **This is the gate that actually stops fork-PR auto-review** — the `/review` comment is posted as the `PROJECT_TOKEN` owner (always trusted), so gating the *comment* author can't help; the **PR author** must be checked. Works for same-repo and SHA-fallback (fork) PR numbers.
-- **Layer 2b — job-level pre-filters:** `claude.yml` (`auto-review` + `claude`), `dispatch.yml`, and the `/test` branch of `e2e.yml`/`web-e2e.yml` add `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), <association>)` so untrusted callers don't even allocate a runner. The runtime `getCollaboratorPermissionLevel` steps are kept as a precise secondary gate.
-- **`pipeline-fix.yml` fork guard:** auto-fix checks out the PR branch by name and runs an agent with `ANTHROPIC_API_KEY`; a `pulls.get` fork check skips forks deterministically (`is_fork`).
+- **Layer 2 — `ci-gate.yml` (load-bearing):** `trigger-review`'s "Check PR author trust" step fetches the PR author (`pulls.get` → `pr.user.login`), calls `getCollaboratorPermissionLevel(author)`, and gates "Trigger auto-review" on `steps.trust.outputs.trusted == 'true'` (`write`/`admin`). **This is the gate that actually stops fork-PR auto-review** — the `/review` comment is posted as the `PROJECT_TOKEN` owner (always trusted), so gating the *comment* author can't help; the **PR author** must be checked. This gate has no runtime backstop after it, so it must be reliable — hence permission, not association. Works for same-repo and SHA-fallback (fork) PR numbers.
+- **Runtime permission steps (the gate for direct comments):** `claude.yml` (`auto-review` + `claude`), `dispatch.yml`, and the `/test` branch of `e2e.yml`/`web-e2e.yml` each have a `getCollaboratorPermissionLevel` step that `core.setFailed`s for non-`write`/`admin` callers, blocking spend before the Anthropic call. (We deliberately do **not** add an `author_association` `if:` pre-filter to save a runner — it's unreliable per the warning above and would false-block a private-member maintainer. The runner cost for a blocked stranger is just minutes, no spend.)
+- **`pipeline-fix.yml` fork guard:** auto-fix checks out the PR branch by name and runs an agent with `ANTHROPIC_API_KEY`; a `pulls.get` fork check (`pr.head.repo.full_name !== pr.base.repo.full_name` — repo-name comparison, not membership, so it's reliable) skips forks deterministically (`is_fork`).
 
-**`author_association` field path by event type:**
+**Invariants:** `validate-pipeline.sh` **#21** (claude.yml keeps a runtime `getCollaboratorPermissionLevel` gate), **#22** (ci-gate trust step uses `steps.trust.outputs.trusted` + `getCollaboratorPermissionLevel`), **#23** (pipeline-fix has the `is_fork` guard).
 
-| Event | Field path |
-|-------|------------|
-| `issue_comment` | `github.event.comment.author_association` |
-| `pull_request_review_comment` | `github.event.comment.author_association` |
-| `pull_request_review` | `github.event.review.author_association` |
-| `issues` | `github.event.issue.author_association` |
-| (ci-gate / pipeline-fix runtime) | `pr.author_association` from `pulls.get` |
-
-Use the `contains(fromJSON('[...]'), x)` idiom (already used in `notify.yml`) in `if:` expressions and `['OWNER','MEMBER','COLLABORATOR'].includes(x)` in `github-script` JS.
-
-**Critical — ci-gate's post is `MEMBER`:** the "Trigger auto-review" step posts `/review` via `secrets.PROJECT_TOKEN`, so the comment author is `mrangelmarino` (User type, `author_association: MEMBER`). The `claude.yml` `auto-review` gate **must** include `MEMBER` or the auto-review chain silently stops. The `["OWNER","MEMBER","COLLABORATOR"]` list satisfies this.
-
-**Sync hazard:** the trusted-association list is duplicated across `claude.yml`, `dispatch.yml`, `e2e.yml`, `web-e2e.yml` (`if:` expressions) and `ci-gate.yml` / `pipeline-fix.yml` (JS `.includes`). Keep them identical. `validate-pipeline.sh` invariants **#21** (claude.yml has the list), **#22** (ci-gate has `steps.trust.outputs.trusted` + `author_association`), and **#23** (pipeline-fix has the `is_fork` guard) enforce presence.
-
-**Not addressed by trust gating:** a maintainer (OWNER/MEMBER) opening an issue whose body literally contains `@claude` will still fire the `claude` job — that's intended. Avoid the accidental self-trigger by not writing a bare `@claude` in issue prose.
+**Not addressed by trust gating:** a maintainer opening an issue whose body literally contains `@claude` will still fire the `claude` job — that's intended. Avoid the accidental self-trigger by not writing a bare `@claude` in issue prose.
 
 ---
 

--- a/.github/scripts/validate-pipeline.sh
+++ b/.github/scripts/validate-pipeline.sh
@@ -269,19 +269,21 @@ else
 fi
 echo ""
 
-# 21. Author-trust gate present in claude.yml (#726)
-# auto-review and @claude jobs must gate on the trusted author_association list
-echo "--- Check: claude.yml author-trust gate ---"
-if grep -q 'OWNER","MEMBER","COLLABORATOR' .github/workflows/claude.yml; then
+# 21. claude.yml retains the runtime permission gate (#726)
+# author_association is unreliable (GITHUB_TOKEN can't see private org membership),
+# so trust is enforced by the runtime getCollaboratorPermissionLevel step, not an if:.
+echo "--- Check: claude.yml runtime permission gate ---"
+if grep -q "getCollaboratorPermissionLevel" .github/workflows/claude.yml; then
   echo "PASS"
 else
-  echo "FAIL: claude.yml missing author_association trust gate (fromJSON OWNER/MEMBER/COLLABORATOR)"
+  echo "FAIL: claude.yml missing runtime getCollaboratorPermissionLevel trust gate"
   ERRORS=$((ERRORS + 1))
 fi
 echo ""
 
 # 22. ci-gate PR-author trust gate before posting /review (#726)
-# trigger-review must check the PR author's association before the Anthropic-spending review
+# trigger-review must check the PR author's effective permission (NOT author_association)
+# before the Anthropic-spending review.
 echo "--- Check: ci-gate PR-author trust gate ---"
 CI_GATE_TRUST_OK=true
 if ! grep -q "steps.trust.outputs.trusted" .github/workflows/ci-gate.yml; then
@@ -289,8 +291,8 @@ if ! grep -q "steps.trust.outputs.trusted" .github/workflows/ci-gate.yml; then
   CI_GATE_TRUST_OK=false
   ERRORS=$((ERRORS + 1))
 fi
-if ! grep -q "author_association" .github/workflows/ci-gate.yml; then
-  echo "FAIL: ci-gate.yml missing author_association trust check"
+if ! grep -q "getCollaboratorPermissionLevel" .github/workflows/ci-gate.yml; then
+  echo "FAIL: ci-gate.yml trust step must use getCollaboratorPermissionLevel (not author_association)"
   CI_GATE_TRUST_OK=false
   ERRORS=$((ERRORS + 1))
 fi

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -84,22 +84,36 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
-            // Only trusted PR authors (OWNER/MEMBER/COLLABORATOR) trigger the
-            // Anthropic-spending auto-review. A fork PR from an untrusted author is
-            // skipped here even though E2E ran — the /review below is posted as the
-            // PROJECT_TOKEN owner (always trusted), so the PR *author* must be checked.
-            // See pipeline-eng SKILL.md "Author Trust Gating".
+            // Only trusted PR authors (repo write/admin) trigger the Anthropic-spending
+            // auto-review. A fork PR from an untrusted author is skipped here even though
+            // E2E ran — the /review below is posted as the PROJECT_TOKEN owner (always
+            // trusted), so the PR *author* must be checked.
+            // Do NOT use pr.author_association: GITHUB_TOKEN cannot see *private* org
+            // membership, so it reports an org MEMBER as 'CONTRIBUTOR' and the legit chain
+            // silently breaks. getCollaboratorPermissionLevel reflects effective repo
+            // permission (incl. org/team grants) reliably. See SKILL.md "Author Trust Gating".
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: Number(process.env.PR_NUMBER),
             });
-            const assoc = pr.author_association;
-            const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
+            const author = pr.user.login;
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status !== 404) throw err;  // 404 = not a collaborator → untrusted
+            }
+            const trusted = ['admin', 'write'].includes(permission);
             core.setOutput('trusted', String(trusted));
-            core.setOutput('association', assoc);
+            core.setOutput('permission', permission);
             if (!trusted) {
-              core.notice(`PR #${process.env.PR_NUMBER} author_association='${assoc}' — skipping auto-review (untrusted author)`);
+              core.notice(`PR #${process.env.PR_NUMBER} author '${author}' permission='${permission}' — skipping auto-review (untrusted)`);
             }
 
       - name: Trigger auto-review
@@ -120,7 +134,7 @@ jobs:
       - name: Notice — auto-review skipped (untrusted author)
         if: steps.pr.outputs.number && steps.dedup.outputs.skip != 'true' && steps.trust.outputs.trusted != 'true'
         run: |
-          echo "::notice::Auto-review skipped for PR #${{ steps.pr.outputs.number }}: author_association=${{ steps.trust.outputs.association }} (not OWNER/MEMBER/COLLABORATOR)"
+          echo "::notice::Auto-review skipped for PR #${{ steps.pr.outputs.number }}: author permission=${{ steps.trust.outputs.permission }} (need write/admin)"
 
   e2e-auto-fix:
     # E2E failed on a PR → post @claude fix request

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/review') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      contains(github.event.comment.body, '/review')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -170,10 +169,10 @@ jobs:
   # Manual invocation via @claude mentions
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/review') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     # Per-issue serialization: runs on the same issue/PR queue; runs on different
     # issues execute concurrently. Each cloud agent works on its own per-issue branch,

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -14,7 +14,6 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       !contains(github.event.comment.body, '@claude') &&
       !contains(github.event.comment.body, '<!-- dispatch-generated -->') &&
       (

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,8 +20,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '/test') &&
-        !contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        !contains(github.event.comment.body, '@claude')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -26,8 +26,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '/test') &&
-        !contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        !contains(github.event.comment.body, '@claude')
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fix-forward for a regression in #730 (Refs #726). **No new issue per the "regression in a just-merged PR" norm.**

## What broke
#730's author-trust gate used `author_association`. That field is **unreliable from a workflow**: `GITHUB_TOKEN` cannot see **private** org membership, so the REST API (`pulls.get`) reports an org `MEMBER` as `CONTRIBUTOR`.

The **post-merge happy-path verification caught it**: I opened a throwaway same-repo PR, and ci-gate's trust step read `author_association='CONTRIBUTOR'` for the repo owner → `trusted=false` → **auto-review skipped on a legitimate PR**. (My earlier "instant" check showed `MEMBER` only because it used a PAT, which *can* see my own private membership — a trap worth remembering.)

## The fix — gate on effective repo permission
- **`ci-gate.yml` trust step:** `getCollaboratorPermissionLevel(pr author)` → `trusted = write/admin` (was `pr.author_association`). This is the load-bearing gate with no runtime backstop, so it must be token-reliable; `getCollaboratorPermissionLevel` reflects real repo access (direct + team + org base) regardless of membership visibility. Verified: returns `admin` for the owner, `none`/404 for a non-collaborator fork author.
- **Dropped the `author_association` `if:` pre-filters** on `claude.yml`/`dispatch.yml`/`e2e.yml`/`web-e2e.yml`. They'd false-block a private-member maintainer the same way. The **runtime `getCollaboratorPermissionLevel` steps that were always there** remain the authoritative gate — a blocked stranger just spends runner minutes, never Anthropic budget. (This also resolves the cloud reviewer's earlier note that the `if:` presence-grep was weak.)
- **`validate-pipeline.sh`:** `#21` now asserts `claude.yml` keeps its runtime permission gate; `#22` asserts ci-gate's trust step uses `getCollaboratorPermissionLevel`. `#23` (pipeline-fix fork guard) unchanged — it compares repo `full_name`, not membership, so it was never affected.
- **pipeline-eng skill:** documents the `author_association` / private-org-membership gotcha so this isn't reintroduced.

All 23 invariants pass locally (incl. YAML/JS syntax).

## Note on review/merge
Because `main` currently carries the broken gate, this PR **won't get an auto cloud review** (ci-gate sees me as `CONTRIBUTOR` and won't post `/review`). I'll merge after `validate-pipeline` + E2E are green, then re-run the same-repo verification to confirm the chain fires end-to-end (`trusted=true` → `/review` → auto-review). Layer 1 (the native `all_external_contributors` gate) is unaffected and remains in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
