### PR TITLE
feat: wire Add to Favorites into chat list_files file tree

### DIFF
--- a/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { FileTree } from '../../files/FileTree'
 import { useTabs } from '../../../hooks/useTabs'
 import { useFileListStore } from '../../../stores/fileListStore'
+import { useSettingsStore } from '../../../stores/settingsStore'
+import { useFavorites } from '../../../stores/projectsStore'
 import type { FileItem } from '../../../types'
 
 interface ListFilesResultProps {
@@ -54,6 +56,27 @@ export function ListFilesResult({ content }: ListFilesResultProps) {
   )
   const { openFileInPreviewTab } = useTabs()
 
+  // Subscribe to favorites once and pass a path Set down the tree (parity with
+  // FileListPanel), so favorited files show the star and the tree avoids a
+  // per-item settingsStore subscription.
+  const favorites = useFavorites()
+  const favoritePaths = useMemo(() => new Set(favorites.map((f) => f.path)), [favorites])
+
+  // Add a path to the persisted favorites list. Idempotent: dedup by path so
+  // re-adding is a no-op. Mirrors FileListPanel.addPathAsFavorite.
+  const addPathAsFavorite = useCallback((path: string, isDirectory: boolean) => {
+    const existing = useSettingsStore.getState().settings.favorites ?? []
+    if (existing.some((f) => f.path === path)) return
+    const name = path.split('/').pop() || path
+    useSettingsStore.getState().addFavorite({
+      id: self.crypto.randomUUID(),
+      name,
+      path,
+      isDirectory,
+      addedAt: new Date().toISOString(),
+    })
+  }, [])
+
   let parsed: ListFilesEnvelope | null = null
   try {
     const cleaned = content.replace(/```json\n?|\n?```/g, '').trim()
@@ -93,10 +116,12 @@ export function ListFilesResult({ content }: ListFilesResultProps) {
     <div className="text-xs">
       <FileTree
         items={files}
+        favoritePaths={favoritePaths}
         expandedFolders={expandedFolders}
         selectedPath={null}
         onFileClick={handleFileClick}
         onFolderToggle={handleFolderToggle}
+        onAddFavorite={addPathAsFavorite}
       />
       {payload.truncated && payload.totalFound !== undefined && (
         <div className="mt-2 text-[11px] text-muted-foreground">


### PR DESCRIPTION
## What
Wire the **Add to Favorites** context-menu action into the chat-side `list_files` file tree so it matches the file explorer panel.

## Why
Closes #728

The chat tool-result renderer `ListFilesResult.tsx` rendered the shared `FileTree` component without an `onAddFavorite` handler (and without `favoritePaths`), so right-clicking a file/folder in a chat `list_files` result showed no "Add to Favorites" item. The wired explorer (`FileListPanel.tsx`) already passes `addPathAsFavorite`; this change brings the chat tree to parity.

## Changes
- `src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx`:
  - Subscribe to favorites via `useFavorites()` and thread a `favoritePaths` Set into `FileTree` (so favorited files show the star, matching the explorer).
  - Add an idempotent `addPathAsFavorite(path, isDirectory)` that dedupes by path and persists through `settingsStore.addFavorite`, mirroring `FileListPanel.addPathAsFavorite`.
  - Pass both into the rendered `FileTree`.

No new dependencies, no UI library changes. All added hooks run before any early return. No privilege-boundary (`src/main`, `src/preload`, builder config) or hot-file changes.

## Validation
- `npm run build` succeeds (exit 0).

## Manual QA
1. Build/run the app (`npm run dev`) with at least one folder open in the file explorer.
2. In chat, ask the assistant to list files (e.g. "list files in this folder") so a `list_files` tool result renders its file tree.
3. Right-click a **file** in that chat result tree → confirm an **Add to Favorites** item now appears; click it.
4. Open the **Favorites** view in the file explorer panel → confirm the file is listed.
5. Right-click the same file again in chat and click **Add to Favorites** again → confirm it is **not** duplicated in Favorites (dedupe by path).
6. Right-click a **folder** in the chat result tree → confirm **Add to Favorites** appears and adding it persists as a directory favorite.
7. Reload the app → confirm the favorites persist (written to settings).
8. Confirm files already favorited show the star indicator in the chat tree.

_Conversation: https://app.warp.dev/conversation/e95dead9-dc0f-46df-a3df-f5388211eabb_
_Run: https://oz.warp.dev/runs/019ec2f7-c6a5-7184-a723-f3810dfec596_

_This PR was generated with [Oz](https://warp.dev/oz)._
