### PR TITLE
feat(tabs): complete tab right-click menu (Favorites + reveal in file explorer) (#717)

### DIFF
--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback, type MouseEvent, type KeyboardEvent } from 'react'
 import { Reorder } from 'framer-motion'
-import { X, FileText, Eye, Plus } from 'lucide-react'
+import { X, FileText, Eye, Plus, Star, ExternalLink } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import { useTabStore, type Tab } from '../../stores/tabStore'
 import { useEditorStore } from '../../stores/editorStore'
@@ -23,6 +23,7 @@ import { useSettingsStore } from '../../stores/settingsStore'
 import { useTabEmoji } from '../../hooks/useTabEmoji'
 import { regenerateEmoji } from '../../lib/emojiService'
 import { useSettings } from '../../hooks/useSettings'
+import { isMacOS } from '../../lib/browserApi'
 
 interface TabBarProps {
   onTabClick: (tabId: string) => void
@@ -278,6 +279,23 @@ function TabItem({
     regenerateEmoji(tab)
   }, [tab])
 
+  // Add the tab's file to global Favorites. Untitled (unsaved) tabs have no
+  // path to point at, so the menu item is disabled for them. Dedup by path
+  // like the file-tree version (FileListPanel.addPathAsFavorite).
+  const handleAddFavorite = useCallback(() => {
+    if (!tab.path) return
+    const existing = useSettingsStore.getState().settings.favorites ?? []
+    if (existing.some((f) => f.path === tab.path)) return
+    const name = tab.path.split('/').pop() || tab.path
+    useSettingsStore.getState().addFavorite({
+      id: self.crypto.randomUUID(),
+      name,
+      path: tab.path,
+      isDirectory: false,
+      addedAt: new Date().toISOString(),
+    })
+  }, [tab.path])
+
   // Shorten path: replace /Users/<username> with ~
   const displayPath = tab.path?.replace(/^\/Users\/[^/]+/, '~') ?? null
 
@@ -416,25 +434,33 @@ function TabItem({
         </ContextMenuTrigger>
         <ContextMenuContent>
           <ContextMenuItem onClick={onClose}>
-            Close
+            Close Tab
           </ContextMenuItem>
           <ContextMenuItem
             onClick={onCloseOthers}
             disabled={tabs.length <= 1}
           >
-            Close Others
+            Close All Other Tabs
           </ContextMenuItem>
-          <ContextMenuSeparator />
+          <ContextMenuItem onClick={onCloseAll}>
+            Close All Tabs
+          </ContextMenuItem>
           {showEmoji && (
             <>
+              <ContextMenuSeparator />
               <ContextMenuItem onClick={handleRegenEmoji}>
                 Regenerate Emoji
               </ContextMenuItem>
-              <ContextMenuSeparator />
             </>
           )}
-          <ContextMenuItem onClick={onCloseAll}>
-            Close All
+          <ContextMenuSeparator />
+          <ContextMenuItem onClick={handleAddFavorite} disabled={!tab.path}>
+            <Star className="h-4 w-4 mr-2" />
+            Add to Favorites
+          </ContextMenuItem>
+          <ContextMenuItem onClick={onShowInFolder} disabled={!tab.path}>
+            <ExternalLink className="h-4 w-4 mr-2" />
+            {isMacOS() ? 'Show in Finder' : 'Open in File Explorer'}
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>


### PR DESCRIPTION
## Summary
Completes the editor tab right-click context menu (#717) by wiring two existing capabilities into the menu and aligning close-action wording. No new IPC channels, store actions, or UI primitives were added.

**What changed in `src/renderer/components/layout/TabBar.tsx`:**
- **Add to Favorites** — new menu item that calls `useSettingsStore.addFavorite(...)` with the tab's path. Dedups by path (matching `FileListPanel.addPathAsFavorite`) and is **disabled for untitled/unsaved tabs** (`tab.path === null`).
- **Show in Finder / Open in File Explorer** — surfaces the already-existing `onShowInFolder` handler (→ `window.api.showInFolder` → `shell.showItemInFolder`) as a menu item. Label switches via `isMacOS()`; **disabled for untitled tabs**.
- **Wording alignment** — `Close` → `Close Tab`, `Close Others` → `Close All Other Tabs`, `Close All` → `Close All Tabs`.
- Added `Star` / `ExternalLink` icons to mirror the FileTree context-menu styling.

Existing close actions and the conditional Regenerate Emoji item are unchanged.

## Why
The tab context menu already offered the close actions and the "Show in Finder" plumbing existed end-to-end but was never surfaced in the menu. This finishes the requested five-option menu.

## Manual QA steps
1. Run `npm run dev` and open a saved markdown file in a tab.
2. Right-click the tab — verify all five options appear: **Close Tab**, **Close All Other Tabs**, **Close All Tabs**, **Add to Favorites**, **Show in Finder** (or **Open in File Explorer** on Windows/Linux).
3. Click **Add to Favorites** — confirm the file appears under Favorites in the Files panel. Right-click again and click **Add to Favorites** a second time — confirm it is **not** duplicated.
4. Click **Show in Finder** / **Open in File Explorer** — confirm the OS file manager opens with the file revealed.
5. Open a new **untitled** (unsaved) tab and right-click it — confirm **Add to Favorites** and **Show in Finder** are **disabled**, while the close actions still work.
6. Confirm existing behavior is intact: **Close Tab**, **Close All Other Tabs** (disabled when only one tab is open), **Close All Tabs**, and the conditional **Regenerate Emoji** item.

Closes #717

_Conversation: https://app.warp.dev/conversation/41583e95-afbd-485d-9574-787fd5860741_
_Run: https://oz.warp.dev/runs/019ec2f7-4ca3-716c-9b1f-5758bb5dfe8a_

_This PR was generated with [Oz](https://warp.dev/oz)._
