### PR TITLE
fix(ci): don't route nitpick-only / docs PRs to auto-fix (#735)

### DIFF
--- a/.claude/skills/pipeline-orchestrate/SKILL.md
+++ b/.claude/skills/pipeline-orchestrate/SKILL.md
@@ -19,13 +19,16 @@ Source of truth: `run-orchestrator.mjs` `route()` function.
 
 | Score (1-10) | PE Risk | Route | Action |
 |--------------|---------|-------|--------|
-| 1-3 | LOW | `auto-fix` | Claude Code pushes fix commit |
+| 1-3 | LOW, nitpick-only (`severity_mix == 1`) or docs/copy (`change_type == 1`) | `hitl-light` | Post analyses, `needs-review` — merge as-is or apply nits by hand |
+| 1-3 | LOW, has a functional finding | `auto-fix` | Claude Code pushes fix commit |
 | 1-3 | MEDIUM+ | `hitl-light` | Post analyses, label `needs-review` |
 | 4-6 | LOW | `auto-fix-verify` | Fix + request human verification |
 | 4-6 | MEDIUM+ | `hitl-full` | Full analyses, assign human |
 | 7+ | Any | `hitl-full` | Label `complex`, full human review |
 | Any | CRITICAL | `hitl-full` | Always escalate |
 | Any | privileged | `hitl-full` | Security hard gate — always escalate |
