### PR TITLE
feat: disable Reopen Closed Tab menu item when stack is empty (#664)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { withRetry, getNetworkErrorMessage } from '../shared/utils/retry'
 import { getDefaultModel, getDefaultHaikuModel } from '../shared/llm/models'
 import { getSettingsDir, LEGACY_SETTINGS_DIR } from './paths'
 import { clearRecentFiles } from './recentFiles'
-import { refreshMenu } from './menu'
+import { refreshMenu, setReopenClosedTabEnabled } from './menu'
 import { credentialStore } from './credentialStore'
 
 // Credential store keys
@@ -1462,6 +1462,12 @@ export function setupIpcHandlers(): void {
     clearRecentFiles()
     refreshMenu()
     app.clearRecentDocuments()
+  })
+
+  // Menu: Toggle the "Reopen Closed Tab" item based on the renderer's
+  // closed-tab stack (enabled when non-empty). Rebuilds the menu only on change.
+  ipcMain.handle('menu:setReopenClosedTabEnabled', async (_event, enabled: boolean) => {
+    setReopenClosedTabEnabled(!!enabled)
   })
 
   // Shell: Open external URL (for CMD+Click on links)

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -7,6 +7,12 @@ import { IS_MAS_BUILD } from './env'
 // Store mainWindow reference so we can rebuild the menu after adding recent files
 let _menuWindow: BrowserWindow | null = null
 
