### PR TITLE
fix: QoL Pass 2 HITL regressions — footnotes (#750) + tab menu (#746)

### DIFF
--- a/e2e/electron.footnotes.spec.ts
+++ b/e2e/electron.footnotes.spec.ts
@@ -100,3 +100,59 @@ test.describe('Electron — Footnote markdown round-trip', () => {
     expect(md).toContain('`inline code`')
   })
 })
+
+test.describe('Electron — Footnote interactive insertion', () => {
+  // Guards the #750 HITL regression: tiptap-footnotes' addFootnote inserts the
+  // reference at the selection anchor WITHOUT clearing the selection. With text
+  // selected, the marker landed inside a live range and the next Enter
+  // (splitBlock) deleted the selected text — "nothing happens, then the line
+  // disappears". The fix collapses the selection to its end before inserting.
+  test('Cmd+Shift+F inserts a footnote and never destroys the selected text', async () => {
+    const result = await executeProseTool(page, 'create_and_open_file', {
+      filename: 'footnote-interactive.md',
+      content: 'The quick brown fox.',
+    })
+    expect(result.success).toBe(true)
+    await waitForEditor(page)
+
+    // Select the word "fox", then trigger the REAL Cmd+Shift+F handler. The
+    // handler is a window keydown listener (Editor.tsx), so we dispatch a
+    // synthetic keydown to window — reliable, and it exercises the actual
+    // call-site chain (real Cmd-key presses are intercepted by macOS in e2e).
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const editor = (window as any).__prose_editor
+      const idx = editor.state.doc.textContent.indexOf('fox')
+      const from = idx + 1
+      editor.chain().focus().setTextSelection({ from, to: from + 3 }).run()
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'f',
+          metaKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    })
+    await page.waitForTimeout(80)
+
+    // The footnote reference and the footnotes section render in the live DOM.
+    await expect(page.locator('.prose-editor sup a.footnote-ref')).toBeVisible()
+    await expect(page.locator('.prose-editor ol.footnotes > li')).toBeVisible()
+
+    // Insertion must not have deleted the selected word.
+    const md = await getEditorMarkdown(page)
+    expect(md).toContain('The quick brown fox')
+    expect(md).toContain('[^1]')
+
+    // Regression guard for the fix: the selection must be COLLAPSED after
+    // insertion. The old bug left a live range spanning the inserted marker, so
+    // the next Enter (splitBlock) deleted the selected text.
+    const selectionEmpty = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).__prose_editor.state.selection.empty,
+    )
+    expect(selectionEmpty).toBe(true)
+  })
+})

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -771,10 +771,14 @@ export function Editor() {
         editor.chain().focus().toggleStrike().run()
       }
     } else if (isMod && e.shiftKey && e.key.toLowerCase() === 'f') {
-      // Cmd+Shift+F: Insert footnote citation
+      // Cmd+Shift+F: Insert footnote citation. Collapse any active selection to
+      // its end first — addFootnote inserts at the selection anchor without
+      // clearing it, so otherwise a subsequent Enter deletes the selected text.
+      // Collapsing (vs deleting) keeps the text and drops the marker after it.
       e.preventDefault()
       if (editor) {
-        editor.chain().focus().addFootnote().run()
+        const { to } = editor.state.selection
+        editor.chain().focus().setTextSelection(to).addFootnote().run()
       }
     } else if (isMod && e.shiftKey && e.key.toLowerCase() === 'e') {
       // Cmd+Shift+E: Toggle source view (disabled in read-only mode)

--- a/src/renderer/components/editor/SelectionPopover.tsx
+++ b/src/renderer/components/editor/SelectionPopover.tsx
@@ -261,7 +261,17 @@ export function SelectionPopover({ editor, onAddComment, onToggleLink }: Selecti
             onMouseDown={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              editor?.chain().focus().addFootnote().run()
+              // Collapse any active selection to its end before inserting.
+              // tiptap-footnotes' addFootnote inserts the reference at the
+              // selection anchor WITHOUT clearing the selection, so otherwise
+              // the marker lands inside a still-live range and the next Enter
+              // (splitBlock) deletes the selected text along with it. Collapsing
+              // (vs deleting) keeps the user's selected text and drops the
+              // marker right after it.
+              if (editor) {
+                const { to } = editor.state.selection
+                editor.chain().focus().setTextSelection(to).addFootnote().run()
+              }
             }}
             title="Insert footnote (Cmd+Shift+F)"
           >

--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -319,9 +319,9 @@ function TabItem({
       whileDrag={{ scale: 1.02, opacity: 0.8 }}
     >
       <ContextMenu>
-        <ContextMenuTrigger asChild>
-          <Tooltip>
-            <TooltipTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ContextMenuTrigger asChild>
               <button
                 onClick={onClick}
                 onMouseDown={onMiddleClick}
@@ -424,14 +424,14 @@ function TabItem({
                   </div>
                 )}
               </button>
-            </TooltipTrigger>
-            {tooltipContent && (
-              <TooltipContent side="bottom" className="max-w-md">
-                {tooltipContent}
-              </TooltipContent>
-            )}
-          </Tooltip>
-        </ContextMenuTrigger>
+            </ContextMenuTrigger>
+          </TooltipTrigger>
+          {tooltipContent && (
+            <TooltipContent side="bottom" className="max-w-md">
+              {tooltipContent}
+            </TooltipContent>
+          )}
+        </Tooltip>
         <ContextMenuContent>
           <ContextMenuItem onClick={onClose}>
             Close Tab

--- a/src/renderer/extensions/footnotes/index.ts
+++ b/src/renderer/extensions/footnotes/index.ts
@@ -46,6 +46,17 @@ export const DocumentWithFootnotes = Document.extend({
 })
 
 export const FootnoteReference = BaseFootnoteReference.extend({
+  // tiptap-footnotes@2.x's FootnoteReference defines no addOptions, yet its
+  // renderHTML reads `this.options.HTMLAttributes` — so rendering an inserted
+  // reference throws "Cannot read properties of undefined (reading
+  // 'HTMLAttributes')" and the footnote never appears. Provide the options the
+  // node's renderHTML expects.
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      HTMLAttributes: {},
+    }
+  },
   addStorage() {
     const parentStorage = this.parent?.() ?? {}
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1872,6 +1872,10 @@
 
 .prose-editor ol.footnotes li {
   margin: 0.5em 0;
+  /* Keep a freshly-inserted, still-empty footnote body visible (otherwise the
+     section is just a 1px rule and the inserted footnote looks like nothing
+     happened). */
+  min-height: 1.5em;
 }
 
 .prose-editor ol.footnotes li p {


### PR DESCRIPTION
HITL on the merged QoL Pass 2 wave surfaced two real regressions. Both fixed here, verified locally.

## Footnotes (`Refs #750 #724`) — interactive insertion was badly broken
1. **Render crash (the real "super broken" cause):** `tiptap-footnotes@2.x`'s `FootnoteReference` defines no `addOptions`, but its `renderHTML` reads `this.options.HTMLAttributes` — so rendering an *inserted* reference threw `Cannot read properties of undefined (reading 'HTMLAttributes')` and the footnote never appeared. (The existing round-trip spec only checks serialization, so it never caught this.) Added the `addOptions` the node expects.
2. **Selection data-loss:** `addFootnote` inserts the reference at the selection anchor *without* clearing the selection — so with text selected, the marker landed inside a live range and the next Enter (`splitBlock`) deleted the selected text. Both call sites (the `Fn` selection-popover button and the `Cmd+Shift+F` shortcut) now **collapse** the selection to its end first (keeping the text, dropping the marker after it).
3. **Visibility:** empty footnote body now has a `min-height` so a freshly-inserted footnote is visible instead of a bare 1px rule.
4. **Test:** new interactive e2e drives the real `Cmd+Shift+F` handler and asserts the reference + body render, the selected text survives, and the selection ends collapsed (distinct from the existing serialization round-trip).

## Tab right-click menu (`Refs #746 #717`) — menu never opened
`<ContextMenuTrigger asChild>` wrapped `<Tooltip>` (a Radix *provider*, not a DOM node), so the trigger props never reached the tab `<button>`. Re-nested so both the tooltip and context-menu triggers compose onto the button.

## Verification
- `e2e/electron.footnotes.spec.ts` (round-trip + new interactive) green locally; `electron.editor.spec.ts` + `smoke.spec.ts` green (no regression from the Editor/TabBar changes).
- Manual: select text → `Cmd+Shift+F` / `Fn` → footnote inserts (text preserved), Return is non-destructive; right-click a tab → menu appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)