### PR TITLE
fix(sentry): use Classic IPC for runtime main-process init (#655)

### DIFF
--- a/src/main/sentry.ts
+++ b/src/main/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/electron/main'
+import { IPCMode } from '@sentry/electron/main'
 import { app } from 'electron'
 import { is } from '@electron-toolkit/utils'
 
@@ -40,12 +41,24 @@ function beforeSend(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
 export function initSentry(enabled: boolean): void {
   if (!enabled || initialized) return
 
+  // The default IPC mode (Protocol + Classic) registers a privileged `sentry-ipc:`
+  // scheme, which @sentry/electron requires to happen BEFORE the app 'ready' event
+  // and otherwise throws "Sentry SDK should be initialized before the Electron app
+  // 'ready' event is fired". The launch-time path (src/main/index.ts) inits before
+  // whenReady so the default is fine there, but the runtime opt-in path (Settings
+  // toggle → sentry:setEnabled) runs after 'ready'. In that case fall back to Classic
+  // IPC, which needs no pre-ready scheme registration. Renderer→main envelope
+  // forwarding is unaffected: the renderer prefers the preload-injected Classic IPC
+  // (window.__SENTRY_IPC__) and only uses the sentry-ipc: protocol as a fallback.
+  const ipcMode = app.isReady() ? IPCMode.Classic : IPCMode.Both
+
   Sentry.init({
     dsn: SENTRY_DSN,
     environment: is.dev ? 'development' : 'production',
     release: app.getVersion(),
     sampleRate: 0.5,
     maxBreadcrumbs: 30,
+    ipcMode,
     beforeSend
   })
   initialized = true


### PR DESCRIPTION
> ⚠️ **Privilege boundary: this PR touches the Electron MAIN process** (`src/main/sentry.ts`). The only change selects the `@sentry/electron` IPC mode at init time. **No sandbox/security settings are changed** — `contextIsolation`, `nodeIntegration`, CSP, and the privileged `sentry-ipc:` scheme registration are all untouched. The privacy invariant ("Sentry never initializes unless `errorTracking.enabled === true`") is preserved: this only changes *how* the SDK wires IPC when it does init, never *whether* it inits.

Closes #655

## What
When error reporting is enabled **at runtime** (Settings toggle while the app is already running), the renderer fires `sentry:setEnabled(true)` → main `setSentryEnabled(true)` → `initSentry(true)` → `Sentry.init()`. Because this happens *after* the Electron `app` `ready` event, `@sentry/electron`'s default IPC mode (`Both` = Protocol + Classic) tries to register the privileged `sentry-ipc:` scheme, which it requires to happen *before* `ready`, producing:

```
Sentry SDK should be initialized before the Electron app 'ready' event is fired
```

This change makes `initSentry()` select the IPC mode based on app state:

- **Pre-`ready` (launch path, `src/main/index.ts`)** — unchanged: default `IPCMode.Both`.
- **Post-`ready` (runtime opt-in path)** — `IPCMode.Classic`, which needs no pre-`ready` scheme registration and therefore does not emit the warning.

## Why it's safe
Renderer→main envelope forwarding is unaffected: the renderer prefers the preload-injected Classic IPC (`window.__SENTRY_IPC__`) and only falls back to the `sentry-ipc:` custom protocol when Classic isn't available. So crash reports still reach the main process in the same session, and the launch-time Protocol path (covered by #391's CSP fix) is unchanged.

## Files
- `src/main/sentry.ts` — choose `ipcMode` based on `app.isReady()`; add `IPCMode` import.

## Validation
- `electron-vite build` compiles cleanly (main/preload/renderer). Note: the full `npm run build` script also runs `build:skill`, which fails in this sandbox only because `zip` is not installed — unrelated to this change.

## Manual QA
1. Build and launch the app with error reporting **off** (`errorTracking.enabled` false / fresh profile).
2. Open Settings → General → **Error Reporting** and toggle it **on** while the app is running.
3. Open the main-process console/logs and confirm the `Sentry SDK should be initialized before the Electron app 'ready' event is fired` warning **no longer appears**, and `[Sentry] Main process initialized` is logged.
4. Trigger a main-process or renderer error (e.g. via a dev error path) and confirm a crash report is still captured in the same session (Classic IPC path works).
5. Fully quit and relaunch with the setting **on**; confirm startup is clean (pre-`ready` Protocol path) and `[Sentry] Main process initialized` logs without warning.
6. Toggle Error Reporting **off** and confirm `[Sentry] Main process disabled` logs and no further reports are sent.

_Conversation: https://app.warp.dev/conversation/f297d358-8879-48f9-aa89-ac6ad86eb6ce_
_Run: https://oz.warp.dev/runs/019ec2f8-411e-7306-88ac-d70afef0b984_

_This PR was generated with [Oz](https://warp.dev/oz)._
