### PR TITLE
feat(chat): make list_files favorites discoverable

### DIFF
--- a/src/renderer/components/chat/toolResultRenderers/index.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/index.tsx
@@ -48,7 +48,7 @@ export interface ToolResultContext {
 type ToolResultRenderer = (content: string, ctx: ToolResultContext) => ToolResultSlots
 
 const toolResultRenderers: Record<string, ToolResultRenderer> = {
-  list_files: (content) => ({ body: <ListFilesResult content={content} /> }),
+  list_files: (content) => ({ body: <ListFilesResult content={content} />, defaultExpanded: true }),
   request_mode_switch: (content, ctx) => ({
     body: <RequestModeSwitchBody content={content} />,
     actions: <RequestModeSwitchActions content={content} messageId={ctx.messageId} toolPartIdx={ctx.toolPartIdx} />,

--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -183,6 +183,9 @@ function FileTreeItem({
   // Denote favorite files in the tree (folders keep their folder icon).
   // favoritePaths is subscribed once at the root and threaded down (no per-item subscription).
   const isFavorite = !item.isDirectory && favoritePaths.has(item.path)
+  // Whether this item (file or folder) is in the favorites list — used for
+  // the trailing star button affordance that applies to both types.
+  const isItemFavorited = favoritePaths.has(item.path)
 
   // Inline rename state
   const [renameValue, setRenameValue] = useState('')
@@ -328,7 +331,7 @@ function FileTreeItem({
 
   const buttonElement = (
     <div
-      className={cn("group flex items-center", !item.isDirectory && onFileLinkClick && "relative")}
+      className={cn("group flex items-center", ((!item.isDirectory && onFileLinkClick) || onAddFavorite) && "relative")}
     >
       <button
         ref={buttonRef}
@@ -402,6 +405,26 @@ function FileTreeItem({
           title="Open in Google Docs"
         >
           <ExternalLink className="h-3 w-3 text-muted-foreground" />
+        </button>
+      )}
+      {onAddFavorite && !isRenaming && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onAddFavorite(item.path, item.isDirectory)
+          }}
+          className={cn(
+            'absolute right-1 p-1 rounded hover:bg-accent transition-opacity',
+            isItemFavorited ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          )}
+          title={isItemFavorited ? 'Favorited' : 'Add to Favorites'}
+        >
+          <Star
+            className={cn(
+              'h-3 w-3',
+              isItemFavorited ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground'
+            )}
+          />
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Expand-by-default**: The `list_files` tool result now renders expanded (tree visible) on first render instead of collapsed — sets `defaultExpanded: true` in the renderer registry, using the existing `ToolResultSlots.defaultExpanded` hook already wired up by `request_mode_switch`.
- **Visible star button per row**: Each `FileTreeItem` now shows a trailing star icon button when `onAddFavorite` is provided. The button is visible on hover for unstarred items and always-visible for already-favorited items (amber filled star). Clicking it calls `onAddFavorite(path, isDirectory)` — the same idempotent `settingsStore.addFavorite` path from #744 that dedupes by path.
- The existing right-click "Add to Favorites" context-menu item is preserved unchanged.
- The `relative` positioning class on the row wrapper is now also applied when `onAddFavorite` is set (previously only guarded by `onFileLinkClick`), so the absolute-positioned star button sits correctly.
- Introduced `isItemFavorited = favoritePaths.has(item.path)` to unify file/folder favorited state for the trailing button (the existing `isFavorite` variable intentionally excludes directories from the leading icon replacement).

## Files changed

- `src/renderer/components/chat/toolResultRenderers/index.tsx` — `defaultExpanded: true` for `list_files`
- `src/renderer/components/files/FileTree.tsx` — trailing star button + relative wrapper fix

## Test plan

- [ ] In chat, use `/list_files` — result tree is expanded on first render (no click needed)
- [ ] Hover a file or folder row in the `list_files` result — star icon appears at right edge
- [ ] Click the star — file/folder is added to Favorites (verify in the Favorites panel)
- [ ] Re-hover a favorited item — star shows filled amber, always visible (not just on hover)
- [ ] Right-click any row — "Add to Favorites" context-menu item still present
- [ ] File explorer (side panel) star button also appears on hover (same component) — click works
- [ ] Re-adding an already-favorited path is idempotent (no duplicate)

Closes #756
Refs #728 #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)