### PR TITLE
chore(skills): open PRs ready for review, not as drafts

### DIFF
--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: implement-issue
-description: Implement one solo-ist/prose GitHub issue end-to-end and open a draft PR. Use when an Oz child agent is assigned exactly one issue to fix or build in this repo.
+description: Implement one solo-ist/prose GitHub issue end-to-end and open a PR ready for review. Use when an Oz child agent is assigned exactly one issue to fix or build in this repo.
 ---
 
 # Implement Issue
 
 You are an autonomous coding agent assigned **exactly one** `solo-ist/prose` GitHub issue. Implement it on a
-fresh branch and open a **draft** PR. You own one clear slice of work — stay in your lane.
+fresh branch and open a PR ready for review. You own one clear slice of work — stay in your lane.
 
 This skill is the base context for Oz cloud children dispatched during a QoL parallelization wave. Cloud runs
 **do not inherit local Agent Profiles**, so every guardrail below is enforced here, in the prompt, and by repo
@@ -64,15 +64,16 @@ The task prompt names the issue number (e.g. "Implement #717"). That is the only
    change is UI-visible, describe the manual QA steps in the PR body.
 7. **Commit** with Conventional Commits and a required scope (e.g. `feat(editor): …`). `Closes #<n>` belongs
    in the PR body, not the commit subject — a bare `(#n)` does not auto-close.
-8. **Open a draft PR** targeting `main`, one PR for this issue only, body containing `Closes #<n>`, a summary of
-   *what* and *why*, and numbered human-verification steps. If Circuit Electron QA was required but not possible,
-   state that explicitly. Before opening it, run `git status` and confirm only the files this issue needs are
-   staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push your branch; never push to `main`.
+8. **Open a PR** targeting `main` (do **not** use `--draft`), one PR for this issue only, body containing
+   `Closes #<n>`, a summary of *what* and *why*, and numbered human-verification steps. If Circuit Electron QA
+   was required but not possible, state that explicitly. Before opening it, run `git status` and confirm only
+   the files this issue needs are staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push
+   your branch; never push to `main`.
 
 ## Hard prohibitions (do NOT do these — surface for a human instead)
 
 - **Never merge. Never push to `main` or any protected branch. Never force-push a shared branch.** You open a
-  draft PR and stop. A human reviews and merges.
+  PR and stop. A human reviews and merges.
 - **Never publish or distribute:** no `npm publish`, `gh release`, `vercel --prod`, `electron-builder --publish`,
   `xcrun iTMSTransporter` / `altool`. **App Store submission for review is never automated** — hard stop.
 - **Never reset `buildVersion`** in `electron-builder.yml` (it is global-monotonic).
@@ -89,5 +90,5 @@ The task prompt names the issue number (e.g. "Implement #717"). That is the only
 
 ## Output
 
-End your run with the **draft PR URL** and a 3–5 line summary: what changed, which files, how you validated, and
+End your run with the **PR URL** and a 3–5 line summary: what changed, which files, how you validated, and
 any privilege-boundary or hot-file touches a reviewer must check.

--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -25,33 +25,49 @@ The task prompt names the issue number (e.g. "Implement #717"). That is the only
 - **Never read or print secrets:** `.env*`, `.mcp.json`, `build/*.provisionprofile`, any `*.p8`, or
   `~/Library/Application Support/Prose/settings.json`.
 
+## Cloud sandbox rules (enforced here — no local profiles in cloud runs)
+
+- **One command per invocation — never chain with `&&`, `;`, or `|`.** Run each shell command as a separate
+  call. Chaining bypasses the auto-approve allowlist and causes permission failures.
+- **Commit scope is required:** `feat(<scope>):` not bare `feat:`. Match the scope to the subsystem you
+  touched (e.g. `feat(editor):`, `fix(chat):`, `fix(main):`).
+- **Build validation in this sandbox:** `npm run build` may succeed fully now that `zip` is pre-installed.
+  If it still fails at `build:skill`, fall back to `npx electron-vite build` for TypeScript validation — that
+  covers renderer/main/preload. Do **not** use `npx tsc -p tsconfig.json --noEmit`; it produces spurious
+  project-reference errors that are not real type errors.
+- **Circuit Electron / live-app verification is not available in the cloud sandbox.** If the issue's acceptance
+  criteria require it, add an explicit note in the PR body: "Circuit Electron QA could not be performed in
+  the cloud sandbox — manual verification required before merge."
+
 ## Workflow
 
