### PR TITLE
chore(qa): add Circuit Electron orphan reaper

### DIFF
--- a/.claude/skills/qa-accelerated/SKILL.md
+++ b/.claude/skills/qa-accelerated/SKILL.md
@@ -109,6 +109,9 @@ git branch -r | grep -E "origin/(feat|fix|refactor|spike|chore)/${issue}-" | hea
 # Kill stale processes first
 pkill -f "Electron.app" 2>/dev/null || true
 pkill -f "electron-vite" 2>/dev/null || true
+# Reap leaked Circuit servers (safe: dead-client orphans only). Runs each issue,
+# so a long batch can't accumulate them. See CLAUDE.md › Orphaned Circuit Server Cleanup.
+node scripts/reap-circuit.mjs 2>/dev/null || true
 
 # Fetch and checkout
 git fetch origin

--- a/.claude/skills/qa-hitl/SKILL.md
+++ b/.claude/skills/qa-hitl/SKILL.md
@@ -97,6 +97,7 @@ Order stages so cheap, no-LLM checks fail fast before expensive ones. Adapt the 
 - **Go/no-go**: 100% pass + fix-PRs merged into the integration branch + deferred items triaged → GO. List deferred bugs and decide ship-anyway vs hold.
 - **Run log**: append a final pass/fail table to the reference doc so the next session has a durable record of verified-vs-deferred.
 - **Release**: on GO, the integration branch merges to `main` (use closing keywords for the umbrella + feature issues in the PR body). Cut the release separately (see the `release` skill).
+- **Reap Circuit servers**: run `node scripts/reap-circuit.mjs` to clear any Circuit Electron servers orphaned during the run. Unlike broad `pkill`, it only touches dead-client orphans — never this session's server or a concurrent agent's — so it respects the multi-agent rule above. See CLAUDE.md › Orphaned Circuit Server Cleanup.
 
 ## Parameterize per run
 

--- a/.claude/skills/qa-pr/SKILL.md
+++ b/.claude/skills/qa-pr/SKILL.md
@@ -49,6 +49,10 @@ The branch name is in the PR details under `head.ref`.
 ```bash
 pkill -f "electron" 2>/dev/null
 pkill -f "vite" 2>/dev/null
+
+# Reap Circuit Electron MCP servers leaked by exited sessions (safe: kills only
+# dead-client orphans, never a live server). See CLAUDE.md › Orphaned Circuit Server Cleanup.
+node scripts/reap-circuit.mjs 2>/dev/null || true
 ```
 
 This is especially important when:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,8 @@ pkill -f "electron-vite.*prose"
 
 # NEVER: pkill -f node      # This kills Circuit Electron MCP!
 # NEVER: pkill -f Electron  # This kills ALL Electron apps!
