### PR TITLE
feat(editor): submit and advance frontmatter edits with Enter/Escape

### DIFF
--- a/src/renderer/components/editor/FrontmatterEditor.tsx
+++ b/src/renderer/components/editor/FrontmatterEditor.tsx
@@ -55,6 +55,12 @@ export function FrontmatterEditor({ frontmatter, onSave }: FrontmatterEditorProp
   // so we don't clobber an in-progress local edit when the store echoes back.
   const skipNextPropSyncRef = useRef(false)
 
+  // Per-row input refs so Enter can advance focus through key/value fields.
+  const keyRefs = useRef<(HTMLInputElement | null)[]>([])
+  const valueRefs = useRef<(HTMLInputElement | null)[]>([])
+  // When Enter appends a new row, remember where to move focus once it renders.
+  const pendingFocusRef = useRef<{ index: number; field: 'key' | 'value' } | null>(null)
+
   // Sync local fields when the frontmatter prop changes from outside this
   // component (e.g., AI-applied frontmatter via MCP suggest_edit). User-initiated
   // edits set the skip flag so we don't re-init on the round-trip.
@@ -87,6 +93,47 @@ export function FrontmatterEditor({ frontmatter, onSave }: FrontmatterEditorProp
   const handleAdd = useCallback(() => {
     setFields(prev => [...prev, { key: '', value: '', readonly: false, originalValue: '' }])
   }, [])
+
+  // Move focus to a freshly-appended row once React has rendered it.
+  useEffect(() => {
+    const pending = pendingFocusRef.current
+    if (!pending) return
+    pendingFocusRef.current = null
+    const target = pending.field === 'key' ? keyRefs.current[pending.index] : valueRefs.current[pending.index]
+    target?.focus()
+  }, [fields])
+
+  // Enter commits the current field and advances focus; Escape collapses the editor.
+  // Persistence is unchanged — saves still happen per keystroke via handleFieldChange.
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>, index: number, which: 'key' | 'value') => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      setIsExpanded(false)
+      return
+    }
+    if (e.key !== 'Enter') return
+    e.preventDefault()
+    if (which === 'key') {
+      // Return in a key field focuses that row's value field.
+      valueRefs.current[index]?.focus()
+      return
+    }
+    // Return in a value field.
+    if (index < fields.length - 1) {
+      // Advance to the next row's key input.
+      keyRefs.current[index + 1]?.focus()
+      return
+    }
+    const row = fields[index]
+    if (!row.key.trim() && !row.value.trim()) {
+      // Return on an empty trailing field collapses the editor.
+      setIsExpanded(false)
+      return
+    }
+    // Append a new blank row and focus its key input once it renders.
+    pendingFocusRef.current = { index: fields.length, field: 'key' }
+    handleAdd()
+  }, [fields, handleAdd])
 
   // Accept handler: write the accepted frontmatter directly to the store FIRST
   // as a durable fallback, then call onSave to reserialize body content (which
@@ -239,16 +286,20 @@ export function FrontmatterEditor({ frontmatter, onSave }: FrontmatterEditorProp
           return (
             <div key={index} className="flex items-center gap-1.5">
               <Input
+                ref={el => { keyRefs.current[index] = el }}
                 value={field.key}
                 onChange={e => handleFieldChange(index, { key: e.target.value })}
+                onKeyDown={e => handleKeyDown(e, index, 'key')}
                 placeholder="key"
                 disabled={isDisabled}
                 className="h-6 px-2 py-0 text-xs font-mono w-32 shrink-0 bg-background/50 border-border/50 disabled:opacity-60 disabled:cursor-default"
               />
               <span className="text-muted-foreground/40 shrink-0">:</span>
               <Input
+                ref={el => { valueRefs.current[index] = el }}
                 value={field.value}
                 onChange={e => handleFieldChange(index, { value: e.target.value })}
+                onKeyDown={e => handleKeyDown(e, index, 'value')}
                 placeholder="value"
                 disabled={isDisabled}
                 className="h-6 px-2 py-0 text-xs font-mono flex-1 bg-background/50 border-border/50 disabled:opacity-60 disabled:cursor-default"


### PR DESCRIPTION
## What & why

Closes #725

Frontmatter was edited as discrete key/value rows where **Return/Enter was a no-op**, forcing users to mouse between fields. This adds keyboard-driven submit-and-advance to the expanded `FrontmatterEditor`:

- **Return in a key field** focuses that row's value field.
- **Return in a value field** advances to the next row's key input, or — if on the trailing row with content — appends a new blank row and focuses its key input.
- **Return on an empty trailing field** collapses the editor.
- **Escape** collapses the editor back to the summary view.

Per-keystroke saving (`handleFieldChange` → `onSave`) is unchanged, and the AI-suggestion (`pendingFrontmatter`) overlay path is untouched. Disabled (protected/readonly) rows don't emit key events, so they're naturally skipped.

### Files
- `src/renderer/components/editor/FrontmatterEditor.tsx` — added per-row input refs, a pending-focus effect for newly appended rows, and an `onKeyDown` handler wired to both inputs.

No privilege-boundary (`src/main/**`, `src/preload/**`, build config) or hot coordination files touched.

## Validation
- `npx electron-vite build` — renderer/main/preload compile cleanly (exit 0). Note: the full `npm run build` could not complete in the sandbox because the `build:skill` step requires the `zip` binary, which is unavailable offline; this is unrelated to the change.

## Manual QA
1. Open a document, expand the frontmatter editor (or click **Add frontmatter**).
2. In a row's **key** input, type a key and press **Return** → focus moves to that row's **value** input.
3. In the **value** input, type a value and press **Return** → focus moves to the next row's key input (if one exists).
4. On the **last** row with content, press **Return** in the value field → a new blank row is appended and its key input is focused.
5. On an **empty trailing** row, press **Return** → the editor collapses to the summary view.
6. With the editor expanded, press **Escape** → the editor collapses to the summary view.
7. Confirm edits still save on every keystroke (collapse/reopen and verify values persist).
8. Trigger an AI frontmatter suggestion and confirm the Accept/Reject overlay is unaffected.


---
_Conversation: https://app.warp.dev/conversation/7a246539-99e3-4271-a54c-c3864fdb7e94_
_Run: https://oz.warp.dev/runs/019ec2f2-77a4-7700-8d25-8e7c08c4288d_

_This PR was generated with [Oz](https://warp.dev/oz)._