-1. **Read the conventions.** `CLAUDE.md` and `AGENTS.md` at the repo root — commit format (Conventional
-   Commits), branch naming, PR format, security rules, UI conventions, and AGENTS.md's **Coding Conventions**
-   (`getApi()` over `window.api`; `validatePath()` on filesystem IPC; existing settings paths/types — no new
-   `homedir()+.prose`; gate unfinished features with `featureFlags.ts`; bump `DB_VERSION` for IndexedDB store
-   changes). Follow them exactly. **Instruction precedence** (AGENTS.md): system/user > AGENTS.md > CLAUDE.md
-   > area docs — if the issue conflicts with these, follow the higher-priority source and note the conflict in
+1. **Read the conventions first — do not skip this step.** Read `CLAUDE.md` and `AGENTS.md` at the repo root
+   before touching any code. Key rules: Conventional Commits with required scope, branch naming
+   `issue-<n>-<short-description>`, PR body must contain `Closes #<n>`, security rules, UI conventions, and
+   AGENTS.md's **Coding Conventions** (`getApi()` over `window.api`; `validatePath()` on filesystem IPC;
+   existing settings paths/types; gate unfinished features with `featureFlags.ts`; bump `DB_VERSION` for
+   IndexedDB store changes). **Instruction precedence** (AGENTS.md): system/user > AGENTS.md > CLAUDE.md >
+   area docs — if the issue conflicts with these, follow the higher-priority source and note the conflict in
    the PR. For a **complex/multi-file** issue, create `docs/issues/<n>/plan.md` first.
-2. **Fetch the issue.** `gh issue view <n>` (and its comments) to extract the problem and acceptance criteria.
+2. **Fetch the issue.** `gh issue view <n> -R solo-ist/prose` (and its comments) to extract the problem and
+   acceptance criteria. Note any file paths in the issue body exactly as written — do not reconstruct them.
 3. **Inspect before editing.** Locate the relevant files and read the surrounding code. Match its style, naming,
    and comment density. Do not introduce new UI libraries (shadcn/ui only) or new dependencies unless the issue
    requires it.
-4. **Branch.** `git fetch origin`, then branch off fresh `origin/main`:
-   `git checkout -b issue-<n>-<short-description>`. Confirm you are not on `main`.
+4. **Branch.** Run `git fetch origin` as a separate command. Then run `git checkout -b issue-<n>-<short-description>`
+   as a separate command. Confirm you are not on `main`. (Never chain these with `&&`.)
 5. **Implement the minimal change** that satisfies the acceptance criteria. Smallest correct diff. No drive-by
    refactors, no unrelated reformatting, no unused imports.
 6. **Validate — smallest sufficient check** (per AGENTS.md): `npm run build` for renderer/main/preload/shared
-   TypeScript; `npm run build:web` for web-specific changes; `npm run test:e2e` for Electron user flows when
-   practical, otherwise build and document manual verification. There is no unit suite — a clean build is the
-   floor. If the change is UI-visible, describe the manual QA steps in the PR body.
-7. **Commit** with Conventional Commits, referencing the issue (`Closes #<n>` belongs in the PR body, not the
-   subject — a bare `(#n)` does not auto-close).
+   TypeScript (falls back to `npx electron-vite build` if `build:skill` fails — see sandbox rules above).
+   `npm run build:web` for web-specific changes. There is no unit suite — a clean build is the floor. If the
+   change is UI-visible, describe the manual QA steps in the PR body.
+7. **Commit** with Conventional Commits and a required scope (e.g. `feat(editor): …`). `Closes #<n>` belongs
+   in the PR body, not the commit subject — a bare `(#n)` does not auto-close.
 8. **Open a draft PR** targeting `main`, one PR for this issue only, body containing `Closes #<n>`, a summary of
