### PR TITLE
chore(mas): pin masDev identity to Apple Development cert SHA-1

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -86,7 +86,7 @@ mas:
     - "!node_modules/builder-util-runtime/**"
 
 masDev:
-  identity: Apple Development
+  identity: 5106DA8B43E1AF25E3B553CABD91400445A9E68A
   provisioningProfile: build/Prose_Development.provisionprofile
 
 win:


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE** until #487 Apple provisioning steps are done and the masDev launch is verified locally (error 163 gone). See checklist below.

## Summary

Pins `masDev.identity` from the bare string `Apple Development` to the SHA-1 fingerprint of the existing valid Apple Development cert for the MAS team `8PT2Y7QQ2F`:

```
5106DA8B43E1AF25E3B553CABD91400445A9E68A
```

(Cert: `CN=Apple Development: ANGEL MARINO (2Y3M2V2Q5F)`, `OU=8PT2Y7QQ2F`, valid through 2027-03-18)

The bare `Apple Development` string already resolves to this cert on the current keychain — this is defensive hygiene to remove ambiguity if a second Apple Development cert is ever added.

## Why this is not the fix for error 163

The root cause of error 163 is a missing or stale `build/Prose_Development.provisionprofile` — the profile must embed:
- The `8PT2Y7QQ2F` Apple Development cert (SHA-1 above)
- This Mac (Provisioning UDID: `00006040-0004482A0187801C`)
- The App Groups capability (`8PT2Y7QQ2F.ist.solo.prose`)

Until those provisioning steps are done, rebuilding with this pin will still yield error 163.

## Pending human steps (before this PR can be merged and verified)

1. **Confirm/register this Mac** under team `8PT2Y7QQ2F` in the Apple Developer portal:
   - Devices → + → Platform macOS → Provisioning UDID `00006040-0004482A0187801C`
2. **Regenerate `build/Prose_Development.provisionprofile`** for `ist.solo.prose` under `8PT2Y7QQ2F`, embedding:
   - The existing Apple Development cert (SHA-1 `5106DA8B43E1AF25E3B553CABD91400445A9E68A`)
   - This Mac device
   - App Groups capability `8PT2Y7QQ2F.ist.solo.prose`
   - Download and replace `build/Prose_Development.provisionprofile`
3. **Run `npx electron-builder --mac mas-dev`** and verify the app launches without error 163.
4. **Then merge this PR.**

Refs #487