### PR TITLE
feat(chat): add /report-bug and /request-feature slash commands

### DIFF
--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -15,6 +15,13 @@ import { executeTool, getAvailableTools, isToolAvailableInMode } from '../../lib
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import { cn } from '../../lib/utils'
 import { useReviewStore } from '../../stores/reviewStore'
+import { getApi } from '../../lib/browserApi'
+import { requestBugReport } from '../EnableLoggingDialog'
+
+// GitHub feedback template URLs (mirror the Toolbar "More" menu / Help menu)
+const BUG_REPORT_URL = 'https://github.com/solo-ist/prose/issues/new?template=bug-report.yml'
+const FEATURE_REQUEST_URL = 'https://github.com/solo-ist/prose/issues/new?template=feature-request.yml'
+const MAS_SUPPORT_URL = 'https://solo.ist/prose/support'
 
 // Tool descriptions for autocomplete
 const toolDescriptions: Record<string, string> = {
@@ -43,7 +50,9 @@ const toolDescriptions: Record<string, string> = {
   clear: 'Start a new chat',
   new: 'New blank tab',
   'quick-review': 'Review suggestions one at a time',
-  'review-diff': 'Side-by-side diff of all suggestions'
+  'review-diff': 'Side-by-side diff of all suggestions',
+  'report-bug': 'Report a bug on GitHub',
+  'request-feature': 'Request a feature on GitHub'
 }
 
 // Commands that require arguments (no-arg will show echo)
@@ -78,7 +87,9 @@ const directExecCommands = [
   'list_files',
   'new_file',
   'quick-review',
-  'review-diff'
+  'review-diff',
+  'report-bug',
+  'request-feature'
 ]
 
 // Auto-execute commands: commands that execute with a default prompt when selected from dropdown
@@ -187,7 +198,7 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
       .map(t => t === 'get_outline' ? 'outline' : t)
     const showReviewShortcuts = toolMode !== 'chat' && suggestionCount > 0
     const reviewShortcuts = showReviewShortcuts ? ['quick-review', 'review-diff'] : []
-    return [...tools, 'help', 'clear', 'new', ...reviewShortcuts]
+    return [...tools, 'help', 'clear', 'new', ...reviewShortcuts, 'report-bug', 'request-feature']
   }, [toolMode, suggestionCount])
 
   // Parse the current command from input (e.g., "/list_files " -> "list_files")
@@ -262,6 +273,26 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
       return
     }
 
+    // Handle /report-bug - chat-layer shortcut to the GitHub bug template.
+    // Routes through requestBugReport() to preserve the Sentry opt-in prompt.
+    // MAS builds substitute the Request Support link, matching the toolbar
+    // and Help menu build-conditional behavior. No LLM involvement.
+    if (command.toolName === 'report-bug') {
+      if (getApi().isMasBuild) {
+        getApi().openExternal?.(MAS_SUPPORT_URL)
+      } else {
+        requestBugReport(BUG_REPORT_URL)
+      }
+      return
+    }
+
+    // Handle /request-feature - chat-layer shortcut to the GitHub feature
+    // request template. No LLM involvement.
+    if (command.toolName === 'request-feature') {
+      getApi().openExternal?.(FEATURE_REQUEST_URL)
+      return
+    }
+
     // Handle /help specially
     if (command.toolName === 'help') {
       const { addMessage } = useChatStore.getState()
@@ -292,6 +323,8 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
 • **/open_file** — Open a file
 • **/save_file** — Save to file
 • **/read_file** — Read file contents
+• **/report-bug** — Report a bug on GitHub
+• **/request-feature** — Request a feature on GitHub
 
 *Tip: Select a command from the dropdown to execute it immediately, or type arguments after the command.*`,
         timestamp: new Date()
@@ -553,6 +586,16 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
 
       // Handle /clear and /new (both are direct-exec)
       if (command.toolName === 'clear' || command.toolName === 'new') {
+        setMessage('')
+        setTimeout(() => textareaRef.current?.focus(), 0)
+        await handleDirectExec(command)
+        return
+      }
+
+      // Handle /report-bug and /request-feature — chat-layer feedback
+      // shortcuts. They aren't AI tools, so route them to direct-exec here
+      // before the tool-registry validation below. No LLM involvement.
+      if (command.toolName === 'report-bug' || command.toolName === 'request-feature') {
         setMessage('')
         setTimeout(() => textareaRef.current?.focus(), 0)
         await handleDirectExec(command)


### PR DESCRIPTION
Closes #716

## What & why

Adds two chat-input slash commands so users can file feedback without leaving the chat panel:

- **`/report-bug`** — routes through the existing `requestBugReport()` flow (preserves the Sentry error-reporting opt-in prompt) and opens the GitHub bug-report template. On MAS builds it substitutes the **Request Support** link (`https://solo.ist/prose/support`), matching the build-conditional behavior already used by the Toolbar "More" menu and the Help menu.
- **`/request-feature`** — opens the GitHub feature-request template.

Both are wired as `directExecCommands` (instant, **zero LLM involvement**), mirroring the `/clear` and `/help` pattern. They appear in the `/` autocomplete dropdown with descriptions and are listed in `/help`.

All changes are confined to `src/renderer/components/chat/ChatInput.tsx`. No AI tool registry, backend, preload, main-process, or GitHub-token changes. URLs reuse the exact templates already shipped elsewhere in the app.

## Validation

- `npx electron-vite build` — clean (main, preload, renderer all bundled, TypeScript compiled with no errors). Note: the full `npm run build` chain has a pre-existing `build:skill` step that requires `zip`, which is unavailable in this sandbox; that step is unrelated to this change.

## Manual QA

1. Open the chat panel and type `/` — confirm `/report-bug` and `/request-feature` appear in the autocomplete with descriptions.
2. Select `/request-feature` — the GitHub feature-request template opens in the browser; no message is sent to the LLM.
3. With Error Reporting **disabled**, select `/report-bug` — the "Help us fix what you're reporting" Sentry opt-in dialog appears; choosing either option then opens the GitHub bug-report template.
4. With Error Reporting **enabled** (or after dismissing the prompt once), select `/report-bug` — the bug-report template opens directly with no prompt.
5. Type `/report-bug` (or `/request-feature`) and press Enter instead of selecting from the dropdown — confirm the same behavior and that nothing is sent to the LLM.
6. Run `/help` — confirm both commands are listed in the catalog.
7. (MAS build, if available) `/report-bug` opens `https://solo.ist/prose/support` instead of the GitHub template.

_Conversation: https://app.warp.dev/conversation/0b1bff28-1d16-4676-b462-ddf3734c581b_
_Run: https://oz.warp.dev/runs/019ec2f7-1bcc-7d46-b4bf-ede9da886e01_

_This PR was generated with [Oz](https://warp.dev/oz)._