-   *what* and *why*, and numbered human-verification steps. Before opening it, run `git status` and confirm only
-   the files this issue needs are staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push
-   your branch; never push to `main`.
+   *what* and *why*, and numbered human-verification steps. If Circuit Electron QA was required but not possible,
+   state that explicitly. Before opening it, run `git status` and confirm only the files this issue needs are
+   staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push your branch; never push to `main`.
 
 ## Hard prohibitions (do NOT do these — surface for a human instead)
 

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: implement-issue
-description: Implement one solo-ist/prose GitHub issue end-to-end and open a draft PR. Use when an Oz child agent is assigned exactly one issue to fix or build in this repo.
+description: Implement one solo-ist/prose GitHub issue end-to-end and open a PR ready for review. Use when an Oz child agent is assigned exactly one issue to fix or build in this repo.
 ---
 
 # Implement Issue
 
 You are an autonomous coding agent assigned **exactly one** `solo-ist/prose` GitHub issue. Implement it on a
-fresh branch and open a **draft** PR. You own one clear slice of work — stay in your lane.
+fresh branch and open a PR ready for review. You own one clear slice of work — stay in your lane.
 
 This skill is the base context for Oz cloud children dispatched during a QoL parallelization wave. Cloud runs
 **do not inherit local Agent Profiles**, so every guardrail below is enforced here, in the prompt, and by repo
@@ -64,15 +64,16 @@ The task prompt names the issue number (e.g. "Implement #717"). That is the only
    change is UI-visible, describe the manual QA steps in the PR body.
 7. **Commit** with Conventional Commits and a required scope (e.g. `feat(editor): …`). `Closes #<n>` belongs
    in the PR body, not the commit subject — a bare `(#n)` does not auto-close.
-8. **Open a draft PR** targeting `main`, one PR for this issue only, body containing `Closes #<n>`, a summary of
-   *what* and *why*, and numbered human-verification steps. If Circuit Electron QA was required but not possible,
-   state that explicitly. Before opening it, run `git status` and confirm only the files this issue needs are
-   staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push your branch; never push to `main`.
+8. **Open a PR** targeting `main` (do **not** use `--draft`), one PR for this issue only, body containing
+   `Closes #<n>`, a summary of *what* and *why*, and numbered human-verification steps. If Circuit Electron QA
+   was required but not possible, state that explicitly. Before opening it, run `git status` and confirm only
+   the files this issue needs are staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push
+   your branch; never push to `main`.
 
 ## Hard prohibitions (do NOT do these — surface for a human instead)
 
 - **Never merge. Never push to `main` or any protected branch. Never force-push a shared branch.** You open a
-  draft PR and stop. A human reviews and merges.
+  PR and stop. A human reviews and merges.
 - **Never publish or distribute:** no `npm publish`, `gh release`, `vercel --prod`, `electron-builder --publish`,
   `xcrun iTMSTransporter` / `altool`. **App Store submission for review is never automated** — hard stop.
 - **Never reset `buildVersion`** in `electron-builder.yml` (it is global-monotonic).
@@ -89,5 +90,5 @@ The task prompt names the issue number (e.g. "Implement #717"). That is the only
 
 ## Output
 
-End your run with the **draft PR URL** and a 3–5 line summary: what changed, which files, how you validated, and
+End your run with the **PR URL** and a 3–5 line summary: what changed, which files, how you validated, and
 any privilege-boundary or hot-file touches a reviewer must check.

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -25,33 +25,49 @@ The task prompt names the issue number (e.g. "Implement #717"). That is the only
 - **Never read or print secrets:** `.env*`, `.mcp.json`, `build/*.provisionprofile`, any `*.p8`, or
   `~/Library/Application Support/Prose/settings.json`.
 
