### PR TITLE
test: re-verify ci-gate trust after fix (do not merge)

### DIFF
--- a/docs/issues/726/ci-verify.md
+++ b/docs/issues/726/ci-verify.md
@@ -1,0 +1,5 @@
+# Post-merge verification scratch (re-run after the #732 trust fix)
+
+Throwaway PR to confirm the corrected gate: E2E → ci-gate "Check PR author trust"
+should now resolve `trusted=true` via `getCollaboratorPermissionLevel` (write/admin)
+→ `/review` posted → auto-review fires. Close + delete after the ci-gate run confirms.


### PR DESCRIPTION
Re-verification after #732. Confirms ci-gate's `getCollaboratorPermissionLevel` trust step resolves `trusted=true` for the owner → `/review` → auto-review fires. **Do not merge — closed after the ci-gate run.**