### PR TITLE
fix(editor): preserve caret on click when promoting preview tab (#729)

### DIFF
--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -532,8 +532,13 @@ export function Editor() {
   useEffect(() => {
     // Only focus once per document load
     if (hasFocusedRef.current) return
-    // Don't steal focus during preview tab navigation
-    if (useEditorStore.getState().isPreviewTab) return
+    // Don't steal focus during preview tab navigation. Mark focus as handled so a
+    // later promotion to a permanent tab (e.g. the user clicks mid-document) doesn't
+    // re-run this effect and yank the caret/scroll back to the top (#729).
+    if (useEditorStore.getState().isPreviewTab) {
+      hasFocusedRef.current = true
+      return
+    }
 
     const shouldShowEmptyState = !isEditing && !document.path && !document.content && !document.isDirty
     if (editor && !shouldShowEmptyState) {


### PR DESCRIPTION
Closes #729

## What & why
Clicking into a document body for the first time after opening it as a **preview tab** caused the caret and viewport to jump to the top, discarding the click position.

**Root cause:** the auto-focus effect in `src/renderer/components/editor/Editor.tsx` returned early when `isPreviewTab` was true *without* marking `hasFocusedRef.current = true`. When the user clicked mid-document, `promoteCurrentPreview()` flipped the tab to permanent (`isPreviewTab → false`), the effect re-ran with `hasFocusedRef` still `false`, and it executed `editor.commands.focus('start')` + `scrollTop = 0` — overriding the caret/scroll the click had just set.

**Fix:** mark `hasFocusedRef.current = true` in the preview short-circuit so a later promotion no longer re-triggers the one-shot focus/scroll. Fresh permanent opens (double-click) are unaffected because `isPreviewTab` is `false` from the start, so the focus-at-top behavior still runs once.

Single-file, renderer-only change. No privilege-boundary or hot-file touches.

## Manual QA
1. Open a document from the explorer with a single click (preview tab) — content long enough to scroll.
2. Without clicking into the body, scroll down to the middle of the document.
3. Click into the body mid-document.
   - **Expected:** caret lands where you clicked; no jump to the top.
4. Open a fresh document via double-click (permanent tab).
   - **Expected:** it starts at the top with the caret ready (unchanged behavior).
5. Re-open the same preview document and confirm double-click/permanent opens behave as before.

_Conversation: https://app.warp.dev/conversation/e2b7168a-5330-4196-a697-605dc105526f_
_Run: https://oz.warp.dev/runs/019ec2f7-f76b-7c23-9808-c131e490844b_

_This PR was generated with [Oz](https://warp.dev/oz)._