+## Cloud sandbox rules (enforced here — no local profiles in cloud runs)
+
+- **One command per invocation — never chain with `&&`, `;`, or `|`.** Run each shell command as a separate
+  call. Chaining bypasses the auto-approve allowlist and causes permission failures.
+- **Commit scope is required:** `feat(<scope>):` not bare `feat:`. Match the scope to the subsystem you
+  touched (e.g. `feat(editor):`, `fix(chat):`, `fix(main):`).
+- **Build validation in this sandbox:** `npm run build` may succeed fully now that `zip` is pre-installed.
+  If it still fails at `build:skill`, fall back to `npx electron-vite build` for TypeScript validation — that
+  covers renderer/main/preload. Do **not** use `npx tsc -p tsconfig.json --noEmit`; it produces spurious
+  project-reference errors that are not real type errors.
+- **Circuit Electron / live-app verification is not available in the cloud sandbox.** If the issue's acceptance
+  criteria require it, add an explicit note in the PR body: "Circuit Electron QA could not be performed in
+  the cloud sandbox — manual verification required before merge."
+
 ## Workflow
 
-1. **Read the conventions.** `CLAUDE.md` and `AGENTS.md` at the repo root — commit format (Conventional
-   Commits), branch naming, PR format, security rules, UI conventions, and AGENTS.md's **Coding Conventions**
-   (`getApi()` over `window.api`; `validatePath()` on filesystem IPC; existing settings paths/types — no new
-   `homedir()+.prose`; gate unfinished features with `featureFlags.ts`; bump `DB_VERSION` for IndexedDB store
-   changes). Follow them exactly. **Instruction precedence** (AGENTS.md): system/user > AGENTS.md > CLAUDE.md
-   > area docs — if the issue conflicts with these, follow the higher-priority source and note the conflict in
+1. **Read the conventions first — do not skip this step.** Read `CLAUDE.md` and `AGENTS.md` at the repo root
+   before touching any code. Key rules: Conventional Commits with required scope, branch naming
+   `issue-<n>-<short-description>`, PR body must contain `Closes #<n>`, security rules, UI conventions, and
+   AGENTS.md's **Coding Conventions** (`getApi()` over `window.api`; `validatePath()` on filesystem IPC;
+   existing settings paths/types; gate unfinished features with `featureFlags.ts`; bump `DB_VERSION` for
+   IndexedDB store changes). **Instruction precedence** (AGENTS.md): system/user > AGENTS.md > CLAUDE.md >
+   area docs — if the issue conflicts with these, follow the higher-priority source and note the conflict in
    the PR. For a **complex/multi-file** issue, create `docs/issues/<n>/plan.md` first.
-2. **Fetch the issue.** `gh issue view <n>` (and its comments) to extract the problem and acceptance criteria.
+2. **Fetch the issue.** `gh issue view <n> -R solo-ist/prose` (and its comments) to extract the problem and
+   acceptance criteria. Note any file paths in the issue body exactly as written — do not reconstruct them.
 3. **Inspect before editing.** Locate the relevant files and read the surrounding code. Match its style, naming,
    and comment density. Do not introduce new UI libraries (shadcn/ui only) or new dependencies unless the issue
    requires it.
-4. **Branch.** `git fetch origin`, then branch off fresh `origin/main`:
-   `git checkout -b issue-<n>-<short-description>`. Confirm you are not on `main`.
+4. **Branch.** Run `git fetch origin` as a separate command. Then run `git checkout -b issue-<n>-<short-description>`
+   as a separate command. Confirm you are not on `main`. (Never chain these with `&&`.)
 5. **Implement the minimal change** that satisfies the acceptance criteria. Smallest correct diff. No drive-by
    refactors, no unrelated reformatting, no unused imports.
 6. **Validate — smallest sufficient check** (per AGENTS.md): `npm run build` for renderer/main/preload/shared
-   TypeScript; `npm run build:web` for web-specific changes; `npm run test:e2e` for Electron user flows when
-   practical, otherwise build and document manual verification. There is no unit suite — a clean build is the
-   floor. If the change is UI-visible, describe the manual QA steps in the PR body.
-7. **Commit** with Conventional Commits, referencing the issue (`Closes #<n>` belongs in the PR body, not the
-   subject — a bare `(#n)` does not auto-close).
+   TypeScript (falls back to `npx electron-vite build` if `build:skill` fails — see sandbox rules above).
+   `npm run build:web` for web-specific changes. There is no unit suite — a clean build is the floor. If the
+   change is UI-visible, describe the manual QA steps in the PR body.
+7. **Commit** with Conventional Commits and a required scope (e.g. `feat(editor): …`). `Closes #<n>` belongs
+   in the PR body, not the commit subject — a bare `(#n)` does not auto-close.
 8. **Open a draft PR** targeting `main`, one PR for this issue only, body containing `Closes #<n>`, a summary of