+// Tracks whether the renderer's session-only closed-tab stack has entries, so
+// the "Reopen Closed Tab" item can be grayed out when there's nothing to
+// reopen. Renderer-driven via the menu:setReopenClosedTabEnabled IPC handler
+// (see ipc.ts). Defaults to false because the stack is always empty at launch.
+let _reopenClosedTabEnabled = false
+
 // Helper to open an external URL without leaking an unhandled promise
 // rejection if the OS can't open the URL (e.g., no default browser).
 function openExternalUrl(url: string): void {
@@ -144,6 +150,7 @@ export function createMenu(mainWindow: BrowserWindow): void {
         {
           label: 'Reopen Closed Tab',
           accelerator: 'CmdOrCtrl+Shift+T',
+          enabled: _reopenClosedTabEnabled,
           click: (): void => {
             sendMenuAction('reopenClosedTab')
           }
@@ -412,4 +419,15 @@ export function refreshMenu(): void {
   if (_menuWindow && !_menuWindow.isDestroyed()) {
     createMenu(_menuWindow)
   }
+}
+
+/**
+ * Enable or disable the "Reopen Closed Tab" menu item based on whether the
+ * renderer's closed-tab stack has entries. Rebuilds the menu only when the
+ * state actually changes, avoiding needless menu churn on every tab event.
+ */
+export function setReopenClosedTabEnabled(enabled: boolean): void {
+  if (_reopenClosedTabEnabled === enabled) return
+  _reopenClosedTabEnabled = enabled
+  refreshMenu()
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -277,6 +277,8 @@ export interface ElectronAPI {
   // Recent files
   refreshRecentMenu: () => Promise<void>
   clearRecentFiles: () => Promise<void>
+  // Native menu: enable/disable "Reopen Closed Tab" based on closed-tab stack
+  setReopenClosedTabEnabled: (enabled: boolean) => Promise<void>
   // Clipboard
   copyToClipboard: (text: string) => Promise<void>
   // Sentry error tracking
@@ -545,6 +547,8 @@ const api: ElectronAPI = {
   // Recent files
   refreshRecentMenu: () => ipcRenderer.invoke('recentFiles:refreshMenu'),
   clearRecentFiles: () => ipcRenderer.invoke('recentFiles:clear'),
+  // Native menu: enable/disable "Reopen Closed Tab" based on closed-tab stack
+  setReopenClosedTabEnabled: (enabled: boolean) => ipcRenderer.invoke('menu:setReopenClosedTabEnabled', enabled),
   // Clipboard (routes through main process, bypasses web Permissions Policy)
   copyToClipboard: (text: string) => ipcRenderer.invoke('clipboard:writeText', text),
   // Sentry error tracking

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -861,6 +861,20 @@ export function App() {
     return unsubscribe
   }, [openFileInTab, saveFile, saveFileAs, createNewTab, setDialogOpen, toggleChat, toggleFileList, isFileListOpen, setShortcutsDialogOpen, setAboutDialogOpen, editor, handleGoogleSync, handleGoogleImport, reopenLastClosedTab])
 
+  // Keep the native "Reopen Closed Tab" menu item enabled only while the
+  // session-only closed-tab stack has entries. Push the current emptiness to
+  // the main process on mount and whenever it flips (no-op in web mode).
+  useEffect(() => {
+    const api = getApi()
+    api.setReopenClosedTabEnabled(useTabStore.getState().closedTabs.length > 0)
+    return useTabStore.subscribe(
+      (state) => state.closedTabs.length > 0,
+      (hasClosedTabs) => {
+        api.setReopenClosedTabEnabled(hasClosedTabs)
+      }
+    )
+  }, [])
+
   // Handle menu:new custom event (dispatched by Editor keyboard handler for Cmd+N in web mode)
   useEffect(() => {
     const handleMenuNew = () => createNewTab()

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -485,6 +485,9 @@ export const browserApi: ElectronAPI = {
   refreshRecentMenu: async (): Promise<void> => {},
   clearRecentFiles: async (): Promise<void> => {},
 
+  // Native menu state - no-op in browser (no native menu)
+  setReopenClosedTabEnabled: async (): Promise<void> => {},
+
   // Clipboard - use browser API in web mode
   copyToClipboard: async (text: string): Promise<void> => { await navigator.clipboard.writeText(text) },
 


### PR DESCRIPTION
> **⚠️ Privilege-boundary change — security gate, focus here:** This PR edits the Electron **main process** menu (`src/main/menu.ts`) and the main↔renderer IPC surface (`src/main/ipc.ts`, `src/preload/index.ts`). It adds one new IPC channel (`menu:setReopenClosedTabEnabled`) that only toggles a boolean and rebuilds the application menu. **No sandbox/security settings are touched** — `contextIsolation`, `nodeIntegration`, and sandbox flags are unchanged. The new handler takes a single boolean (coerced with `!!`), invokes no shell/filesystem/network APIs, and exposes no new data to the renderer.

## What & why

Follow-up to #646 (PR #661). The native **Reopen Closed Tab** (`Cmd+Shift+T`) menu item was always enabled, even when the closed-tab stack is empty. The renderer handler already no-ops in that case, but a grayed-out item gives better affordance.

This plumbs the renderer's session-only closed-tab stack emptiness into the main-process menu, mirroring the existing recent-files state-broadcast / `refreshMenu` pattern:

- `src/main/menu.ts` — track `_reopenClosedTabEnabled` (defaults `false`; the stack is always empty at launch), apply it to the menu item's `enabled`, and add `setReopenClosedTabEnabled()` which rebuilds the menu **only when the value changes**.
- `src/main/ipc.ts` — new `menu:setReopenClosedTabEnabled` IPC handler.
- `src/preload/index.ts` — expose `setReopenClosedTabEnabled(enabled)` on the context bridge.
- `src/renderer/lib/browserApi.ts` — no-op in web mode (no native menu).
- `src/renderer/components/layout/App.tsx` — push initial emptiness on mount and subscribe to `tabStore.closedTabs` length, syncing only when it flips between empty/non-empty.

## Verification

- `npx electron-vite build` + `npm run build:preload` — compiles clean (exit 0). The full `npm run build` only fails at the unrelated `build:skill` step because `zip` is not installed in this sandbox.
- No unit suite exists for this area (per `AGENTS.md`); manual QA steps below.

## Manual QA (Electron, macOS)

1. Launch the app fresh (no tabs closed yet). Open the **File** menu → confirm **Reopen Closed Tab** is **grayed out / disabled**.
2. Open or create a couple of tabs, then close one (`Cmd+W`). Open **File** → confirm **Reopen Closed Tab** is now **enabled**.
3. Press `Cmd+Shift+T` (or click the item) → the closed tab reopens.
4. Close tabs until the closed-tab stack is empty again (reopen everything you closed) → confirm the item returns to **disabled**.
5. Repeat close/reopen a few times → confirm the enabled/disabled state tracks the stack correctly with no stale state.

_Conversation: https://app.warp.dev/conversation/3f0936cb-518f-4021-9a1a-5ad653252fd8_
_Run: https://oz.warp.dev/runs/019ec2f8-7375-7d50-adeb-467043c7e952_

_This PR was generated with [Oz](https://warp.dev/oz)._