+# To clear LEAKED Circuit servers safely, use the reaper (orphans only) — see below:
+#   node scripts/reap-circuit.mjs
 ```
 
 If the PID file is missing but Electron processes exist, they're likely stale from a crashed session. Kill them before starting fresh.
@@ -117,6 +119,19 @@ Multiple Claude Code agents may run simultaneously on this machine, potentially 
 - **Session conflicts**: Circuit Electron sessions may collide
 
 **Always prefer the PID file method** for cleanup. When encountering "address already in use" errors, check if another agent is active before assuming a bug. Vite automatically finds alternative ports, but DevTools debugging port (9222) conflicts will cause launch failures.
+
+### Orphaned Circuit Server Cleanup
+
+Circuit Electron (`@snowfort/circuit-electron`, a `0.0.x` alpha) does **not** exit when its Claude client disconnects. Orphaned servers reparent to `launchd` and many spin into ~100% CPU busy-loops; left alone they pile up (one sweep found 74 of them eating ~10 cores). The dev-server PID protocol above does **not** cover this — it kills the app, not the MCP server.
+
+Reap them safely with:
+
+```bash
+node scripts/reap-circuit.mjs            # kill orphaned servers
+node scripts/reap-circuit.mjs --dry-run  # report only, kill nothing
+```
+
+This is the safe inverse of "NEVER pkill -f node": it kills a Circuit process **only** if its parent chain reaches `init` (pid 1) through Circuit processes alone. Any server still attached to a live client — this session's, a concurrent agent's, even a terminal you launched it from — is spared, so it's multi-agent safe by construction. The QA skills (`qa-pr`, `qa-accelerated`, `qa-hitl`) invoke it automatically; run it by hand any time CPU spikes from stray `node` processes.
 
 ### Built App Location
 

--- a/scripts/reap-circuit.mjs
+++ b/scripts/reap-circuit.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * reap-circuit.mjs — surgically kill orphaned Circuit Electron MCP servers.
+ *
+ * Circuit Electron (@snowfort/circuit-electron, a 0.0.x alpha) does not exit
+ * when its Claude client disconnects. Orphaned servers reparent to launchd and
+ * a chunk of them spin into ~100% CPU busy-loops. Left alone they accumulate
+ * (we once found 74 of them eating ~10 cores).
+ *
+ * This is the SAFE inverse of the "NEVER pkill -f node" rule in CLAUDE.md: it
+ * never touches a live server. A circuit process is reaped only if walking up
+ * its parent chain reaches init (pid 1) through circuit processes alone. If the
+ * chain roots in ANY live non-circuit parent — the current session's `claude`,
+ * a concurrent agent's, or a terminal you launched it from — it is spared.
+ * That makes it multi-agent safe by construction (see Multi-Agent Awareness).
+ *
+ * Usage:
+ *   node scripts/reap-circuit.mjs            # reap orphans
+ *   node scripts/reap-circuit.mjs --dry-run  # report only, kill nothing
+ */
+
+import { execSync } from 'node:child_process';
+
+const dryRun = process.argv.includes('--dry-run') || process.argv.includes('-n');
+
+// pid, ppid, %cpu, command for every process. Tab-free parse: first three
+// whitespace-delimited fields, then the rest is the command (may contain spaces).
+const rows = execSync('ps -axo pid=,ppid=,pcpu=,command=', { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean)
+  .map((line) => {
+    const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/);
+    if (!m) return null;
+    return { pid: +m[1], ppid: +m[2], cpu: parseFloat(m[3]), command: m[4] };
+  })
+  .filter(Boolean);
+
+const byPid = new Map(rows.map((p) => [p.pid, p]));
+// Match only real invocations — the leaf (`.bin/circuit-electron`) and the npm
+// wrapper (`@snowfort/circuit-electron`) always have a slash before the name.
+// Requiring that slash avoids matching a shell that merely echoes the string.
+const isCircuit = (p) => p && /\/circuit-electron/.test(p.command);
+const circuit = rows.filter(isCircuit);
+
+// An orphan's parent chain is circuit-only until it hits init (pid 1).
+// Reaching a live non-circuit ancestor (a claude client, peer agent, shell)
+// means it's still attached to something → spare it.
+function isOrphan(proc) {
+  let cur = proc;
+  while (true) {
+    if (cur.ppid === 1) return true;            // circuit-only chain rooted at launchd
+    const parent = byPid.get(cur.ppid);
+    if (!isCircuit(parent)) return false;       // attached to a live non-circuit parent
+    cur = parent;                               // parent is also circuit → keep climbing
+  }
+}
+
+const orphans = circuit.filter(isOrphan);
+const live = circuit.length - orphans.length;
+
+if (orphans.length === 0) {
+  console.log(
+    circuit.length === 0
+      ? 'Circuit Electron: none running. Nothing to reap.'
+      : `Circuit Electron: ${circuit.length} running, all attached to live clients. Nothing to reap.`
+  );
+  process.exit(0);
+}
+
+const totalCpu = orphans.reduce((s, p) => s + (p.cpu || 0), 0).toFixed(1);
+console.log(
+  `Circuit Electron: ${circuit.length} running — ${live} live, ${orphans.length} orphaned ` +
+  `(${totalCpu}% CPU)${dryRun ? ' [dry-run]' : ''}`
+);
+
+for (const p of orphans) {
+  const tag = p.cpu > 50 ? ` ⚠ ${p.cpu}% CPU` : '';
+  if (dryRun) {
+    console.log(`  would reap pid ${p.pid} (ppid ${p.ppid})${tag}`);
+  } else {
+    try {
+      process.kill(p.pid, 'SIGKILL');
+      console.log(`  reaped pid ${p.pid} (ppid ${p.ppid})${tag}`);
+    } catch (err) {
+      if (err.code !== 'ESRCH') console.log(`  pid ${p.pid}: ${err.message}`);
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `scripts/reap-circuit.mjs`, a surgical reaper for orphaned Circuit Electron MCP servers, documents it in `CLAUDE.md`, and wires it into the `qa-pr`, `qa-accelerated`, and `qa-hitl` cleanup steps.

## Why

Circuit Electron (`@snowfort/circuit-electron`, a `0.0.x` alpha) does **not** exit when its Claude client disconnects. Orphaned servers reparent to `launchd` and many spin into ~100% CPU busy-loops; left alone they pile up (one sweep found **74** of them eating ~10 cores). The dev-server PID protocol kills the *app*, not the MCP *server*, so it never covered this case.

## How it's safe (the inverse of "NEVER pkill -f node")

A Circuit process is reaped **only** if walking up its parent chain reaches `init` (pid 1) through Circuit processes alone. If the chain roots in any live non-Circuit parent — this session's `claude`, a concurrent agent's, or a terminal you launched it from — it is **spared**. That makes it multi-agent safe by construction.

```bash
node scripts/reap-circuit.mjs            # reap orphans
node scripts/reap-circuit.mjs --dry-run  # report only, kill nothing
```

## Changes

- `scripts/reap-circuit.mjs` — new 88-line reaper (no deps; pure Node)
- `CLAUDE.md` — new "Orphaned Circuit Server Cleanup" section + pointer in the pkill block
- `.claude/skills/qa-pr|qa-accelerated|qa-hitl/SKILL.md` — invoke the reaper during cleanup so long QA batches can't accumulate orphans

Docs-and-tooling only; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)