### PR TITLE
fix: tab/menu + emoji + favorites/projects polish (QoL Pass 2 HITL)

### DIFF
--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { cn } from '../../lib/utils'
 import type { ChatMessage as ChatMessageType } from '../../types'
 import { User, AlertCircle, Sparkles, CheckCircle2, XCircle, RotateCcw, ChevronDown } from 'lucide-react'
@@ -19,6 +19,19 @@ type ToolCallStatus = 'drafting' | 'executing' | 'success' | 'error'
 // Tool call indicator component with AI sparkle styling
 function ToolCallIndicator({ name, status, onClick, children, actions, defaultExpanded = false }: { name: string; status: ToolCallStatus; onClick?: () => void; children?: React.ReactNode; actions?: React.ReactNode; defaultExpanded?: boolean }) {
   const [expanded, setExpanded] = useState(defaultExpanded)
+  // A live tool call mounts during `executing`, when `defaultExpanded` is still
+  // false (the custom renderer that sets it only runs once the result arrives).
+  // Since useState's initializer is captured once, the later flip to true would
+  // be ignored and the block would stay collapsed. Apply it exactly once on the
+  // false→true transition, so a freshly-finished list_files auto-expands while
+  // still respecting a manual collapse afterward.
+  const appliedDefaultExpand = useRef(defaultExpanded)
+  useEffect(() => {
+    if (defaultExpanded && !appliedDefaultExpand.current) {
+      appliedDefaultExpand.current = true
+      setExpanded(true)
+    }
+  }, [defaultExpanded])
   // Drafting and executing are mid-flight states: no body to expand yet.
   const hasBody = children != null && status !== 'executing' && status !== 'drafting'
   const hasActions = actions != null

--- a/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
+++ b/src/renderer/components/chat/toolResultRenderers/ListFilesResult.tsx
@@ -3,7 +3,7 @@ import { FileTree } from '../../files/FileTree'
 import { useTabs } from '../../../hooks/useTabs'
 import { useFileListStore } from '../../../stores/fileListStore'
 import { useSettingsStore } from '../../../stores/settingsStore'
-import { useFavorites } from '../../../stores/projectsStore'
+import { useFavorites, useProjects } from '../../../stores/projectsStore'
 import type { FileItem } from '../../../types'
 
 interface ListFilesResultProps {
@@ -61,6 +61,10 @@ export function ListFilesResult({ content }: ListFilesResultProps) {
   // per-item settingsStore subscription.
   const favorites = useFavorites()
   const favoritePaths = useMemo(() => new Set(favorites.map((f) => f.path)), [favorites])
+  // Same for projects, so a project folder in a result shows the project icon
+  // (parity with the file-explorer panel).
+  const projects = useProjects()
+  const projectPaths = useMemo(() => new Set(projects.map((p) => p.path)), [projects])
 
   // Add a path to the persisted favorites list. Idempotent: dedup by path so
   // re-adding is a no-op. Mirrors FileListPanel.addPathAsFavorite.
@@ -75,6 +79,13 @@ export function ListFilesResult({ content }: ListFilesResultProps) {
       isDirectory,
       addedAt: new Date().toISOString(),
     })
+  }, [])
+
+  // Inverse of addPathAsFavorite, so the tree's right-click menu can toggle
+  // (Add ↔ Remove) here too, matching the file-explorer panel.
+  const removePathAsFavorite = useCallback((path: string) => {
+    const fav = (useSettingsStore.getState().settings.favorites ?? []).find((f) => f.path === path)
+    if (fav) useSettingsStore.getState().removeFavorite(fav.id)
   }, [])
 
   let parsed: ListFilesEnvelope | null = null