-   *what* and *why*, and numbered human-verification steps. Before opening it, run `git status` and confirm only
-   the files this issue needs are staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push
-   your branch; never push to `main`.
+   *what* and *why*, and numbered human-verification steps. If Circuit Electron QA was required but not possible,
+   state that explicitly. Before opening it, run `git status` and confirm only the files this issue needs are
+   staged — no scratch/temp artifacts, no unrelated or other-agent changes. Push your branch; never push to `main`.
 
 ## Hard prohibitions (do NOT do these — surface for a human instead)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Key areas:
 
 - `src/main/` - Electron main process, IPC, settings, integrations, updater, Sentry, MCP bridge.
 - `src/preload/` - Context bridge for renderer-safe APIs.
-- `src/renderer/` - React app, TipTap editor, Zustand stores, UI components.
+- `src/renderer/` - React app, TipTap editor, Zustand stores, UI components. Chat tool-result renderers live in `src/renderer/components/chat/toolResultRenderers/` (e.g. `ListFilesResult.tsx`).
 - `src/shared/` - Shared schemas, tools, LLM utilities, and cross-process types.
 - `src/mcp-stdio/` - Stdio MCP server used by Claude Desktop.
 - `docs/` - Architecture notes, patterns, issue plans, troubleshooting, release docs, and `docs/roadmap.md` (the canonical roadmap + operating model).
@@ -73,6 +73,11 @@ There is no unit test suite. Choose the smallest verification that covers the ch
 - Web-specific changes: run `npm run build:web` or `npm run test:web` when behavior changed.
 - Electron user flows: run `npm run test:e2e` when practical, otherwise build and document manual verification.
 - E2E test changes: run `npm run typecheck:e2e` and the relevant Playwright command.
+
+**Cloud sandbox note:** If `npm run build` fails at the `build:skill` step (requires `zip`), fall back to
+`npx electron-vite build` — it validates renderer/main/preload TypeScript. Do **not** use
+`npx tsc -p tsconfig.json --noEmit`; it produces spurious project-reference errors (`TS6305`/`TS6306`) that
+are not real type errors in this multi-tsconfig project.
 
 ## Dev Server Safety
 

--- a/docs/issues/644/cloud-environments.md
+++ b/docs/issues/644/cloud-environments.md
@@ -12,32 +12,35 @@ run physically cannot push code.
 
 ---
 
-## Environment A — `prose-maint` (read + comment) · **day-one**
+## Environment A — `prose-maint` · `sJWY3YRhhmWx4CnNEr4ZUA` (read + comment)
 For the recurring maintenance workflows (board/roadmap drift, stale triage). Reads the repo + board, uses Claude
 to summarize, and posts a **single report** (comment or issue) behind a human-approval boundary.
 
 | Aspect | Value |
 |---|---|
-| Repo checkout | `solo-ist/prose`, default branch, shallow is fine (read-only) |
-| Runtime image | Node **20** (matches CI — `node-version: 20` in `.github/workflows/e2e.yml`/`web-e2e.yml`) |
-| Setup commands | `npm ci` *(only if a build/lint step is needed; pure `gh`-query workflows can skip install)* |
-| Secrets | `ANTHROPIC_API_KEY` (summarization). GitHub token scoped to **`issues:write` + `contents:read` only** — no `contents:write`, no `workflows`, no admin. |
-| Branch/PR perms | none — this env cannot create branches or PRs. Comment/issue only. |
+| Repo checkout | `solo-ist/prose`, default branch |
+| Runtime image | `warpdotdev/dev-base:latest-agents` (bundles `gh` + agent CLIs) |
+| Setup commands | `cd prose && npm ci --legacy-peer-deps` · `apt-get install -y zip 2>/dev/null \|\| true` · `git config --global user.email '442369+mrangelmarino@users.noreply.github.com'` · `git config --global user.name 'Angel Marino'` |
+| GitHub auth | Runtime `GH_TOKEN` from the Oz App — **do not** `gh auth login` in setup (secrets not injected at setup time) |
+| Secrets | `ANTHROPIC_API_KEY` |
+| Branch/PR perms | none — comment/issue only |
 | Output artifact | one Markdown report comment on the durable log issue **#738**, prefixed with the `<!-- oz-maint-drift -->` sentinel for dedup |
 
