### PR TITLE
feat(chat): arrow-key roving tabindex for the Chat/Activity tablist (#719)

### DIFF
--- a/e2e/electron.activity-panel.spec.ts
+++ b/e2e/electron.activity-panel.spec.ts
@@ -131,6 +131,39 @@ test.describe('Electron — Activity panel', () => {
     await expect(page.getByTestId('annotation-detached-badge')).toBeVisible()
   })
 
+  test('arrow keys move focus + selection across the tablist (#719)', async () => {
+    // Land on the Chat tab; roving tabindex puts focus on the active tab.
+    const chatTab = page.getByRole('tab', { name: 'Chat' })
+    const activityTab = page.getByRole('tab', { name: /Activity/ })
+    await chatTab.click()
+    await chatTab.focus()
+    await expect(chatTab).toHaveJSProperty('tabIndex', 0)
+    await expect(activityTab).toHaveJSProperty('tabIndex', -1)
+
+    // ArrowRight → focus + select Activity.
+    await page.keyboard.press('ArrowRight')
+    await expect(activityTab).toBeFocused()
+    await expect(activityTab).toHaveAttribute('aria-selected', 'true')
+    await expect(activityTab).toHaveJSProperty('tabIndex', 0)
+    await expect(chatTab).toHaveJSProperty('tabIndex', -1)
+
+    // ArrowRight wraps back to Chat.
+    await page.keyboard.press('ArrowRight')
+    await expect(chatTab).toBeFocused()
+    await expect(chatTab).toHaveAttribute('aria-selected', 'true')
+
+    // ArrowLeft wraps to the last tab (Activity); End stays on it; Home returns.
+    await page.keyboard.press('ArrowLeft')
+    await expect(activityTab).toBeFocused()
+    await expect(activityTab).toHaveAttribute('aria-selected', 'true')
+    await page.keyboard.press('Home')
+    await expect(chatTab).toBeFocused()
+    await expect(chatTab).toHaveAttribute('aria-selected', 'true')
+    await page.keyboard.press('End')
+    await expect(activityTab).toBeFocused()
+    await expect(activityTab).toHaveAttribute('aria-selected', 'true')
+  })
+
   test('chat actions stay visible on the Activity tab (#688)', async () => {
     // On the Activity tab, the chat action cluster must NOT disappear.
     await page.getByRole('tab', { name: /Activity/ }).click()

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -28,6 +28,8 @@ import { cn } from '../../lib/utils'
 export function ChatPanel() {
   const { messages, isLoading, isStreaming, sendMessage, stopGeneration, clearMessages } = useChat()
   const scrollRef = useRef<HTMLDivElement>(null)
+  const chatTabRef = useRef<HTMLButtonElement>(null)
+  const activityTabRef = useRef<HTMLButtonElement>(null)
   const reviewMode = useReviewMode()
   const [infoOpen, setInfoOpen] = useState(false)
   const [sidebarMode, setSidebarMode] = useState<'chat' | 'activity'>('chat')
@@ -148,6 +150,40 @@ export function ChatPanel() {
     sendMessage(userContent)
   }, [messages, sendMessage])
 
+  // Roving-tabindex arrow-key navigation for the Chat/Activity tablist
+  // (WAI-ARIA tabs pattern). Left/Right move focus between tabs and wrap at
+  // the ends; Home/End jump to the first/last. Activation follows focus.
+  const handleTabKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      const tabs = [
+        { mode: 'chat' as const, ref: chatTabRef },
+        { mode: 'activity' as const, ref: activityTabRef },
+      ]
+      const current = tabs.findIndex((t) => t.mode === sidebarMode)
+      let next = current
+      switch (e.key) {
+        case 'ArrowRight':
+          next = (current + 1) % tabs.length
+          break
+        case 'ArrowLeft':
+          next = (current - 1 + tabs.length) % tabs.length
+          break
+        case 'Home':
+          next = 0
+          break
+        case 'End':
+          next = tabs.length - 1
+          break
+        default:
+          return
+      }
+      e.preventDefault()
+      setSidebarMode(tabs[next].mode)
+      tabs[next].ref.current?.focus()
+    },
+    [sidebarMode]
+  )
+
   const handleNewChat = () => {
     // Land in the chat view so the new conversation is visible, even if the
     // action was invoked from the Activity tab.
@@ -183,11 +219,14 @@ export function ChatPanel() {
         <div className="flex items-center gap-3">
           <div role="tablist" aria-label="Chat panel views" className="flex items-center gap-3">
             <button
+              ref={chatTabRef}
               role="tab"
               aria-selected={sidebarMode === 'chat'}
               aria-controls="chat-tabpanel"
               id="chat-tab-chat"
+              tabIndex={sidebarMode === 'chat' ? 0 : -1}
               onClick={() => setSidebarMode('chat')}
+              onKeyDown={handleTabKeyDown}
               className={cn(
                 'text-sm border-b-2 pb-1 -mb-px transition-colors',
                 sidebarMode === 'chat'
@@ -198,11 +237,14 @@ export function ChatPanel() {
               Chat
             </button>
             <button
+              ref={activityTabRef}
               role="tab"
               aria-selected={sidebarMode === 'activity'}
               aria-controls="chat-tabpanel"
               id="chat-tab-activity"
+              tabIndex={sidebarMode === 'activity' ? 0 : -1}
               onClick={() => setSidebarMode('activity')}
+              onKeyDown={handleTabKeyDown}
               className={cn(
                 'flex items-center gap-1.5 text-sm border-b-2 pb-1 -mb-px transition-colors',
                 sidebarMode === 'activity'


### PR DESCRIPTION
## What & why
Follow-up to #686 (PR #718). The Chat/Activity tab buttons were converted to a proper ARIA tablist (`role="tablist"` + `role="tab"` + `aria-selected`, with a `role="tabpanel"`), but the WAI-ARIA [tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) keyboard behavior was deliberately deferred. This adds it.

Closes #719

## Changes
- `src/renderer/components/chat/ChatPanel.tsx`
  - **Roving tabindex**: the active tab gets `tabindex="0"`, the inactive one `tabindex="-1"`, so Tab lands on the tablist once and arrows navigate within it.
  - **Arrow-key handler** (`onKeyDown` on both tabs): `ArrowLeft`/`ArrowRight` move focus + selection between the two tabs and wrap at the ends; `Home`/`End` jump to the first/last tab. Activation follows focus (standard for a 2-tab automatic-activation tablist).
- `e2e/electron.activity-panel.spec.ts` — new keyboard-nav test asserting roving `tabIndex`, focus movement, wrapping, and `aria-selected` across Arrow/Home/End.

## Reviewer notes
- `ChatPanel.tsx` is on the skill's "hot" coordination file list, but this issue is specifically scoped to it. No privilege-boundary (`src/main`, `src/preload`, electron config) files touched.
- Change is additive only (refs + handler + attributes); no behavior change to mouse/click selection.

## Validation
- `npx electron-vite build` — clean (exit 0). The full `npm run build` only fails at the unrelated `build:skill` step because the `zip` binary is unavailable in the sandbox (no network for `apt`); it does not touch app code.
- `npm run typecheck:e2e` — clean (exit 0).

## Manual QA
1. Launch the app and open the chat sidebar (`Cmd/Ctrl+Shift+L`).
2. Press `Tab` until focus lands on the **Chat** tab — only one tab should be in the tab order.
3. Press `ArrowRight`: focus and selection move to **Activity** (the Activity panel shows).
4. Press `ArrowRight` again: it wraps back to **Chat**.
5. Press `ArrowLeft`: it wraps to **Activity** (last tab).
6. Press `Home`: focus + selection jump to **Chat**; press `End`: jump to **Activity**.
7. Confirm mouse clicks on each tab still switch views as before.

---
_Conversation: https://app.warp.dev/conversation/bf717a4c-23bf-4809-a3c8-49e229b41136_
_Run: https://oz.warp.dev/runs/019ec2f7-7d15-7ead-8731-d17b1a2366e8_

_This PR was generated with [Oz](https://warp.dev/oz)._