@@ -117,11 +128,13 @@ export function ListFilesResult({ content }: ListFilesResultProps) {
       <FileTree
         items={files}
         favoritePaths={favoritePaths}
+        projectPaths={projectPaths}
         expandedFolders={expandedFolders}
         selectedPath={null}
         onFileClick={handleFileClick}
         onFolderToggle={handleFolderToggle}
         onAddFavorite={addPathAsFavorite}
+        onRemoveFavorite={removePathAsFavorite}
       />
       {payload.truncated && payload.totalFound !== undefined && (
         <div className="mt-2 text-[11px] text-muted-foreground">

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -94,6 +94,7 @@ export function FileListPanel() {
   // Subscribe to favorites once here and pass a path Set down the tree, so each
   // FileTreeItem doesn't hold its own settingsStore subscription (O(1), not O(nodes)).
   const favoritePaths = useMemo(() => new Set(favorites.map((f) => f.path)), [favorites])
+  const projectPaths = useMemo(() => new Set(projects.map((p) => p.path)), [projects])
   const { exitToRoot } = useProjectsStore()
   const defaultSaveDirectory = useSettingsStore((s) => s.settings.defaultSaveDirectory)
   // The project whose folder contains the current view root (handles drill-down
@@ -354,6 +355,19 @@ export function FileListPanel() {
       isDirectory,
       addedAt: new Date().toISOString(),
     })
+  }, [])
+
+  // Inverse of the add helpers: look the pointer up by path and drop it. Go
+  // through useProjectsStore.removeProject (not the bare settings mutator) so an
+  // active project removal also reconciles the explorer view back to base root.
+  const removePathAsFavorite = useCallback((path: string) => {
+    const fav = (useSettingsStore.getState().settings.favorites ?? []).find((f) => f.path === path)
+    if (fav) useProjectsStore.getState().removeFavorite(fav.id)
+  }, [])
+
+  const removePathAsProject = useCallback((path: string) => {
+    const proj = (useSettingsStore.getState().settings.projects ?? []).find((p) => p.path === path)
+    if (proj) useProjectsStore.getState().removeProject(proj.id)
   }, [])
 
   const handleCreateNewFile = async () => {
@@ -1436,6 +1450,7 @@ export function FileListPanel() {
                     <FileTree
                       items={files}
                       favoritePaths={favoritePaths}
+                      projectPaths={projectPaths}
                       expandedFolders={expandedFolders}
                       selectedPath={selectedPath}
                       loadingFolders={loadingFolders}
@@ -1459,6 +1474,8 @@ export function FileListPanel() {
                       onNewFile={handleNewFileInDir}
                       onAddProject={addPathAsProject}
                       onAddFavorite={addPathAsFavorite}
+                      onRemoveProject={removePathAsProject}
+                      onRemoveFavorite={removePathAsFavorite}
                       onFileDrop={handleFileDrop}
                     />
                   )}

--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import type { FileItem } from '../../types'
 import { ChevronRight, ChevronDown, FileText, FileType, Folder, FolderOpen, Loader2, Trash2, Edit3, ExternalLink, Copy, Scissors, ClipboardPaste, FilePlus, Boxes, Star } from 'lucide-react'
 import { cn } from '../../lib/utils'
+import { useSettingsStore } from '../../stores/settingsStore'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -183,9 +184,21 @@ function FileTreeItem({
   // Denote favorite files in the tree (folders keep their folder icon).
   // favoritePaths is subscribed once at the root and threaded down (no per-item subscription).
   const isFavorite = !item.isDirectory && favoritePaths.has(item.path)
-  // Whether this item (file or folder) is in the favorites list — used for
-  // the trailing star button affordance that applies to both types.
-  const isItemFavorited = favoritePaths.has(item.path)
+
+  // Toggle this file's favorite state from the leading icon affordance. Add
+  // goes through the threaded onAddFavorite (so the call site's dedupe/persist
+  // logic runs); remove looks up the favorite by path and drops it.
+  const handleToggleFavorite = useCallback(() => {
+    if (item.isDirectory) return
+    if (isFavorite) {
+      const fav = (useSettingsStore.getState().settings.favorites ?? []).find(
+        (f) => f.path === item.path
+      )
+      if (fav) useSettingsStore.getState().removeFavorite(fav.id)
+    } else {
+      onAddFavorite?.(item.path, item.isDirectory)
+    }
+  }, [isFavorite, item.path, item.isDirectory, onAddFavorite])
 
   // Inline rename state
   const [renameValue, setRenameValue] = useState('')
@@ -331,7 +344,7 @@ function FileTreeItem({
 
   const buttonElement = (
     <div
-      className={cn("group flex items-center", ((!item.isDirectory && onFileLinkClick) || onAddFavorite) && "relative")}
+      className={cn("group flex items-center", !item.isDirectory && onFileLinkClick && "relative")}
     >
       <button
         ref={buttonRef}
@@ -372,7 +385,35 @@ function FileTreeItem({
         ) : (
           <>
             <span className="w-3.5" />
-            {isFavorite ? (
+            {onAddFavorite && !isRenaming ? (
+              // Quick-favorite affordance in the file-icon slot: filled star when
+              // favorited; otherwise the file icon, swapped to an empty star on
+              // row hover. Clicking toggles favorite (stopPropagation so it does
+              // not also open the file).
+              <span
+                role="button"
+                tabIndex={-1}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleToggleFavorite()
+                }}
+                title={isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
+                className="shrink-0 inline-flex h-4 w-4 items-center justify-center"
+              >
+                {isFavorite ? (
+                  <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
+                ) : (
+                  <>
+                    {item.name.endsWith('.txt') ? (
+                      <FileType className="h-4 w-4 text-muted-foreground group-hover:hidden" />
+                    ) : (
+                      <FileText className="h-4 w-4 text-muted-foreground group-hover:hidden" />
+                    )}
+                    <Star className="hidden h-4 w-4 text-muted-foreground group-hover:block hover:text-amber-400" />
+                  </>
+                )}
+              </span>
+            ) : isFavorite ? (
               <Star className="h-4 w-4 shrink-0 fill-amber-400 text-amber-400" />
             ) : item.name.endsWith('.txt') ? (
               <FileType className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -405,26 +446,6 @@ function FileTreeItem({
           title="Open in Google Docs"
         >
           <ExternalLink className="h-3 w-3 text-muted-foreground" />
-        </button>
-      )}
-      {onAddFavorite && !isRenaming && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onAddFavorite(item.path, item.isDirectory)
-          }}
-          className={cn(
-            'absolute right-1 p-1 rounded hover:bg-accent transition-opacity',
-            isItemFavorited ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-          )}
-          title={isItemFavorited ? 'Favorited' : 'Add to Favorites'}
-        >
-          <Star
-            className={cn(
-              'h-3 w-3',
-              isItemFavorited ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground'
-            )}
-          />
         </button>
       )}
     </div>

--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import type { FileItem } from '../../types'
 import { ChevronRight, ChevronDown, FileText, FileType, Folder, FolderOpen, Loader2, Trash2, Edit3, ExternalLink, Copy, Scissors, ClipboardPaste, FilePlus, Boxes, Star } from 'lucide-react'
 import { cn } from '../../lib/utils'
-import { useSettingsStore } from '../../stores/settingsStore'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -12,12 +11,14 @@ import {
   ContextMenuTrigger
 } from '../ui/context-menu'
 
-const EMPTY_FAVORITE_PATHS: ReadonlySet<string> = new Set()
+const EMPTY_PATH_SET: ReadonlySet<string> = new Set()
 
 interface FileTreeProps {
   items: FileItem[]
   /** Set of favorited file paths, subscribed once at the root and threaded down. */
   favoritePaths?: ReadonlySet<string>
+  /** Set of project folder paths, subscribed once at the root and threaded down. */
+  projectPaths?: ReadonlySet<string>
   expandedFolders: Set<string>
   selectedPath: string | null
   loadingFolders?: Set<string>
@@ -42,13 +43,16 @@ interface FileTreeProps {
   onNewFile?: (dirPath: string) => void
   onAddProject?: (path: string) => void
   onAddFavorite?: (path: string, isDirectory: boolean) => void
+  onRemoveProject?: (path: string) => void
+  onRemoveFavorite?: (path: string) => void
   onFileDrop?: (sourcePath: string, targetDirPath: string) => void
   depth?: number
 }
 
 export function FileTree({
   items,
-  favoritePaths = EMPTY_FAVORITE_PATHS,
+  favoritePaths = EMPTY_PATH_SET,
+  projectPaths = EMPTY_PATH_SET,
   expandedFolders,
   selectedPath,
   loadingFolders,
@@ -73,6 +77,8 @@ export function FileTree({
   onNewFile,
   onAddProject,
   onAddFavorite,
+  onRemoveProject,
+  onRemoveFavorite,
   onFileDrop,
   depth = 0
 }: FileTreeProps) {
@@ -83,6 +89,7 @@ export function FileTree({
           key={item.path}
           item={item}
           favoritePaths={favoritePaths}
+          projectPaths={projectPaths}
           expandedFolders={expandedFolders}
           selectedPath={selectedPath}
           loadingFolders={loadingFolders}
@@ -107,6 +114,8 @@ export function FileTree({
           onNewFile={onNewFile}
           onAddProject={onAddProject}
           onAddFavorite={onAddFavorite}
+          onRemoveProject={onRemoveProject}
+          onRemoveFavorite={onRemoveFavorite}
           onFileDrop={onFileDrop}
           depth={depth}
         />
@@ -118,6 +127,7 @@ export function FileTree({
 interface FileTreeItemProps {
   item: FileItem
   favoritePaths: ReadonlySet<string>
+  projectPaths: ReadonlySet<string>
   expandedFolders: Set<string>
   selectedPath: string | null
   loadingFolders?: Set<string>
@@ -142,6 +152,8 @@ interface FileTreeItemProps {
   onNewFile?: (dirPath: string) => void
   onAddProject?: (path: string) => void
   onAddFavorite?: (path: string, isDirectory: boolean) => void
+  onRemoveProject?: (path: string) => void
+  onRemoveFavorite?: (path: string) => void
   onFileDrop?: (sourcePath: string, targetDirPath: string) => void
   depth: number
 }
@@ -149,6 +161,7 @@ interface FileTreeItemProps {
 function FileTreeItem({
   item,
   favoritePaths,
+  projectPaths,
   expandedFolders,
   selectedPath,
   loadingFolders,
@@ -173,6 +186,8 @@ function FileTreeItem({
   onNewFile,
   onAddProject,
   onAddFavorite,
+  onRemoveProject,
+  onRemoveFavorite,
   onFileDrop,
   depth
 }: FileTreeItemProps) {
@@ -184,21 +199,11 @@ function FileTreeItem({
   // Denote favorite files in the tree (folders keep their folder icon).
   // favoritePaths is subscribed once at the root and threaded down (no per-item subscription).
   const isFavorite = !item.isDirectory && favoritePaths.has(item.path)
-
-  // Toggle this file's favorite state from the leading icon affordance. Add
-  // goes through the threaded onAddFavorite (so the call site's dedupe/persist
-  // logic runs); remove looks up the favorite by path and drops it.
-  const handleToggleFavorite = useCallback(() => {
-    if (item.isDirectory) return
-    if (isFavorite) {
-      const fav = (useSettingsStore.getState().settings.favorites ?? []).find(
-        (f) => f.path === item.path
-      )
-      if (fav) useSettingsStore.getState().removeFavorite(fav.id)
-    } else {
-      onAddFavorite?.(item.path, item.isDirectory)
-    }
-  }, [isFavorite, item.path, item.isDirectory, onAddFavorite])
+  // For the right-click menu, favorite/project membership applies to folders too
+  // (a folder can be a favorite or a project), unlike the file-only icon above.
+  // These drive the "Add … / Remove …" toggle so the menu reflects current state.
+  const isFavoritePath = favoritePaths.has(item.path)
+  const isProjectPath = projectPaths.has(item.path)
 
   // Inline rename state
   const [renameValue, setRenameValue] = useState('')
@@ -378,6 +383,10 @@ function FileTreeItem({
             )}
             {isDragOver ? (
               <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+            ) : isProjectPath ? (
+              // Project folders get the established project icon (Boxes), mirroring
+              // how favorited files swap their file icon for a star.
+              <Boxes className="h-4 w-4 shrink-0 text-muted-foreground" />
             ) : (
               <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
             )}
@@ -385,36 +394,8 @@ function FileTreeItem({
         ) : (
           <>
             <span className="w-3.5" />
-            {onAddFavorite && !isRenaming ? (
-              // Quick-favorite affordance in the file-icon slot: filled star when
-              // favorited; otherwise the file icon, swapped to an empty star on
-              // row hover. Clicking toggles favorite (stopPropagation so it does
-              // not also open the file).
-              <span
-                role="button"
-                tabIndex={-1}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleToggleFavorite()
-                }}
-                title={isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
-                className="shrink-0 inline-flex h-4 w-4 items-center justify-center"
-              >
-                {isFavorite ? (
-                  <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
-                ) : (
-                  <>
-                    {item.name.endsWith('.txt') ? (
-                      <FileType className="h-4 w-4 text-muted-foreground group-hover:hidden" />
-                    ) : (
-                      <FileText className="h-4 w-4 text-muted-foreground group-hover:hidden" />
-                    )}
-                    <Star className="hidden h-4 w-4 text-muted-foreground group-hover:block hover:text-amber-400" />
-                  </>
-                )}
-              </span>
-            ) : isFavorite ? (
-              <Star className="h-4 w-4 shrink-0 fill-amber-400 text-amber-400" />
+            {isFavorite ? (
+              <Star className="h-4 w-4 shrink-0 fill-current text-muted-foreground" />
             ) : item.name.endsWith('.txt') ? (
               <FileType className="h-4 w-4 shrink-0 text-muted-foreground" />
             ) : (
@@ -499,10 +480,17 @@ function FileTreeItem({
       {onAddFavorite && (
         <>
           <ContextMenuSeparator />
-          <ContextMenuItem onClick={() => onAddFavorite(item.path, false)}>
-            <Star className="h-4 w-4 mr-2" />
-            Add to Favorites
-          </ContextMenuItem>
+          {isFavoritePath && onRemoveFavorite ? (
+            <ContextMenuItem onClick={() => onRemoveFavorite(item.path)}>
+              <Star className="h-4 w-4 mr-2 fill-current" />
+              Remove from Favorites
+            </ContextMenuItem>
+          ) : (
+            <ContextMenuItem onClick={() => onAddFavorite(item.path, false)}>
+              <Star className="h-4 w-4 mr-2" />
+              Add to Favorites
+            </ContextMenuItem>
+          )}
         </>
       )}
       {(onFileTrash || onFileDelete) && (
@@ -548,16 +536,30 @@ function FileTreeItem({
       )}
       {(onAddProject || onAddFavorite) && <ContextMenuSeparator />}
       {onAddProject && (
-        <ContextMenuItem onClick={() => onAddProject(item.path)}>
-          <Boxes className="h-4 w-4 mr-2" />
-          Add as Project
-        </ContextMenuItem>
+        isProjectPath && onRemoveProject ? (
+          <ContextMenuItem onClick={() => onRemoveProject(item.path)}>
+            <Boxes className="h-4 w-4 mr-2" />
+            Remove from Projects
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem onClick={() => onAddProject(item.path)}>
+            <Boxes className="h-4 w-4 mr-2" />
+            Add as Project
+          </ContextMenuItem>
+        )
       )}
       {onAddFavorite && (
-        <ContextMenuItem onClick={() => onAddFavorite(item.path, true)}>
-          <Star className="h-4 w-4 mr-2" />
-          Add to Favorites
-        </ContextMenuItem>
+        isFavoritePath && onRemoveFavorite ? (
+          <ContextMenuItem onClick={() => onRemoveFavorite(item.path)}>
+            <Star className="h-4 w-4 mr-2 fill-amber-400 text-amber-400" />
+            Remove from Favorites
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem onClick={() => onAddFavorite(item.path, true)}>
+            <Star className="h-4 w-4 mr-2" />
+            Add to Favorites
+          </ContextMenuItem>
+        )
       )}
     </ContextMenuContent>
   )
@@ -580,6 +582,7 @@ function FileTreeItem({
         <FileTree
           items={item.children}
           favoritePaths={favoritePaths}
+          projectPaths={projectPaths}
           expandedFolders={expandedFolders}
           selectedPath={selectedPath}
           loadingFolders={loadingFolders}
@@ -604,6 +607,8 @@ function FileTreeItem({
           onNewFile={onNewFile}
           onAddProject={onAddProject}
           onAddFavorite={onAddFavorite}
+          onRemoveProject={onRemoveProject}
+          onRemoveFavorite={onRemoveFavorite}
           onFileDrop={onFileDrop}
           depth={depth + 1}
         />

--- a/src/renderer/components/files/ProjectsPanel.tsx
+++ b/src/renderer/components/files/ProjectsPanel.tsx
@@ -87,7 +87,7 @@ function ProjectItem({ id, name, path, isActive, onSwitch, onRename, onRemove }:
           onClick={() => onRemove(id)}
         >
           <Trash2 className="h-4 w-4 mr-2" />
-          Remove
+          Remove from Projects
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
@@ -132,7 +132,7 @@ function FavoriteItem({ id, name, path, onNavigate, onRename, onRemove }: Favori
           onClick={() => onRemove(id)}
         >
           <Trash2 className="h-4 w-4 mr-2" />
-          Remove
+          Remove from Favorites
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -24,6 +24,8 @@ import { useTabEmoji } from '../../hooks/useTabEmoji'
 import { regenerateEmoji } from '../../lib/emojiService'
 import { useSettings } from '../../hooks/useSettings'
 import { isMacOS } from '../../lib/browserApi'
+import { isAIConfigured } from '../../lib/llm'
+import { useNotificationStore } from '../../stores/notificationStore'
 
 interface TabBarProps {
   onTabClick: (tabId: string) => void
@@ -275,19 +277,39 @@ function TabItem({
   const lastDot = tab.path ? tab.path.lastIndexOf('.') : -1
   const extension = lastDot > 0 ? tab.path!.substring(lastDot) : ''
 
+  // Emoji generation is LLM-powered (main-process emoji:generate → Anthropic).
+  // Without a configured key it silently no-ops, so give explicit feedback
+  // rather than appearing dead.
   const handleRegenEmoji = useCallback(() => {
+    if (!isAIConfigured(settings)) {
+      useNotificationStore.getState().notify({
+        id: 'emoji-needs-ai',
+        message: 'Emoji generation needs an Anthropic API key — add one in Settings → Integrations.',
+      })
+      return
+    }
     regenerateEmoji(tab)
-  }, [tab])
+  }, [tab, settings])
 
-  // Add the tab's file to global Favorites. Untitled (unsaved) tabs have no
-  // path to point at, so the menu item is disabled for them. Dedup by path
-  // like the file-tree version (FileListPanel.addPathAsFavorite).
-  const handleAddFavorite = useCallback(() => {
+  // Whether this tab's file is currently a favorite. Subscribed (not a
+  // getState snapshot) so the menu item's label/icon stay in sync after a
+  // toggle. Untitled (unsaved) tabs have no path and can't be favorited.
+  const isFavorited = useSettingsStore(
+    (state) => !!tab.path && (state.settings.favorites ?? []).some((f) => f.path === tab.path)
+  )
+
+  // Toggle the tab's file in global Favorites. Dedup by path like the
+  // file-tree version (FileListPanel.addPathAsFavorite).
+  const handleToggleFavorite = useCallback(() => {
     if (!tab.path) return
-    const existing = useSettingsStore.getState().settings.favorites ?? []
-    if (existing.some((f) => f.path === tab.path)) return
+    const store = useSettingsStore.getState()
+    const existing = (store.settings.favorites ?? []).find((f) => f.path === tab.path)
+    if (existing) {
+      store.removeFavorite(existing.id)
+      return
+    }
     const name = tab.path.split('/').pop() || tab.path
-    useSettingsStore.getState().addFavorite({
+    store.addFavorite({
       id: self.crypto.randomUUID(),
       name,
       path: tab.path,
@@ -454,9 +476,9 @@ function TabItem({
             </>
           )}
           <ContextMenuSeparator />
-          <ContextMenuItem onClick={handleAddFavorite} disabled={!tab.path}>
-            <Star className="h-4 w-4 mr-2" />
-            Add to Favorites
+          <ContextMenuItem onClick={handleToggleFavorite} disabled={!tab.path}>
+            <Star className={cn('h-4 w-4 mr-2', isFavorited && 'fill-amber-400 text-amber-400')} />
+            {isFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
           </ContextMenuItem>
           <ContextMenuItem onClick={onShowInFolder} disabled={!tab.path}>
             <ExternalLink className="h-4 w-4 mr-2" />

--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -21,7 +21,6 @@ import {
 import type { TabTier } from '../../hooks/useTabTier'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useTabEmoji } from '../../hooks/useTabEmoji'
-import { regenerateEmoji } from '../../lib/emojiService'
 import { useSettings } from '../../hooks/useSettings'
 import { isMacOS } from '../../lib/browserApi'
 import { isAIConfigured } from '../../lib/llm'
@@ -262,7 +261,7 @@ function TabItem({
 
   // Emoji: always generate eagerly, display based on tab width or setting
   const { settings } = useSettings()
-  const emoji = useTabEmoji(tab)
+  const { emoji, regenerate } = useTabEmoji(tab)
   const showEmoji = settings.llm.emojiIcons || (tabWidth !== undefined && tabWidth <= 140)
 
   // Focus input when editing starts
@@ -288,8 +287,14 @@ function TabItem({
       })
       return
     }
-    regenerateEmoji(tab)
-  }, [tab, settings])
+    // For the active tab the freshest content lives in the editor, not
+    // tab.content (which can lag) — pass it so regeneration reflects what the
+    // user actually wrote (mirrors the H1-suggestion logic in handleDoubleClick).
+    const liveContent = isActive
+      ? useEditorStore.getState().document.content
+      : tab.content
+    regenerate(liveContent)
+  }, [tab, isActive, settings, regenerate])
 
   // Whether this tab's file is currently a favorite. Subscribed (not a
   // getState snapshot) so the menu item's label/icon stay in sync after a
@@ -477,7 +482,7 @@ function TabItem({
           )}
           <ContextMenuSeparator />
           <ContextMenuItem onClick={handleToggleFavorite} disabled={!tab.path}>
-            <Star className={cn('h-4 w-4 mr-2', isFavorited && 'fill-amber-400 text-amber-400')} />
+            <Star className={cn('h-4 w-4 mr-2', isFavorited && 'fill-current')} />
             {isFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
           </ContextMenuItem>
           <ContextMenuItem onClick={onShowInFolder} disabled={!tab.path}>

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -162,6 +162,12 @@ export function Toolbar() {
     ? useTabStore.getState().getTabById(pendingCloseTabId)
     : null
 
+  // Bulk-close (Close Other / Close All Tabs) confirmation when one or more of
+  // the tabs being closed have unsaved changes.
+  const [pendingBulkClose, setPendingBulkClose] = useState<
+    { kind: 'others' | 'all'; keepTabId?: string; dirtyCount: number } | null
+  >(null)
+
   // Conditional 3-state cycle that always starts with a *visible* flip:
   // from System, jump to the opposite of what the OS is currently showing;
   // then to the OS-matching value; then back to System.
@@ -228,23 +234,32 @@ export function Toolbar() {
   }
 
   const handleCloseOthers = async (tabId: string) => {
-    // Check for dirty tabs
+    // Confirm before discarding any unsaved tabs (the bulk close force-closes).
     const dirtyTabs = tabs.filter(t => t.id !== tabId && t.isDirty)
     if (dirtyTabs.length > 0) {
-      // For now, just close non-dirty tabs
-      // TODO: Could show a multi-save dialog
+      setPendingBulkClose({ kind: 'others', keepTabId: tabId, dirtyCount: dirtyTabs.length })
+      return
     }
     await closeOtherTabs(tabId)
   }
 
   const handleCloseAll = async () => {
-    // Check for dirty tabs
     const dirtyTabs = tabs.filter(t => t.isDirty)
     if (dirtyTabs.length > 0) {
-      // For now, just close non-dirty tabs
-      // TODO: Could show a multi-save dialog
+      setPendingBulkClose({ kind: 'all', dirtyCount: dirtyTabs.length })
+      return
     }
     await closeAllTabs()
+  }
+
+  const handleConfirmBulkClose = async () => {
+    if (!pendingBulkClose) return
+    if (pendingBulkClose.kind === 'others' && pendingBulkClose.keepTabId) {
+      await closeOtherTabs(pendingBulkClose.keepTabId)
+    } else {
+      await closeAllTabs()
+    }
+    setPendingBulkClose(null)
   }
 
   const handleClose = useCallback(async () => {
@@ -635,6 +650,30 @@ export function Toolbar() {
             </AlertDialogAction>
             <AlertDialogAction onClick={handleSaveAndClose}>
               Save
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Bulk-close confirmation: Close Other / Close All Tabs with unsaved work */}
+      <AlertDialog open={pendingBulkClose !== null} onOpenChange={(open) => !open && setPendingBulkClose(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingBulkClose?.dirtyCount === 1
+                ? 'Close an unsaved document?'
+                : `Close ${pendingBulkClose?.dirtyCount} unsaved documents?`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingBulkClose?.dirtyCount === 1
+                ? 'One of the tabs being closed has unsaved changes that will be lost.'
+                : `${pendingBulkClose?.dirtyCount} of the tabs being closed have unsaved changes that will be lost.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPendingBulkClose(null)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleConfirmBulkClose}>
+              Close Without Saving
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/renderer/components/ui/context-menu.tsx
+++ b/src/renderer/components/ui/context-menu.tsx
@@ -19,7 +19,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       inset && "pl-8",
       className
     )}
@@ -72,7 +72,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -88,7 +88,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -112,7 +112,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/renderer/hooks/useTabEmoji.ts
+++ b/src/renderer/hooks/useTabEmoji.ts
@@ -1,13 +1,24 @@
-import { useState, useEffect } from 'react'
-import { generateEmoji, getEmojiSync, FALLBACK_EMOJI } from '../lib/emojiService'
+import { useState, useEffect, useCallback } from 'react'
+import { generateEmoji, regenerateEmoji, getEmojiSync, FALLBACK_EMOJI } from '../lib/emojiService'
 import type { Tab } from '../stores/tabStore'
 
+export interface TabEmoji {
+  /** The emoji to display for this tab. */
+  emoji: string
+  /**
+   * Clear this tab's cached emoji and generate a fresh one, updating the
+   * displayed value when it resolves. Optionally pass live content (e.g. the
+   * active tab's in-editor text) since `tab.content` can lag behind the editor.
+   */
+  regenerate: (contentOverride?: string) => Promise<void>
+}
+
 /**
- * Returns an emoji for a tab. Always generates eagerly so the emoji is
- * ready when the tab bar needs to display it. Starts with cached emoji
- * or fallback, updates async when generation completes.
+ * Returns an emoji for a tab plus a regenerate function. Always generates
+ * eagerly so the emoji is ready when the tab bar needs to display it. Starts
+ * with cached emoji or fallback, updates async when generation completes.
  */
-export function useTabEmoji(tab: Tab): string {
+export function useTabEmoji(tab: Tab): TabEmoji {
   const [emoji, setEmoji] = useState<string>(() => {
     return getEmojiSync(tab) ?? FALLBACK_EMOJI
   })
@@ -33,5 +44,16 @@ export function useTabEmoji(tab: Tab): string {
     // (e.g. a "…Robots" emoji leaking onto the next Untitled tab).
   }, [tab.id, tab.path, tab.title])
 
-  return emoji
+  // Regenerate is a user action (the tab's "Regenerate Emoji" menu item). The
+  // service clears its cache and re-generates; we must push the result into
+  // local state ourselves — the effect above won't re-run (its deps are
+  // unchanged), so without this the visible emoji would never update.
+  const regenerate = useCallback(async (contentOverride?: string) => {
+    const result = await regenerateEmoji(
+      contentOverride !== undefined ? { ...tab, content: contentOverride } : tab
+    )
+    setEmoji(result)
+  }, [tab])
+
+  return { emoji, regenerate }
 }

--- a/src/renderer/hooks/useTabEmoji.ts
+++ b/src/renderer/hooks/useTabEmoji.ts
@@ -27,7 +27,11 @@ export function useTabEmoji(tab: Tab): string {
     })
 
     return () => { cancelled = true }
-  }, [tab.path, tab.title])
+    // Keyed on tab.id (not just path/title): a new/Untitled tab can share a
+    // path (null) with a previous one, so without tab.id the effect wouldn't
+    // re-run and an earlier tab's in-flight emoji could resolve onto this tab
+    // (e.g. a "…Robots" emoji leaking onto the next Untitled tab).
+  }, [tab.id, tab.path, tab.title])
 
   return emoji
 }

--- a/src/renderer/lib/emojiService.ts
+++ b/src/renderer/lib/emojiService.ts
@@ -19,8 +19,14 @@ const queue: Array<() => void> = []
 
 export const FALLBACK_EMOJI = '\u{1F4C4}' // 📄
 
-function getCacheKey(tab: { path: string | null; title: string }): string {
-  return tab.path ? `path:${tab.path}` : `title:${tab.title}`
+function getCacheKey(tab: { id: string; path: string | null; title: string }): string {
+  // Saved files key on path (so multiple tabs of the same file share an emoji
+  // and it persists across sessions). Untitled tabs have no path AND share the
+  // title "Untitled", so a title key collides across every Untitled tab — an
+  // emoji generated for one (e.g. a robot from a "…Robots" draft) would leak
+  // onto the next. Key those on the stable per-tab id instead (tab ids survive
+  // restart via session persistence, so a restored draft keeps its emoji).
+  return tab.path ? `path:${tab.path}` : `id:${tab.id}`
 }
 
 function getPromptTitle(tab: { path: string | null; title: string }): string {
@@ -62,7 +68,7 @@ function releaseConcurrencySlot(): void {
  * otherwise triggers async generation and returns fallback.
  * Only caches real emoji results — fallbacks are NOT cached, allowing retries.
  */
-export async function generateEmoji(tab: { path: string | null; title: string; content?: string }): Promise<string> {
+export async function generateEmoji(tab: { id: string; path: string | null; title: string; content?: string }): Promise<string> {
   const key = getCacheKey(tab)
 
   // 1. Check memory cache (only contains real emojis, never fallback)
@@ -126,14 +132,14 @@ export async function generateEmoji(tab: { path: string | null; title: string; c
 /**
  * Get emoji synchronously from memory cache. Returns undefined if not cached.
  */
-export function getEmojiSync(tab: { path: string | null; title: string }): string | undefined {
+export function getEmojiSync(tab: { id: string; path: string | null; title: string }): string | undefined {
   return memoryCache.get(getCacheKey(tab))
 }
 
 /**
  * Regenerate emoji for a tab (clears cache and generates fresh).
  */
-export async function regenerateEmoji(tab: { path: string | null; title: string; content?: string }): Promise<string> {
+export async function regenerateEmoji(tab: { id: string; path: string | null; title: string; content?: string }): Promise<string> {
   const key = getCacheKey(tab)
   memoryCache.delete(key)
   await deleteEmojiCache(key).catch(() => {})


### PR DESCRIPTION
HITL fix-up branch for the QoL Pass 2 wave. Covers the tab context-menu
follow-ups plus the deeper emoji / `list_files` / favorites-projects polish
surfaced across two more rounds of manual QA. All verified live in the dev
instance.

## Tab context menu
- Bulk close ("Close All" / "Close Others") now confirms before discarding
  unsaved docs instead of silently closing them.
- "Add to Favorites" ↔ "Remove from Favorites" reflects current state.

## Emoji
- Fix Untitled-tab emoji **leak**: the service cache keyed every path-less
  tab as `title:Untitled`, so an emoji generated for one (e.g. a robot from
  a "…Robots" draft) leaked onto the next Untitled tab. Path-less tabs now
  key on `tab.id`.
- Fix **Regenerate Emoji** doing nothing: `useTabEmoji` returns
  `{emoji, regenerate}` so the displayed value updates; regenerate uses live
  editor content for the active tab. Keyless path shows a notification.

## Chat / files
- `list_files` result reliably **defaults expanded** (the expand state had
  been captured during streaming when the flag was still false).
- Removed the hover-star favorite affordance from the file tree (explorer +
  `list_files`). Favoriting stays on right-click + the passive star indicator.
- **Remove from Favorites / Remove from Projects** toggle when an item is
  already one — in the FileTree menu, `list_files`, and the Favorites/Projects
  panels.
- Monochrome favorite star (dropped amber); project folders show the Boxes
  project icon (parity with favorited files).
- Pointer cursor on all context-menu items.

Refs #746 #717