-## Environment B — `prose-build` (write-capable) · **later, only if needed**
-For background work that changes code (e.g. parallel repo-wide checks, an Oz-side PR-QA pass). **Before standing
-this up, confirm it isn't just duplicating the existing GitHub Actions pipeline** (`claude.yml` already does
-PR-QA/review with `claude-code-action`). The scheduled maintenance runs are the clear day-one win; this is opt-in.
+## Environment B — `prose-build` · `erUdWNSiECqkTQ7BXj6J4Y` (write-capable)
+For implementation children (one per issue). Creates branches + draft PRs; never merges, never pushes `main`.
 
 | Aspect | Value |
 |---|---|
-| Repo checkout | `solo-ist/prose`, full history (`fetch-depth: 0`) for rebase/branch work |
-| Runtime image | Node **20** + Playwright deps if it runs e2e (`npx playwright install --with-deps`) |
-| Setup commands | `npm ci` |
-| Secrets | `ANTHROPIC_API_KEY` + `PROJECT_TOKEN` (or a PAT with `repo` scope) for branch/PR creation |
-| Branch/PR perms | create branches + **draft** PRs only; **never** merge, never push to `main`/protected branches |
-| Output artifact | a draft PR or a branch + summary comment, always behind human review before merge |
+| Repo checkout | `solo-ist/prose`, full history |
+| Runtime image | `warpdotdev/dev-base:latest-agents` |
+| Setup commands | `cd prose && npm ci --include=dev --no-audit --no-fund` · `apt-get install -y zip 2>/dev/null \|\| true` · `git config --global user.email '442369+mrangelmarino@users.noreply.github.com'` · `git config --global user.name 'Angel Marino'` |
+| GitHub auth | Runtime `GH_TOKEN` from the Oz App — already authenticated for clone/branch/PR. No setup-phase token needed |
+| Secrets | `ANTHROPIC_API_KEY` |
+| Branch/PR perms | create branches + **draft** PRs only; branch protection (`enforce_admins`) blocks merge / push-to-main |
+
+> **Setup command rationale:** `zip` is needed for `npm run build`'s `build:skill` step (absent from the base
+> image by default). The git noreply email pre-empts the GH007 push rejection every agent otherwise hits.
+> Both were discovered during the Wave-1 friction audit (June 2026) and patched into the live envs.
 
 ---
 
@@ -62,12 +65,34 @@ PR-QA/review with `claude-code-action`). The scheduled maintenance runs are the 
 
 ---
 
-## Recreate steps (Warp UI)
-1. Cloud Agents → Environments → **New environment** → name `prose-maint`; set repo `solo-ist/prose`, Node 20.
-2. Setup command: `npm ci` (or leave empty for query-only runs).
-3. Attach secrets: `ANTHROPIC_API_KEY`; create/attach a GitHub token scoped to `issues:write` + `contents:read`.
-4. Set branch/PR permissions to **none** (comment/issue only).
-5. Validate with one manual run of the workflow in [`recurring-workflows.md`](recurring-workflows.md); confirm it
-   posts the report and stops at the approval gate.
-6. *(Deferred)* repeat for `prose-build` with full checkout, `PROJECT_TOKEN`, and draft-PR-only permissions — only
-   after confirming it doesn't duplicate the GitHub Actions pipeline.
+## Recreate steps (CLI)
+
+```bash
+# prose-maint (read + comment)
+oz environment create \
+  --name prose-maint \
+  --docker-image warpdotdev/dev-base:latest-agents \
+  --repo solo-ist/prose \
+  --setup-command "cd prose && npm ci --legacy-peer-deps" \
+  --setup-command "apt-get install -y zip 2>/dev/null || true" \
+  --setup-command "git config --global user.email '442369+mrangelmarino@users.noreply.github.com'" \
+  --setup-command "git config --global user.name 'Angel Marino'"
+# Attach ANTHROPIC_API_KEY secret; set branch/PR perms = none
+
+# prose-build (write-capable)
+oz environment create \
+  --name prose-build \
+  --docker-image warpdotdev/dev-base:latest-agents \
+  --repo solo-ist/prose \
+  --setup-command "cd prose && npm ci --include=dev --no-audit --no-fund" \
+  --setup-command "apt-get install -y zip 2>/dev/null || true" \
+  --setup-command "git config --global user.email '442369+mrangelmarino@users.noreply.github.com'" \
+  --setup-command "git config --global user.name 'Angel Marino'"
+# Attach ANTHROPIC_API_KEY secret; set branch/PR perms = branches + draft PRs only
+```
+
+Validate `prose-build` with a single smoke-test run before fanning out:
+```bash
+oz agent run-cloud -e <ENV_ID> -n smoke \
+  -p "Run: gh issue view 1 -R solo-ist/prose --json number,title && echo OK"
+```