+
+**Nitpick/docs carve-out (#735):** a docs-only or nitpick-only PR is the *lowest*-complexity case, so it scores ≤ 3 and would otherwise hit `auto-fix` — but there's nothing substantive for the fix agent to change, so it makes cosmetic edits the next review re-flags as fresh nits, driving a review → fix → review loop. The router consults the scorer's `severity_mix` / `change_type` dimensions and downgrades these to `hitl-light` instead. `auto-fix` is reserved for low-score PRs with at least one functional finding to act on.
 
 ### Label Mapping
 
@@ -68,6 +71,13 @@ If the same PR also touched `src/main/ipc.ts`:
 - Path: privileged = true → immediate `hitl-full` (score doesn't matter)
 - Labels: `complex`, `needs-review`
 - No auto-fix dispatched
+
+For a docs-only PR (e.g. `docs/issues/644/*.md`) with only cosmetic nits (the #735 case):
+- Scorer returns: `{"score": 2.3, "threshold": "auto-fix", "dimensions": {"severity_mix": 1, "change_type": 1, ...}}`
+- PE returns: `{"risk": "LOW", "privileged": false, "concerns": 4}`
+- Path: score < 4, risk LOW, but `severity_mix == 1` → `hitl-light` (carve-out), **not** `auto-fix`
+- Labels: `needs-review`
+- No auto-fix dispatched — verdict notes the `auto-fix → hitl-light` downgrade
 
 ## Output Format
 

--- a/.claude/skills/pipeline-scorer/SKILL.md
+++ b/.claude/skills/pipeline-scorer/SKILL.md
@@ -30,11 +30,13 @@ Scores each dimension 1-5, then computes a composite score (average x 2, range 1
 
 | Score | Route | What it means downstream |
 |-------|-------|------------------------|
-| 1-3 | `auto-fix` | Issues are trivial — `pipeline-fix.yml` pushes a fix commit |
+| 1-3 | `auto-fix` | Issues are trivial — orchestrator dispatches `pipeline-fix.yml` **only if** there's a functional finding to act on (see carve-out) |
 | 4-6 | `review` | Needs human verification — may become `auto-fix-verify` or `hitl-full` depending on PE risk |
 | 7-10 | `complex` | Full human review required — always routes `hitl-full` |
 
 Note: the scorer's threshold label is an input to the orchestrator, which applies its own routing matrix combining it with the PE risk level. The scorer does not directly dispatch anything.
+
+**Nitpick/docs carve-out (#735):** a `1-3` threshold does **not** guarantee `auto-fix`. The orchestrator downgrades nitpick-only (`severity_mix == 1`) or docs/copy/config (`change_type == 1`) findings to `hitl-light` instead — an auto-fix agent has nothing substantive to change there, so it would churn the branch and drive a review → fix → review loop. The `dimensions` you emit are what the orchestrator reads to make this call, so score them honestly. See `pipeline-orchestrate`.
 
 ## Calibration Examples
 

--- a/.github/scripts/run-orchestrator.mjs
+++ b/.github/scripts/run-orchestrator.mjs
@@ -53,7 +53,7 @@ console.log(`PE: risk=${pe.risk}, privileged=${pe.privileged}, concerns=${pe.con
 // Routing matrix
 // ---------------------------------------------------------------------------
 
-function route(score, risk, privileged) {
+function route(score, risk, privileged, severityMix, changeType) {
   // Security hard gate: CRITICAL risk or privileged paths always escalate
   if (risk === 'CRITICAL' || privileged) {
     return 'hitl-full'
@@ -69,11 +69,23 @@ function route(score, risk, privileged) {
     return risk === 'LOW' ? 'auto-fix-verify' : 'hitl-full'
   }
 
+  // Low score range (1-3) + LOW risk normally auto-fixes. But nitpick-only
+  // findings (severity_mix === 1 = style/nitpicks) or docs/copy/config changes
+  // (change_type === 1) give an auto-fix agent nothing substantive to change —
+  // it makes cosmetic edits the next review re-flags as fresh nits, driving the
+  // review → fix → review loop. Route those to light human review instead (merge
+  // as-is or apply nits by hand). auto-fix stays for low-score PRs that have at
+  // least one functional finding to act on. See #735.
+  if (risk === 'LOW' && (severityMix === 1 || changeType === 1)) {
+    return 'hitl-light'
+  }
+
   // Low score range (1-3)
   return risk === 'LOW' ? 'auto-fix' : 'hitl-light'
 }
 
-const verdict = route(scorer.score, pe.risk, pe.privileged)
+const dims = scorer.dimensions || {}
+const verdict = route(scorer.score, pe.risk, pe.privileged, dims.severity_mix, dims.change_type)
 
 console.log(`Verdict: ${verdict}`)
 
@@ -109,6 +121,18 @@ const criticalNote = pe.risk === 'CRITICAL'
   ? '\n> **[CRITICAL RISK]** PE analysis flagged critical architectural risk.\n'
   : ''
 
+// The scorer maps any score <= 3 to its own `auto-fix` threshold, but the router
+// downgrades nitpick-only / docs-only findings to hitl-light (see route()). Surface
+// that so the verdict doesn't look inconsistent with the scorer threshold.
+const nitpickDowngrade =
+  verdict === 'hitl-light' && pe.risk === 'LOW' && scorer.score < 4 &&
+  (dims.severity_mix === 1 || dims.change_type === 1)
+const nitpickNote = nitpickDowngrade
+  ? `- Downgraded from \`auto-fix\` → \`hitl-light\`: ${
+      dims.severity_mix === 1 ? 'findings are nitpick-only' : 'docs/copy/config change'
+    } — nothing substantive to auto-fix without churning the branch (#735)\n`
+  : ''
+
 const output = `<!-- orchestrator-verdict: ${verdict} -->
 ## Pipeline Verdict: PR #${PR_NUMBER}
 
@@ -126,7 +150,7 @@ ${securityNote}${criticalNote}
 
 - Scorer threshold: \`${scorer.threshold}\` (score ${scorer.score}/10)
 - PE risk level: \`${pe.risk}\` with ${pe.concerns} concern(s)
-${pe.privileged ? '- **Security gate triggered** — privilege-boundary files detected\n' : ''}- Applied labels: \`${labels}\`
+${nitpickNote}${pe.privileged ? '- **Security gate triggered** — privilege-boundary files detected\n' : ''}- Applied labels: \`${labels}\`
 
 ---
 *Pipeline triage complete. ${verdict === 'auto-fix' || verdict === 'auto-fix-verify' ? 'Auto-fix workflow will be triggered.' : 'Awaiting human action.'}*


### PR DESCRIPTION
## What

Stops the triage orchestrator from routing **nitpick-only / docs-only** PRs to `auto-fix`, which is the engine of a potential review → fix → review **infinite loop** on the Claude cloud pipeline.

Closes #735.

## Root cause

`route()` in `.github/scripts/run-orchestrator.mjs` sent every score ≤ 3 + `LOW`-risk PR to `auto-fix`, regardless of *what kind* of findings they were. A docs-only PR with only cosmetic nits is the lowest-complexity case, so it lands there — but there's nothing substantive for the fix agent to change. It makes subjective prose edits that the next review re-flags as fresh nits → push → E2E → `/review` → `issues-found` → triage → `auto-fix` → … bounded only by a fragile single-attempt circuit breaker.

Observed on PR #734 (docs-only): scorer `2.3/10`, `severity_mix: 1`, `change_type: 1`, PE `LOW`/privilege-CLEAR → **Route: AUTO-FIX**. Not currently spinning only because *both* auto-fix dispatch paths are coincidentally broken (a `PROJECT_TOKEN` 403 on `gh workflow run`, and `GITHUB_TOKEN` recursion-suppression on the comment trigger) — fixing the 403 without this change would activate the loop.

Not related to #726/#732 (trust gating) — those don't touch the orchestrator.

## Change

In the low-score/`LOW`-risk branch, `route()` now consults the scorer's already-emitted `severity_mix` / `change_type` dimensions:

- `severity_mix === 1` (nitpick-only) **or** `change_type === 1` (docs/copy/config) → `hitl-light` (post analyses, `needs-review`, human merges as-is or applies nits by hand).
- Otherwise unchanged: `auto-fix` stays for low-score PRs with at least one functional finding.
- Missing `dimensions` (older comment format) → falls back to the original `auto-fix` behavior.

The verdict comment surfaces the `auto-fix → hitl-light` downgrade so it doesn't look inconsistent with the scorer's own threshold. `pipeline-orchestrate` matrix + decision traces and `pipeline-scorer` thresholds note updated to match.

## Verification

- `node run-orchestrator.mjs` driven across an 8-case route matrix — all pass:

  | Case | Verdict |
  |------|---------|
  | docs nitpick (#734: `severity_mix:1, change_type:1`, LOW) | `hitl-light` ✅ (was `auto-fix`) |
  | low score, LOW, functional finding | `auto-fix` (unchanged) |
  | low score, LOW, nitpick-only code | `hitl-light` |
  | medium score, LOW | `auto-fix-verify` (unchanged) |
  | score ≥ 7 | `hitl-full` (unchanged) |
  | privileged | `hitl-full` (unchanged) |
  | low score, MEDIUM | `hitl-light` (unchanged) |
  | missing dimensions | `auto-fix` (safe fallback) |

- `bash .github/scripts/validate-pipeline.sh` → **ALL CHECKS PASSED**.

## Not in this PR (follow-ups)

- Harden the single-attempt circuit breaker (set the attempt sentinel/label *before* running the fix agent, not rely on the LLM posting it).
- Decide whether `PROJECT_TOKEN` should gain `workflow` scope (the 403) — sequence **after** this lands.
- PR #734 is stuck with a stale `auto-fix-dispatched` label; clear it so it can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
