### PR TITLE
feat(chat): NL GitHub issue creation via /report-bug and /request-feature

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -114,6 +114,7 @@ function stripSecretsForDisk(settings: Settings): Settings {
 function getSettingsPath(): string { return join(getSettingsDir(), 'settings.json') }
 const ANTHROPIC_KEY_PATH = join(LEGACY_SETTINGS_DIR, '.remarkable-anthropic-key') // Legacy path for migration
 const REMARKABLE_CREDENTIAL_KEY = 'remarkable-anthropic-key'
+const GITHUB_PAT_KEY = 'github-pat'
 
 /**
  * Expand ~ to home directory
@@ -1796,6 +1797,161 @@ export function setupIpcHandlers(): void {
       return
     }
     app.dock.setIcon(img)
+  })
+
+  // GitHub PAT — store, check, test, create issue, clear
+  // The token lives ONLY in the main process (credentialStore). The renderer
+  // never receives it — all GitHub API calls happen here.
+
+  ipcMain.handle('github:storeToken', async (_event, token: string): Promise<{ success: boolean; error?: string }> => {
+    if (IS_MAS_BUILD) {
+      return { success: false, error: 'GitHub integration is not available in the Mac App Store version.' }
+    }
+    if (!credentialStore.isAvailable()) {
+      return { success: false, error: 'Secure storage is not available on this system.' }
+    }
+    if (!token || typeof token !== 'string') {
+      return { success: false, error: 'Invalid token.' }
+    }
+    await credentialStore.set(GITHUB_PAT_KEY, token)
+    return { success: true }
+  })
+
+  ipcMain.handle('github:hasToken', async (): Promise<boolean> => {
+    if (IS_MAS_BUILD || !credentialStore.isAvailable()) return false
+    const token = await credentialStore.get(GITHUB_PAT_KEY)
+    return !!token
+  })
+
+  ipcMain.handle('github:testToken', async (): Promise<{ success: boolean; login?: string; error?: string }> => {
+    if (IS_MAS_BUILD) {
+      return { success: false, error: 'GitHub integration is not available in the Mac App Store version.' }
+    }
+    if (!credentialStore.isAvailable()) {
+      return { success: false, error: 'Secure storage is not available.' }
+    }
+    const token = await credentialStore.get(GITHUB_PAT_KEY)
+    if (!token) {
+      return { success: false, error: 'No GitHub token configured.' }
+    }
+    try {
+      const https = await import('https')
+      const result = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const options = {
+          hostname: 'api.github.com',
+          path: '/user',
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/vnd.github+json',
+            'User-Agent': `prose/${app.getVersion()}`,
+            'X-GitHub-Api-Version': '2022-11-28'
+          }
+        }
+        const req = https.request(options, (res) => {
+          let body = ''
+          res.on('data', (chunk) => { body += chunk })
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
+        })
+        req.on('error', reject)
+        req.end()
+      })
+
+      if (result.status === 200) {
+        const data = JSON.parse(result.body) as { login?: string }
+        return { success: true, login: data.login }
+      } else if (result.status === 401) {
+        return { success: false, error: 'Invalid token — authentication failed.' }
+      } else {
+        return { success: false, error: `GitHub API returned ${result.status}.` }
+      }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Network error.' }
+    }
+  })
+
+  ipcMain.handle('github:createIssue', async (
+    _event,
+    request: { owner: string; repo: string; title: string; body: string; labels?: string[] }
+  ): Promise<{ success: boolean; url?: string; number?: number; error?: string }> => {
+    if (IS_MAS_BUILD) {
+      return { success: false, error: 'GitHub integration is not available in the Mac App Store version.' }
+    }
+    if (!credentialStore.isAvailable()) {
+      return { success: false, error: 'Secure storage is not available.' }
+    }
+    const token = await credentialStore.get(GITHUB_PAT_KEY)
+    if (!token) {
+      return { success: false, error: 'No GitHub token configured.' }
+    }
+
+    // Basic input validation
+    if (!request.owner || !request.repo || !request.title || !request.body) {
+      return { success: false, error: 'Missing required fields.' }
+    }
+    // Guard against injection via owner/repo (alphanumeric, dash, underscore, dot only)
+    if (!/^[a-zA-Z0-9._-]+$/.test(request.owner) || !/^[a-zA-Z0-9._-]+$/.test(request.repo)) {
+      return { success: false, error: 'Invalid repository owner or name.' }
+    }
+
+    try {
+      const https = await import('https')
+      const payload = JSON.stringify({
+        title: request.title,
+        body: request.body,
+        labels: request.labels ?? []
+      })
+
+      const result = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const options = {
+          hostname: 'api.github.com',
+          path: `/repos/${request.owner}/${request.repo}/issues`,
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/vnd.github+json',
+            'User-Agent': `prose/${app.getVersion()}`,
+            'X-GitHub-Api-Version': '2022-11-28',
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload)
+          }
+        }
+        const req = https.request(options, (res) => {
+          let body = ''
+          res.on('data', (chunk) => { body += chunk })
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
+        })
+        req.on('error', reject)
+        req.write(payload)
+        req.end()
+      })
+
+      if (result.status === 201) {
+        const data = JSON.parse(result.body) as { html_url?: string; number?: number }
+        return { success: true, url: data.html_url, number: data.number }
+      } else if (result.status === 401) {
+        return { success: false, error: 'GitHub token is invalid or expired.' }
+      } else if (result.status === 403) {
+        return { success: false, error: 'GitHub token lacks the required permissions (needs issues:write scope).' }
+      } else if (result.status === 404) {
+        return { success: false, error: 'Repository not found or not accessible with this token.' }
+      } else if (result.status === 410) {
+        return { success: false, error: 'Issues are disabled for this repository.' }
+      } else {
+        let errorMsg = `GitHub API returned ${result.status}.`
+        try {
+          const errData = JSON.parse(result.body) as { message?: string }
+          if (errData.message) errorMsg = errData.message
+        } catch { /* ignore JSON parse errors */ }
+        return { success: false, error: errorMsg }
+      }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Network error.' }
+    }
+  })
+
+  ipcMain.handle('github:clearToken', async (): Promise<void> => {
+    await credentialStore.delete(GITHUB_PAT_KEY)
   })
 
   ipcMain.handle('skill:download', async (): Promise<{ success: boolean; error?: string }> => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -158,6 +158,27 @@ export interface GoogleSyncMetadata {
   documents: Record<string, GoogleDocEntry>
 }
 
+export interface GitHubTestTokenResult {
+  success: boolean
+  login?: string
+  error?: string
+}
+
+export interface GitHubCreateIssueRequest {
+  owner: string
+  repo: string
+  title: string
+  body: string
+  labels?: string[]
+}
+
+export interface GitHubCreateIssueResult {
+  success: boolean
+  url?: string
+  number?: number
+  error?: string
+}
+
 export interface McpServerStatus {
   installed: boolean
   version: string | null
@@ -266,6 +287,12 @@ export interface ElectronAPI {
   googleGetSyncMetadata: () => Promise<GoogleSyncMetadata | null>
   googleUpdateSyncMetadataEntry: (entry: GoogleDocEntry) => Promise<void>
   googleRemoveSyncMetadataEntry: (googleDocId: string) => Promise<void>
+  // GitHub integration (PAT-based issue creation; desktop-only, not MAS)
+  githubStoreToken: (token: string) => Promise<{ success: boolean; error?: string }>
+  githubHasToken: () => Promise<boolean>
+  githubTestToken: () => Promise<GitHubTestTokenResult>
+  githubCreateIssue: (request: GitHubCreateIssueRequest) => Promise<GitHubCreateIssueResult>
+  githubClearToken: () => Promise<void>
   // MCP Server integration
   mcpGetStatus: () => Promise<McpServerStatus>
   mcpInstall: () => Promise<McpInstallResult>
@@ -538,6 +565,12 @@ const api: ElectronAPI = {
   googleGetSyncMetadata: () => ipcRenderer.invoke('google:getSyncMetadata'),
   googleUpdateSyncMetadataEntry: (entry: GoogleDocEntry) => ipcRenderer.invoke('google:updateSyncMetadataEntry', entry),
   googleRemoveSyncMetadataEntry: (googleDocId: string) => ipcRenderer.invoke('google:removeSyncMetadataEntry', googleDocId),
+  // GitHub integration
+  githubStoreToken: (token: string) => ipcRenderer.invoke('github:storeToken', token),
+  githubHasToken: () => ipcRenderer.invoke('github:hasToken'),
+  githubTestToken: () => ipcRenderer.invoke('github:testToken'),
+  githubCreateIssue: (request: GitHubCreateIssueRequest) => ipcRenderer.invoke('github:createIssue', request),
+  githubClearToken: () => ipcRenderer.invoke('github:clearToken'),
   // MCP Server integration
   mcpGetStatus: () => ipcRenderer.invoke('mcp:getStatus'),
   mcpInstall: () => ipcRenderer.invoke('mcp:install'),

--- a/src/renderer/components/chat/ChatInput.tsx
+++ b/src/renderer/components/chat/ChatInput.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } from 'react'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
-import { Square, MessageSquare, ChevronRight, X, Sparkles } from 'lucide-react'
+import { Textarea } from '../ui/textarea'
+import { Square, MessageSquare, ChevronRight, X, Sparkles, Loader2, Github } from 'lucide-react'
 import { useChat } from '../../hooks/useChat'
 import { useAIConfigured } from '../../hooks/useAIConfigured'
-import { aiUnavailableMessage } from '../../lib/llm'
+import { aiUnavailableMessage, isAIConfigured } from '../../lib/llm'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useEditorStore } from '../../stores/editorStore'
@@ -17,11 +18,28 @@ import { cn } from '../../lib/utils'
 import { useReviewStore } from '../../stores/reviewStore'
 import { getApi } from '../../lib/browserApi'
 import { requestBugReport } from '../EnableLoggingDialog'
+import { APP_VERSION } from '../../buildInfo.generated'
 
 // GitHub feedback template URLs (mirror the Toolbar "More" menu / Help menu)
 const BUG_REPORT_URL = 'https://github.com/solo-ist/prose/issues/new?template=bug-report.yml'
 const FEATURE_REQUEST_URL = 'https://github.com/solo-ist/prose/issues/new?template=feature-request.yml'
 const MAS_SUPPORT_URL = 'https://solo.ist/prose/support'
+
+// GitHub repo coordinates for the API path
+const GITHUB_OWNER = 'solo-ist'
+const GITHUB_REPO = 'prose'
+
+/** State for the GitHub issue confirm panel shown after LLM drafting */
+interface GitHubDraftState {
+  /** 'bug' or 'feature' — determines default labels */
+  kind: 'bug' | 'feature'
+  title: string
+  body: string
+  /** ID of the assistant chat message showing the "Drafting…" placeholder */
+  assistantMsgId: string
+  /** Whether the final API call is in flight */
+  isFiling: boolean
+}
 
 // Tool descriptions for autocomplete
 const toolDescriptions: Record<string, string> = {
@@ -164,6 +182,7 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
   const [commentCount, setCommentCount] = useState(0)
   const [suggestionFeedbackCount, setSuggestionFeedbackCount] = useState(0)
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [githubDraft, setGitHubDraft] = useState<GitHubDraftState | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const { context, setContext, toolMode, processComments, getCommentCount, processSuggestionReplies, getSuggestionFeedbackCount, isInitializing } = useChat()
@@ -273,23 +292,141 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
       return
     }
 
-    // Handle /report-bug - chat-layer shortcut to the GitHub bug template.
-    // Routes through requestBugReport() to preserve the Sentry opt-in prompt.
-    // MAS builds substitute the Request Support link, matching the toolbar
-    // and Help menu build-conditional behavior. No LLM involvement.
-    if (command.toolName === 'report-bug') {
-      if (getApi().isMasBuild) {
-        getApi().openExternal?.(MAS_SUPPORT_URL)
-      } else {
-        requestBugReport(BUG_REPORT_URL)
-      }
-      return
-    }
+    // Handle /report-bug and /request-feature
+    // Enhanced path (when GitHub PAT + AI are both configured):
+    //   1. Use the user's natural-language text (rawArg) as context.
+    //   2. Call LLM to format a structured issue draft.
+    //   3. Show a confirm panel so the user can edit before filing.
+    //   4. On confirm, call github:createIssue (main process; token never
+    //      leaves the main process) and return the URL in chat.
+    // Fallback (no token, MAS, or AI not configured):
+    //   /report-bug  → requestBugReport() [preserves Sentry opt-in prompt]
+    //   /request-feature → prefilled GitHub template URL
+    if (command.toolName === 'report-bug' || command.toolName === 'request-feature') {
+      const isBug = command.toolName === 'report-bug'
+      const api = getApi()
 
-    // Handle /request-feature - chat-layer shortcut to the GitHub feature
-    // request template. No LLM involvement.
-    if (command.toolName === 'request-feature') {
-      getApi().openExternal?.(FEATURE_REQUEST_URL)
+      // MAS builds and web mode always use the URL fallback
+      if (api.isMasBuild) {
+        api.openExternal?.(MAS_SUPPORT_URL)
+        return
+      }
+
+      const { settings } = useSettingsStore.getState()
+      const hasToken = await api.githubHasToken?.()
+      const aiConfigured = isAIConfigured(settings)
+
+      // Both token AND AI must be available for the enhanced path
+      if (hasToken && aiConfigured && !api.isMasBuild) {
+        const { addMessage } = useChatStore.getState()
+        const rawDescription = command.rawArg?.trim() || ''
+
+        // Show user's command in chat
+        const userMsgId = createMessageId()
+        addMessage({
+          id: userMsgId,
+          role: 'user',
+          content: `/${command.toolName}${rawDescription ? ' ' + rawDescription : ''}`,
+          timestamp: new Date()
+        })
+
+        const assistantMsgId = createMessageId()
+        addMessage({
+          id: assistantMsgId,
+          role: 'assistant',
+          content: `<tool-executing name="${command.toolName}">Drafting issue…</tool-executing>`,
+          timestamp: new Date()
+        })
+
+        try {
+          // Build system + user prompt for the LLM
+          const appVersion = APP_VERSION ?? 'unknown'
+          const platform = api.platform ?? 'unknown'
+
+          const systemPrompt = isBug
+            ? `You are a precise technical writer formatting a GitHub bug report for the Prose markdown editor.
+Output ONLY valid JSON with exactly these fields:
+{
+  "title": "<concise bug title, under 72 chars, plain text>",
+  "body": "<markdown body with sections: ## Bug Description, ## Steps to Reproduce, ## Expected Behavior, ## Actual Behavior, ## Environment>",
+  "labels": ["bug"]
+}
+In the body's Environment section always include:
+- App version: ${appVersion || 'unknown'}
+- Platform: ${platform}
+Fill in what you know from context; use "…" for anything unknown.
+No explanations outside the JSON.`
+            : `You are a precise technical writer formatting a GitHub feature request for the Prose markdown editor.
+Output ONLY valid JSON with exactly these fields:
+{
+  "title": "<concise feature title, under 72 chars, plain text>",
+  "body": "<markdown body with sections: ## Problem / Motivation, ## Proposed Solution, ## Alternatives Considered>",
+  "labels": ["enhancement"]
+}
+No explanations outside the JSON.`
+
+          const userPrompt = rawDescription
+            ? `Format the following as a GitHub issue:\n\n${rawDescription}`
+            : `The user ran /${command.toolName} with no description. Create a helpful placeholder issue that can be edited before filing.`
+
+          const response = await api.llmChat({
+            provider: settings.llm.provider,
+            model: settings.llm.model,
+            apiKey: settings.llm.apiKey,
+            baseUrl: settings.llm.baseUrl,
+            messages: [{ role: 'user', content: userPrompt }],
+            system: systemPrompt
+          })
+
+          // Parse the LLM response — it should be JSON
+          let title = ''
+          let body = ''
+          try {
+            // Strip markdown code fences if present
+            const jsonStr = response.content
+              .replace(/^```(?:json)?\n?/, '')
+              .replace(/\n?```$/, '')
+              .trim()
+            const parsed = JSON.parse(jsonStr) as { title?: string; body?: string }
+            title = parsed.title?.trim() ?? ''
+            body = parsed.body?.trim() ?? ''
+          } catch {
+            // If JSON parse fails, use raw content as body with a generic title
+            title = isBug ? 'Bug report' : 'Feature request'
+            body = response.content
+          }
+
+          if (!title) title = isBug ? 'Bug report' : 'Feature request'
+          if (!body) body = rawDescription || '(No description provided)'
+
+          // Update the assistant message to show it's pending user review
+          useChatStore.getState().updateMessage(assistantMsgId, {
+            content: `<tool-executing name="${command.toolName}">Review the draft below before filing…</tool-executing>`
+          })
+
+          // Show the confirm panel
+          setGitHubDraft({
+            kind: isBug ? 'bug' : 'feature',
+            title,
+            body,
+            assistantMsgId,
+            isFiling: false
+          })
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : 'Unknown error'
+          useChatStore.getState().updateMessage(assistantMsgId, {
+            content: `<tool-result name="${command.toolName}" success="false">Failed to draft issue: ${errMsg}</tool-result>`
+          })
+        }
+        return
+      }
+
+      // Fallback: no token or AI not configured → URL behavior
+      if (isBug) {
+        requestBugReport(BUG_REPORT_URL)
+      } else {
+        api.openExternal?.(FEATURE_REQUEST_URL)
+      }
       return
     }
 
@@ -773,8 +910,106 @@ export function ChatInput({ onSend, isLoading, isStreaming, onStop }: ChatInputP
     wasStreaming.current = isStreaming ?? false
   }, [isStreaming])
 
+  // File the GitHub issue draft after the user reviews and confirms
+  const handleGitHubFile = async () => {
+    if (!githubDraft) return
+    const draft = githubDraft
+    setGitHubDraft({ ...draft, isFiling: true })
+
+    const labels = draft.kind === 'bug' ? ['bug'] : ['enhancement']
+    const result = await getApi().githubCreateIssue?.({
+      owner: GITHUB_OWNER,
+      repo: GITHUB_REPO,
+      title: draft.title,
+      body: draft.body,
+      labels
+    })
+
+    if (result?.success && result.url) {
+      useChatStore.getState().updateMessage(draft.assistantMsgId, {
+        content: `<tool-result name="${draft.kind === 'bug' ? 'report-bug' : 'request-feature'}" success="true">Issue filed: [#${result.number}](${result.url})</tool-result>`
+      })
+    } else {
+      useChatStore.getState().updateMessage(draft.assistantMsgId, {
+        content: `<tool-result name="${draft.kind === 'bug' ? 'report-bug' : 'request-feature'}" success="false">Failed to file issue: ${result?.error ?? 'Unknown error'}</tool-result>`
+      })
+    }
+    setGitHubDraft(null)
+    setTimeout(() => textareaRef.current?.focus(), 0)
+  }
+
+  const handleGitHubCancel = () => {
+    if (!githubDraft) return
+    useChatStore.getState().updateMessage(githubDraft.assistantMsgId, {
+      content: `<tool-result name="${githubDraft.kind === 'bug' ? 'report-bug' : 'request-feature'}" success="false">Cancelled.</tool-result>`
+    })
+    setGitHubDraft(null)
+    setTimeout(() => textareaRef.current?.focus(), 0)
+  }
+
   return (
     <div className="border-t border-border p-4">
+      {/* GitHub issue confirm panel — shown after the LLM drafts an issue
+          and before the user files it. Renders above the context block. */}
+      {githubDraft && (
+        <div className="mb-3 rounded-md border border-border bg-muted/30 p-3 space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <Github className="h-3.5 w-3.5" />
+              Review &amp; file {githubDraft.kind === 'bug' ? 'bug report' : 'feature request'}
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-5 w-5 shrink-0"
+              onClick={handleGitHubCancel}
+              disabled={githubDraft.isFiling}
+              aria-label="Cancel"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+          <input
+            type="text"
+            value={githubDraft.title}
+            onChange={(e) => setGitHubDraft({ ...githubDraft, title: e.target.value })}
+            placeholder="Issue title"
+            className="w-full rounded border border-border bg-background px-2 py-1 text-sm font-medium placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+            disabled={githubDraft.isFiling}
+          />
+          <Textarea
+            value={githubDraft.body}
+            onChange={(e) => setGitHubDraft({ ...githubDraft, body: e.target.value })}
+            placeholder="Issue body (Markdown)"
+            className="min-h-[120px] text-xs font-mono resize-y"
+            disabled={githubDraft.isFiling}
+          />
+          <div className="flex gap-2 pt-1">
+            <Button
+              size="sm"
+              onClick={handleGitHubFile}
+              disabled={githubDraft.isFiling || !githubDraft.title.trim() || !githubDraft.body.trim()}
+              className="gap-1.5"
+            >
+              {githubDraft.isFiling ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Github className="h-3.5 w-3.5" />
+              )}
+              File issue
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleGitHubCancel}
+              disabled={githubDraft.isFiling}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
       {/* Context block */}
       {context && (
         <div className="mb-3 rounded-md bg-muted/50 p-3">

--- a/src/renderer/components/settings/GitHubIntegration.tsx
+++ b/src/renderer/components/settings/GitHubIntegration.tsx
@@ -1,0 +1,233 @@
+import { useState, useEffect } from 'react'
+import { Label } from '../ui/label'
+import { Input } from '../ui/input'
+import { Button } from '../ui/button'
+import { Loader2, CheckCircle, XCircle, Github, Trash2 } from 'lucide-react'
+
+/**
+ * Settings panel for configuring a GitHub Personal Access Token (PAT).
+ *
+ * The token is stored via the OS-encrypted credential store (safeStorage) in
+ * the main process — the renderer never sees the token value after saving it.
+ * The component only holds the token in local state while the user is actively
+ * typing in the input; once saved the local copy is cleared.
+ *
+ * Gate: desktop-only, non-MAS. Callers must render this component only when
+ * `!isWebMode() && !window.api?.isMasBuild`.
+ */
+export function GitHubIntegration() {
+  const [tokenInput, setTokenInput] = useState('')
+  const [isConnected, setIsConnected] = useState(false)
+  const [connectedLogin, setConnectedLogin] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isTesting, setIsTesting] = useState(false)
+  const [isRemoving, setIsRemoving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+
+  // Check whether a token is already stored on mount
+  useEffect(() => {
+    let cancelled = false
+    async function checkToken() {
+      const hasToken = await window.api?.githubHasToken?.()
+      if (cancelled) return
+      if (hasToken) {
+        // Silently test the stored token to get the login name
+        const result = await window.api?.githubTestToken?.()
+        if (cancelled) return
+        if (result?.success && result.login) {
+          setIsConnected(true)
+          setConnectedLogin(result.login)
+        } else {
+          // Token exists but is no longer valid (revoked/expired)
+          setIsConnected(false)
+          setConnectedLogin(null)
+          setError('Your stored token appears invalid. Please enter a new one.')
+        }
+      }
+    }
+    checkToken()
+    return () => { cancelled = true }
+  }, [])
+
+  const handleSave = async () => {
+    const token = tokenInput.trim()
+    if (!token) return
+
+    setError(null)
+    setSuccessMsg(null)
+    setIsSaving(true)
+
+    try {
+      // Store first, then test
+      const storeResult = await window.api?.githubStoreToken?.(token)
+      if (!storeResult?.success) {
+        setError(storeResult?.error ?? 'Failed to save token.')
+        return
+      }
+
+      // Test the newly stored token
+      const testResult = await window.api?.githubTestToken?.()
+      if (testResult?.success && testResult.login) {
+        setIsConnected(true)
+        setConnectedLogin(testResult.login)
+        setTokenInput('') // Clear from local state now it's saved securely
+        setSuccessMsg(`Connected as @${testResult.login}`)
+      } else {
+        // Invalid token — clear it from the store
+        await window.api?.githubClearToken?.()
+        setError(testResult?.error ?? 'Token validation failed.')
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleTest = async () => {
+    setError(null)
+    setSuccessMsg(null)
+    setIsTesting(true)
+    try {
+      const result = await window.api?.githubTestToken?.()
+      if (result?.success && result.login) {
+        setConnectedLogin(result.login)
+        setSuccessMsg(`Token is valid — authenticated as @${result.login}`)
+      } else {
+        setError(result?.error ?? 'Token validation failed.')
+      }
+    } finally {
+      setIsTesting(false)
+    }
+  }
+
+  const handleRemove = async () => {
+    setError(null)
+    setSuccessMsg(null)
+    setIsRemoving(true)
+    try {
+      await window.api?.githubClearToken?.()
+      setIsConnected(false)
+      setConnectedLogin(null)
+      setTokenInput('')
+    } finally {
+      setIsRemoving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-0.5">
+        <div className="flex items-center gap-2">
+          <Github className="h-4 w-4" />
+          <Label>GitHub</Label>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Connect a Personal Access Token to file issues directly from chat via{' '}
+          <span className="font-mono">/report-bug</span> and{' '}
+          <span className="font-mono">/request-feature</span>.
+        </p>
+      </div>
+
+      {isConnected && connectedLogin ? (
+        <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+          <div className="flex items-center gap-2 text-sm">
+            <CheckCircle className="h-4 w-4 text-green-500" />
+            <span>
+              Connected as{' '}
+              <span className="font-mono font-medium">@{connectedLogin}</span>
+            </span>
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleTest}
+              disabled={isTesting}
+            >
+              {isTesting ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              ) : null}
+              Verify token
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRemove}
+              disabled={isRemoving}
+              className="text-destructive hover:text-destructive"
+            >
+              {isRemoving ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              Remove token
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="github-pat" className="text-xs">
+              Personal Access Token
+            </Label>
+            <Input
+              id="github-pat"
+              type="password"
+              placeholder="ghp_..."
+              value={tokenInput}
+              onChange={(e) => setTokenInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && tokenInput.trim()) handleSave()
+              }}
+              className="font-mono text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Needs{' '}
+              <span className="font-mono">repo</span> scope (or{' '}
+              <span className="font-mono">public_repo</span> for public repos).{' '}
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:text-foreground transition-colors"
+                onClick={() =>
+                  window.api?.openExternal?.(
+                    'https://github.com/settings/tokens/new?scopes=public_repo&description=Prose+issue+reporter'
+                  )
+                }
+              >
+                Create one on GitHub
+              </button>
+              .
+            </p>
+          </div>
+
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={!tokenInput.trim() || isSaving}
+          >
+            {isSaving ? (
+              <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+            ) : null}
+            Save token
+          </Button>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-start gap-2 text-sm text-destructive">
+          <XCircle className="h-4 w-4 shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {successMsg && (
+        <div className="flex items-start gap-2 text-sm text-green-600 dark:text-green-400">
+          <CheckCircle className="h-4 w-4 shrink-0 mt-0.5" />
+          <span>{successMsg}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -26,6 +26,7 @@ import { RemarkableIntegration } from './RemarkableIntegration'
 import { GoogleDocsIntegration } from './GoogleDocsIntegration'
 import { McpIntegration } from './McpIntegration'
 import { ProseSkillIntegration } from './ProseSkillIntegration'
+import { GitHubIntegration } from './GitHubIntegration'
 import { isWebMode } from '../../lib/browserApi'
 import type { Settings } from '../../types'
 import { Eye, EyeOff, AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
@@ -699,7 +700,11 @@ export function SettingsDialog() {
                 setRemarkableConfig={setRemarkableConfig}
               />
             )}
-            {/* All three integrations (Mcp, ProseSkill, Remarkable) are gated
+            {!isWebMode() && !window.api?.isMasBuild && <Separator />}
+            {/* GitHub PAT integration — desktop-only, not MAS. MAS keeps the
+                support-URL fallback in the chat commands. */}
+            {!isWebMode() && !window.api?.isMasBuild && <GitHubIntegration />}
+            {/* All integrations (Mcp, ProseSkill, Remarkable, GitHub) are gated
                 to desktop, non-MAS builds — without this fallback, web and MAS
                 users land on a completely empty Integrations tab with no
                 explanation when they click into it. */}

--- a/src/renderer/lib/browserApi.ts
+++ b/src/renderer/lib/browserApi.ts
@@ -438,6 +438,13 @@ export const browserApi: ElectronAPI = {
     return () => {}
   },
 
+  // GitHub integration - not available in browser mode (requires main-process IPC)
+  githubStoreToken: async () => ({ success: false, error: 'Not available in browser mode' }),
+  githubHasToken: async () => false,
+  githubTestToken: async () => ({ success: false, error: 'Not available in browser mode' }),
+  githubCreateIssue: async () => ({ success: false, error: 'Not available in browser mode' }),
+  githubClearToken: async () => {},
+
   // Google Docs integration - not available in browser mode
   googleIsConfigured: async () => false,
   googleStartAuth: async () => ({

--- a/src/renderer/mocks/webApi.ts
+++ b/src/renderer/mocks/webApi.ts
@@ -482,6 +482,33 @@ export function createMockApi(): ElectronAPI {
 
     onRemarkableSyncProgress: () => () => {},
 
+    // ---- GitHub integration (stubs) ---------------------------------------
+
+    githubStoreToken: async (_token: string): Promise<{ success: boolean; error?: string }> => ({
+      success: false,
+      error: 'GitHub integration is not available in web mode',
+    }),
+
+    githubHasToken: async (): Promise<boolean> => false,
+
+    githubTestToken: async (): Promise<{ success: boolean; login?: string; error?: string }> => ({
+      success: false,
+      error: 'GitHub integration is not available in web mode',
+    }),
+
+    githubCreateIssue: async (_request: {
+      owner: string
+      repo: string
+      title: string
+      body: string
+      labels?: string[]
+    }): Promise<{ success: boolean; url?: string; number?: number; error?: string }> => ({
+      success: false,
+      error: 'GitHub integration is not available in web mode',
+    }),
+
+    githubClearToken: async (): Promise<void> => {},
+
     // ---- Google Docs (stubs) ----------------------------------------------
 
     googleIsConfigured: async (): Promise<boolean> => false,

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -534,6 +534,18 @@ export interface ElectronAPI {
   // File association (default markdown editor)
   // Returns: true (is default), false (not default), null (can't detect)
   fileAssociationIsDefault: () => Promise<boolean | null>
+  // GitHub integration (PAT-based issue creation; desktop-only, not MAS)
+  githubStoreToken?: (token: string) => Promise<{ success: boolean; error?: string }>
+  githubHasToken?: () => Promise<boolean>
+  githubTestToken?: () => Promise<{ success: boolean; login?: string; error?: string }>
+  githubCreateIssue?: (request: {
+    owner: string
+    repo: string
+    title: string
+    body: string
+    labels?: string[]
+  }) => Promise<{ success: boolean; url?: string; number?: number; error?: string }>
+  githubClearToken?: () => Promise<void>
   // Google Docs integration
   googleIsConfigured: () => Promise<boolean>
   googleStartAuth: () => Promise<GoogleAuthResult>


### PR DESCRIPTION
## Summary

Implements #755 — turns `/report-bug` and `/request-feature` from URL-only shortcuts into full LLM-assisted issue-filing commands when a GitHub PAT is configured, while preserving the existing URL-fallback behavior from #743 with zero regression.

## Design

### Auth (PAT-based)
- New **Settings → Integrations → GitHub** panel (`GitHubIntegration.tsx`): user pastes a PAT with `public_repo` or `repo` scope, clicks Save. The token is stored via `credentialStore` (OS `safeStorage`); the renderer component only holds it in local state while typing, then clears it after save. A "Verify token" button calls the GitHub `/user` endpoint to confirm authentication and display the login name. Remove button calls `github:clearToken`.
- OAuth is explicitly deferred — the issue calls it out as a follow-up.

### IPC (main process — token never leaves)
Five new handlers in `src/main/ipc.ts` (all gated with `IS_MAS_BUILD` and `credentialStore.isAvailable()` guards):
- `github:storeToken` — encrypts and stores via `credentialStore`
- `github:hasToken` — boolean check (no token value exposed to renderer)
- `github:testToken` — calls `api.github.com/user`; returns `{ success, login }` — login display name only, never the token
- `github:createIssue` — validates owner/repo against an alphanumeric allowlist, builds and POSTs the JSON payload via Node's built-in `https` module; interprets GitHub API status codes explicitly
- `github:clearToken` — deletes from `credentialStore`

All wired in `src/preload/index.ts` and declared (optional with `?`) in `src/renderer/types/index.ts`. Browser stubs added in `browserApi.ts` and `webApi.ts` mocks.

### Chat flow
`/report-bug [description]` or `/request-feature [description]` — when a PAT + AI are both configured:
1. Shows "Drafting issue…" placeholder in the chat thread.
2. Calls `llmChat` (non-streaming, single-turn) with a tightly-scoped system prompt requesting only a JSON object `{ title, body, labels }`. For bug reports the prompt inserts `APP_VERSION` and `platform` into the environment section automatically.
3. Parses the JSON response; falls back to raw content as body if parsing fails.
4. Renders a **confirm/edit panel** above the chat input — editable title (plain `<input>`) and body (`<Textarea>`) — with "File issue" and "Cancel" buttons.
5. On confirm: calls `github:createIssue`; on success updates the chat message with a markdown link `[#N](url)`; on failure shows the error.
6. On cancel: updates the chat message with "Cancelled."

### Fallback (no regression to #743)
- No PAT configured → existing URL behavior (`requestBugReport()` for bugs, `openExternal(FEATURE_REQUEST_URL)` for features).
- MAS build → `openExternal(MAS_SUPPORT_URL)` (same as before).
- AI not configured but PAT present → URL fallback (both token AND AI must be available for the enhanced path).
- Web mode → `browserApi` stubs return `{ success: false }` and the URL fallback fires.

### MAS / build-conditional
`IS_MAS_BUILD` is checked in every `github:*` IPC handler and the Settings component is only rendered when `!isWebMode() && !window.api?.isMasBuild`.

## Security checklist
- [x] Token stored via `credentialStore` (safeStorage) — never plaintext, never sent to renderer
- [x] GitHub API call runs in main process only
- [x] `owner`/`repo` validated against `/^[a-zA-Z0-9._-]+$/` before path construction
- [x] No `innerHTML` with dynamic data — all output goes through the existing `<tool-result>` tag / React rendering
- [x] `contextIsolation: true`, `nodeIntegration: false` unchanged
- [x] No hardcoded secrets
- [x] `shell.openExternal` paths unchanged (still http/https only)

## Files changed
- `src/main/ipc.ts` — 5 new `github:*` IPC handlers + `GITHUB_PAT_KEY` constant
- `src/preload/index.ts` — interfaces + 5 preload bindings
- `src/renderer/types/index.ts` — optional method declarations on `ElectronAPI`
- `src/renderer/lib/browserApi.ts` — browser stubs
- `src/renderer/mocks/webApi.ts` — mock stubs
- `src/renderer/components/settings/GitHubIntegration.tsx` — new PAT settings component
- `src/renderer/components/settings/SettingsDialog.tsx` — wires `GitHubIntegration` into Integrations tab
- `src/renderer/components/chat/ChatInput.tsx` — extended `/report-bug` + `/request-feature` handlers

## Assumptions / follow-ups
- **Hardcoded repo**: `GITHUB_OWNER = 'solo-ist'`, `GITHUB_REPO = 'prose'` — issues always file against the Prose repo. Could be made configurable later if needed.
- **OAuth deferred**: The issue mentions OAuth device flow as an alternative auth; deferred per the scope note in #755.
- **Labels**: `['bug']` for bug reports, `['enhancement']` for feature requests. Labels that don't exist on the repo are silently ignored by the GitHub API.
- `buildInfo.generated.ts` is gitignored (auto-generated at build time); the import already existed in `AboutDialog.tsx` and works in the build pipeline.

Closes #755
Refs #716 #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)