--- a/docs/issues/644/cloud-environments.md
+++ b/docs/issues/644/cloud-environments.md
@@ -27,7 +27,8 @@ to summarize, and posts a **single report** (comment or issue) behind a human-ap
 | Output artifact | one Markdown report comment on the durable log issue **#738**, prefixed with the `<!-- oz-maint-drift -->` sentinel for dedup |
 
 ## Environment B — `prose-build` · `erUdWNSiECqkTQ7BXj6J4Y` (write-capable)
-For implementation children (one per issue). Creates branches + draft PRs; never merges, never pushes `main`.
+For implementation children (one per issue). Creates branches + PRs (ready for review by default, per the
+`implement-issue` skill); never merges, never pushes `main`.
 
 | Aspect | Value |
 |---|---|
@@ -36,7 +37,7 @@ For implementation children (one per issue). Creates branches + draft PRs; never
 | Setup commands | `cd prose && npm ci --include=dev --no-audit --no-fund` · `apt-get install -y zip 2>/dev/null \|\| true` · `git config --global user.email '442369+mrangelmarino@users.noreply.github.com'` · `git config --global user.name 'Angel Marino'` |
 | GitHub auth | Runtime `GH_TOKEN` from the Oz App — already authenticated for clone/branch/PR. No setup-phase token needed |
 | Secrets | `ANTHROPIC_API_KEY` |
-| Branch/PR perms | create branches + **draft** PRs only; branch protection (`enforce_admins`) blocks merge / push-to-main |
+| Branch/PR perms | create branches + PRs (draft **or** ready-for-review); branch protection (`enforce_admins`) blocks merge / push-to-main |
 
 > **Setup command rationale:** `zip` is needed for `npm run build`'s `build:skill` step (absent from the base
 > image by default). The git noreply email pre-empts the GH007 push rejection every agent otherwise hits.
@@ -88,7 +89,7 @@ oz environment create \
   --setup-command "apt-get install -y zip 2>/dev/null || true" \
   --setup-command "git config --global user.email '442369+mrangelmarino@users.noreply.github.com'" \
   --setup-command "git config --global user.name 'Angel Marino'"
-# Attach ANTHROPIC_API_KEY secret; set branch/PR perms = branches + draft PRs only
+# Attach ANTHROPIC_API_KEY secret; set branch/PR perms = branches + PRs (draft or ready-for-review)
 ```
 
 Validate `prose-build` with a single smoke-test run before fanning out:


### PR DESCRIPTION
Cloud agents were calling `gh pr create --draft` because the skill said "Open a draft PR" throughout. This removes all draft language and adds an explicit prohibition so the model can't reintroduce it.

**Changes:**
- Frontmatter description: "open a draft PR" → "open a PR ready for review"
- Intro paragraph: "open a **draft** PR" → "open a PR ready for review"
- Step 8: "**Open a draft PR**" → "**Open a PR** (do **not** use `--draft`)"
- Hard prohibitions: "open a draft PR and stop" → "open a PR and stop"
- Output section: "draft PR URL" → "PR URL"

Both `.agents/skills/` and `.claude/skills/` copies updated.

**Verification:** All 8 existing Batch-1 draft PRs converted via `gh pr ready` — no code changes, docs/skills only.