### PR TITLE
chore(release): v1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prose",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prose",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "A minimal markdown editor with AI chat",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump for the **v1.6.4** GitHub/desktop release.

Cuts the next patch off `main`, which has accumulated the full QoL Pass 2 wave
since v1.6.3 (footnotes/super-subscript, Favorites & Projects across the app,
`/report-bug` + `/request-feature`, frontmatter Enter/Escape, Chat/Activity
arrow-key nav, the HITL polish in #759, and the esbuild security pin in #761).

Once merged, I'll tag `v1.6.4` to trigger `release.yml` (build → sign →
notarize → draft release), then publish with full release notes.

Bump only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
