### PR TITLE
fix(files): file explorer bugs — scroll, multi-select, focus

### DIFF
--- a/e2e/electron.file-explorer-qa.spec.ts
+++ b/e2e/electron.file-explorer-qa.spec.ts
@@ -230,8 +230,10 @@ test.describe('Electron — file explorer QA (#723)', () => {
 
     // The file list sorts by localeCompare, so the visible order is:
     // alpha(0), beta(1), delta(2), epsilon(3), eta(4), gamma(5), iota(6), kappa(7), theta(8), zeta(9)
-    // Shift+click eta — should select the contiguous run alpha..eta (5 files)
-    await panel.getByText('eta').click({ modifiers: ['Shift'] })
+    // Shift+click eta — should select the contiguous run alpha..eta (5 files).
+    // Use an exact-name locator: 'eta' is a substring of beta/theta/zeta so
+    // getByText without anchoring would match 4 elements and throw in strict mode.
+    await panel.locator('button[title]', { hasText: /^eta$/ }).click({ modifiers: ['Shift'] })
     await page.waitForTimeout(100)
 
     const selected = await getSelectedPaths(page)

--- a/e2e/electron.file-explorer-qa.spec.ts
+++ b/e2e/electron.file-explorer-qa.spec.ts
@@ -228,19 +228,22 @@ test.describe('Electron — file explorer QA (#723)', () => {
     await panel.getByText('alpha').click()
     await page.waitForTimeout(100)
 
-    // Shift+click delta — should select alpha through delta
-    await panel.getByText('delta').click({ modifiers: ['Shift'] })
+    // The file list sorts by localeCompare, so the visible order is:
+    // alpha(0), beta(1), delta(2), epsilon(3), eta(4), gamma(5), iota(6), kappa(7), theta(8), zeta(9)
+    // Shift+click eta — should select the contiguous run alpha..eta (5 files)
+    await panel.getByText('eta').click({ modifiers: ['Shift'] })
     await page.waitForTimeout(100)
 
     const selected = await getSelectedPaths(page)
     const baseNames = selected.map((p) => p.split('/').pop() ?? '')
-    // alpha, beta, gamma, delta should all be selected
+    // All files alphabetically between alpha and eta should be selected
     expect(baseNames).toContain('alpha.md')
     expect(baseNames).toContain('beta.md')
-    expect(baseNames).toContain('gamma.md')
     expect(baseNames).toContain('delta.md')
-    // And selection should be at least 4
-    expect(selected.length).toBeGreaterThanOrEqual(4)
+    expect(baseNames).toContain('epsilon.md')
+    expect(baseNames).toContain('eta.md')
+    // And selection should be at least 5
+    expect(selected.length).toBeGreaterThanOrEqual(5)
   })
 
   test('Bug 2: plain click clears multi-select and selects single file', async () => {

--- a/e2e/electron.file-explorer-qa.spec.ts
+++ b/e2e/electron.file-explorer-qa.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * File Explorer QA (#723) — regression coverage for three concrete bugs:
+ *
+ * 1. Rename → Enter scrolls the file explorer to the top.
+ *    The rename-activation effect was calling scrollTo(0, 0) on the Radix
+ *    scroll viewport to undo scroll drift from select(), but that wiped the
+ *    user's scroll position. Fix: save/restore scrollTop around the select().
+ *
+ * 2. No multi-select (Shift+Click, Cmd/Ctrl+Click, Cmd+A).
+ *    Add range-select and toggle-select with Cmd+A select-all.
+ *
+ * 3. After file delete, focus does not return to the explorer.
+ *    handleConfirmDelete now calls containerRef.current?.focus() after the
+ *    file is trashed.
+ *
+ * All tests run in an isolated PROSE_USER_DATA_DIR profile with a fixture
+ * directory of markdown files so the file explorer is populated.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  ensureFileListOpen,
+  selectors,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaFilesDir: string
+
+const FILE_NAMES = [
+  'alpha.md',
+  'beta.md',
+  'gamma.md',
+  'delta.md',
+  'epsilon.md',
+  'zeta.md',
+  'eta.md',
+  'theta.md',
+  'iota.md',
+  'kappa.md',
+]
+
+test.beforeAll(async () => {
+  test.setTimeout(90_000)
+
+  // Isolated profile + populated fixture directory
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-723-profile-'))
+  qaFilesDir = mkdtempSync(join(tmpdir(), 'prose-qa-723-files-'))
+  mkdirSync(qaFilesDir, { recursive: true })
+  for (const name of FILE_NAMES) {
+    writeFileSync(join(qaFilesDir, name), `# ${name.replace('.md', '')}\n\nContent.\n`)
+  }
+
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        defaultSaveDirectory: qaFilesDir,
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+  await ensureFileListOpen(page)
+
+  // Switch to the folder view showing our fixture files
+  const filesBtn = page.locator(selectors.filesButton)
+  if (await filesBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await filesBtn.click()
+  }
+  // Wait for at least one file to appear
+  const panel = page.locator(selectors.fileListPanel)
+  await panel.getByText('alpha').waitFor({ state: 'visible', timeout: 10_000 })
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaFilesDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Helper: get the scroll viewport's current scrollTop inside the panel.
+// ---------------------------------------------------------------------------
+async function getPanelScrollTop(testPage: Page): Promise<number> {
+  return testPage.evaluate(() => {
+    const panel = document.querySelector('[data-testid="file-list-panel"]')
+    const viewport = panel?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null
+    return viewport?.scrollTop ?? 0
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Helper: get all paths currently in selectedPaths store.
+// ---------------------------------------------------------------------------
+async function getSelectedPaths(testPage: Page): Promise<string[]> {
+  return testPage.evaluate(() => {
+    // Access the Zustand store directly via the module registry isn't practical
+    // from a CDP context; instead read the visual state — items with
+    // bg-accent class that are not the "hover" state are selected.
+    const panel = document.querySelector('[data-testid="file-list-panel"]')
+    if (!panel) return []
+    const selected: string[] = []
+    const buttons = panel.querySelectorAll('button[title]')
+    for (const btn of buttons) {
+      if (btn.classList.contains('bg-accent')) {
+        const titleAttr = btn.getAttribute('title')
+        if (titleAttr) selected.push(titleAttr)
+      }
+    }
+    return selected
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: Rename → Enter must not scroll the file list to the top
+// ---------------------------------------------------------------------------
+test.describe('Electron — file explorer QA (#723)', () => {
+  test('Bug 1: rename via Enter preserves scroll position', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Scroll to the bottom of the file list so scroll position is non-zero
+    await page.evaluate(() => {
+      const fp = document.querySelector('[data-testid="file-list-panel"]')
+      const viewport = fp?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null
+      if (viewport) viewport.scrollTop = 1000
+    })
+
+    // Give scroll event a frame to settle
+    await page.waitForTimeout(100)
+
+    const scrollBefore = await getPanelScrollTop(page)
+    // Should be > 0 if the list is actually scrollable; if not, the test is
+    // still valid — we just confirm no unexpected reset occurs.
+
+    // Right-click a file near the bottom of our fixture list to open context menu
+    await panel.getByText('kappa').click({ button: 'right' })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
+
+    // Click Rename
+    const renameItem = page.getByRole('menuitem', { name: 'Rename' })
+    await renameItem.waitFor({ state: 'visible', timeout: 3_000 })
+    await renameItem.click()
+
+    // Give the rename input time to focus (there's a 50ms rAF + setTimeout delay)
+    await page.waitForTimeout(200)
+
+    // Verify scroll was not reset to 0 by the rename-activation effect
+    const scrollDuringRename = await getPanelScrollTop(page)
+    expect(scrollDuringRename).toBeGreaterThanOrEqual(scrollBefore - 10)
+
+    // Commit the rename with Enter (using the same name so no actual rename occurs)
+    await page.keyboard.press('Escape')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Bug 2: Multi-select — Cmd+Click, Shift+Click, Cmd+A
+  // ---------------------------------------------------------------------------
+  test('Bug 2: Cmd+click toggles files into multi-select', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Single-click alpha to establish anchor
+    await panel.getByText('alpha').click()
+    await page.waitForTimeout(100)
+
+    // Cmd+click beta — should add it to selection
+    await panel.getByText('beta').click({ modifiers: ['Meta'] })
+    await page.waitForTimeout(100)
+
+    // Cmd+click gamma
+    await panel.getByText('gamma').click({ modifiers: ['Meta'] })
+    await page.waitForTimeout(100)
+
+    const selected = await getSelectedPaths(page)
+    // At least alpha, beta, gamma should be selected
+    const baseNames = selected.map((p) => p.split('/').pop() ?? '')
+    expect(baseNames).toContain('alpha.md')
+    expect(baseNames).toContain('beta.md')
+    expect(baseNames).toContain('gamma.md')
+  })
+
+  test('Bug 2: Cmd+A selects all visible files', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Focus the panel
+    await panel.click()
+
+    // Ensure multi-select is cleared first via single click
+    await panel.getByText('alpha').click()
+    await page.waitForTimeout(100)
+
+    // Press Cmd+A
+    await page.keyboard.press('Meta+a')
+    await page.waitForTimeout(100)
+
+    const selected = await getSelectedPaths(page)
+    // All fixture .md files should be selected
+    expect(selected.length).toBeGreaterThanOrEqual(FILE_NAMES.length)
+  })
+
+  test('Bug 2: Shift+click range-selects from anchor to target', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Click alpha (anchor)
+    await panel.getByText('alpha').click()
+    await page.waitForTimeout(100)
+
+    // Shift+click delta — should select alpha through delta
+    await panel.getByText('delta').click({ modifiers: ['Shift'] })
+    await page.waitForTimeout(100)
+
+    const selected = await getSelectedPaths(page)
+    const baseNames = selected.map((p) => p.split('/').pop() ?? '')
+    // alpha, beta, gamma, delta should all be selected
+    expect(baseNames).toContain('alpha.md')
+    expect(baseNames).toContain('beta.md')
+    expect(baseNames).toContain('gamma.md')
+    expect(baseNames).toContain('delta.md')
+    // And selection should be at least 4
+    expect(selected.length).toBeGreaterThanOrEqual(4)
+  })
+
+  test('Bug 2: plain click clears multi-select and selects single file', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Start with Cmd+A to get multi-select
+    await panel.click()
+    await panel.getByText('alpha').click()
+    await page.keyboard.press('Meta+a')
+    await page.waitForTimeout(100)
+
+    const allSelected = await getSelectedPaths(page)
+    expect(allSelected.length).toBeGreaterThan(1)
+
+    // Plain click on beta
+    await panel.getByText('beta').click()
+    await page.waitForTimeout(100)
+
+    const afterClick = await getSelectedPaths(page)
+    // Only beta (or nothing extra) should be selected
+    expect(afterClick.length).toBeLessThanOrEqual(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Bug 3: Focus returns to explorer after delete
+  // ---------------------------------------------------------------------------
+  test('Bug 3: focus returns to file explorer panel after file deletion', async () => {
+    // Create a temp file in our fixture dir so we can safely delete it
+    const tempName = 'to-be-deleted.md'
+    writeFileSync(join(qaFilesDir, tempName), '# Temp\n')
+
+    // Wait for the file watcher to pick up the new file
+    const panel = page.locator(selectors.fileListPanel)
+    await panel.getByText('to-be-deleted').waitFor({ state: 'visible', timeout: 8_000 })
+
+    // Right-click → Move to Trash
+    await panel.getByText('to-be-deleted').click({ button: 'right' })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
+    const trashItem = page.getByRole('menuitem', { name: 'Move to Trash' })
+    await trashItem.waitFor({ state: 'visible', timeout: 3_000 })
+    await trashItem.click()
+
+    // Confirm the delete dialog
+    const confirmBtn = page.getByRole('button', { name: 'Move to Trash' }).last()
+    await confirmBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    await confirmBtn.click()
+
+    // Wait for dialog to close
+    await page.waitForSelector('[role="dialog"]', { state: 'detached', timeout: 5_000 })
+
+    // After deletion, the explorer panel should be focused (not body/document)
+    const focusedTestId = await page.evaluate(() => {
+      return document.activeElement?.getAttribute('data-testid') ??
+             document.activeElement?.tagName?.toLowerCase() ??
+             'unknown'
+    })
+
+    // The containerRef div has data-testid="file-list-panel" and tabIndex={-1}
+    expect(focusedTestId).toBe('file-list-panel')
+  })
+})

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -185,6 +185,12 @@ export function FileListPanel() {
   const renamingPath = useFileListStore((s) => s.renamingPath)
   const setRenamingPath = useFileListStore((s) => s.setRenamingPath)
 
+  // Multi-select state and actions
+  const selectedPaths = useFileListStore((s) => s.selectedPaths)
+  const toggleSelectFile = useFileListStore((s) => s.toggleSelectFile)
+  const rangeSelectTo = useFileListStore((s) => s.rangeSelectTo)
+  const clearMultiSelect = useFileListStore((s) => s.clearMultiSelect)
+
   // Delete confirmation state
   const [deleteTarget, setDeleteTarget] = useState<{
     path: string
@@ -312,8 +318,11 @@ export function FileListPanel() {
       // Refresh file list
       await loadFiles()
 
-      // Close dialog
+      // Close dialog and return focus to the explorer panel
       setDeleteTarget(null)
+      requestAnimationFrame(() => {
+        containerRef.current?.focus()
+      })
     } catch (error) {
       console.error('Failed to delete file:', error)
       setOperationError('Failed to delete file. Please try again.')
@@ -465,6 +474,24 @@ export function FileListPanel() {
   const handleRenameCancel = useCallback(() => {
     setRenamingPath(null)
   }, [setRenamingPath])
+
+  // Range-select: resolves visible file paths and delegates to the store
+  const handleFileRangeSelect = useCallback((path: string) => {
+    const { files, expandedFolders } = useFileListStore.getState()
+    // Collect visible file paths (not folders) in tree order
+    const collectVisible = (items: typeof files): string[] => {
+      const paths: string[] = []
+      for (const item of items) {
+        if (!item.isDirectory) paths.push(item.path)
+        if (item.isDirectory && expandedFolders.has(item.path) && item.children) {
+          paths.push(...collectVisible(item.children))
+        }
+      }
+      return paths
+    }
+    const visibleFilePaths = collectVisible(files)
+    rangeSelectTo(path, visibleFilePaths)
+  }, [rangeSelectTo])
 
   // Dialog-based rename (for Google Docs view where inline isn't available)
   const handleFileRename = (path: string) => {
@@ -1453,11 +1480,14 @@ export function FileListPanel() {
                       projectPaths={projectPaths}
                       expandedFolders={expandedFolders}
                       selectedPath={selectedPath}
+                      selectedPaths={selectedPaths}
                       loadingFolders={loadingFolders}
                       renamingPath={renamingPath}
                       clipboardPath={clipboardPath}
                       clipboardOperation={clipboardOperation}
                       onFileClick={handleFileClick}
+                      onFileToggleSelect={toggleSelectFile}
+                      onFileRangeSelect={handleFileRangeSelect}
                       onFileDoubleClick={handleFileDoubleClick}
                       onFolderToggle={toggleFolder}
                       onFolderDoubleClick={setRootPath}

--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -21,11 +21,17 @@ interface FileTreeProps {
   projectPaths?: ReadonlySet<string>
   expandedFolders: Set<string>
   selectedPath: string | null
+  /** All currently selected paths for multi-select. */
+  selectedPaths?: ReadonlySet<string>
   loadingFolders?: Set<string>
   renamingPath?: string | null
   clipboardPath?: string | null
   clipboardOperation?: 'copy' | 'cut' | null
   onFileClick: (path: string) => void
+  /** Cmd/Ctrl+click: toggle this path in the selection set. */
+  onFileToggleSelect?: (path: string) => void
+  /** Shift+click: range-select from anchor to this path. */
+  onFileRangeSelect?: (path: string) => void
   onFolderToggle: (path: string) => void
   onFolderDoubleClick?: (path: string) => void
   onFileDoubleClick?: (path: string) => void
@@ -55,11 +61,14 @@ export function FileTree({
   projectPaths = EMPTY_PATH_SET,
   expandedFolders,
   selectedPath,
+  selectedPaths = EMPTY_PATH_SET,
   loadingFolders,
   renamingPath,
   clipboardPath,
   clipboardOperation,
   onFileClick,
+  onFileToggleSelect,
+  onFileRangeSelect,
   onFolderToggle,
   onFolderDoubleClick,
   onFileDoubleClick,
@@ -92,11 +101,14 @@ export function FileTree({
           projectPaths={projectPaths}
           expandedFolders={expandedFolders}
           selectedPath={selectedPath}
+          selectedPaths={selectedPaths}
           loadingFolders={loadingFolders}
           renamingPath={renamingPath}
           clipboardPath={clipboardPath}
           clipboardOperation={clipboardOperation}
           onFileClick={onFileClick}
+          onFileToggleSelect={onFileToggleSelect}
+          onFileRangeSelect={onFileRangeSelect}
           onFolderToggle={onFolderToggle}
           onFolderDoubleClick={onFolderDoubleClick}
           onFileDoubleClick={onFileDoubleClick}
@@ -130,11 +142,14 @@ interface FileTreeItemProps {
   projectPaths: ReadonlySet<string>
   expandedFolders: Set<string>
   selectedPath: string | null
+  selectedPaths: ReadonlySet<string>
   loadingFolders?: Set<string>
   renamingPath?: string | null
   clipboardPath?: string | null
   clipboardOperation?: 'copy' | 'cut' | null
   onFileClick: (path: string) => void
+  onFileToggleSelect?: (path: string) => void
+  onFileRangeSelect?: (path: string) => void
   onFolderToggle: (path: string) => void
   onFolderDoubleClick?: (path: string) => void
   onFileDoubleClick?: (path: string) => void
@@ -164,11 +179,14 @@ function FileTreeItem({
   projectPaths,
   expandedFolders,
   selectedPath,
+  selectedPaths,
   loadingFolders,
   renamingPath,
   clipboardPath,
   clipboardOperation,
   onFileClick,
+  onFileToggleSelect,
+  onFileRangeSelect,
   onFolderToggle,
   onFolderDoubleClick,
   onFileDoubleClick,
@@ -192,7 +210,8 @@ function FileTreeItem({
   depth
 }: FileTreeItemProps) {
   const isExpanded = expandedFolders.has(item.path)
-  const isSelected = selectedPath === item.path
+  // Primary selection (for single-file operations) OR part of multi-select set
+  const isSelected = selectedPath === item.path || selectedPaths.has(item.path)
   const isLoading = loadingFolders?.has(item.path) ?? false
   const isRenaming = renamingPath === item.path
   const isCut = clipboardOperation === 'cut' && clipboardPath === item.path
@@ -294,12 +313,15 @@ function FileTreeItem({
         setTimeout(() => {
           const input = inputRef.current
           if (!input) return
+          // Save the parent scroll position before select() can move it
+          const viewport = input.closest('[data-radix-scroll-area-viewport]') as HTMLElement | null
+          const savedScrollTop = viewport?.scrollTop ?? 0
           input.focus({ preventScroll: true })
           input.select()
-          // Reset scroll caused by select() showing cursor at end
+          // select() moves the cursor to end — reset just the input's own scroll,
+          // then restore the panel's scroll so the view stays where the user was.
           input.scrollLeft = 0
-          // Also reset parent scroll container if it shifted
-          input.closest('[data-radix-scroll-area-viewport]')?.scrollTo(0, 0)
+          if (viewport) viewport.scrollTop = savedScrollTop
         }, 50)
       })
     }
@@ -322,13 +344,24 @@ function FileTreeItem({
     e.stopPropagation()
   }
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
     if (isRenaming) return
     if (item.isDirectory) {
       onFolderToggle(item.path)
-    } else {
-      onFileClick(item.path)
+      return
     }
+    // Multi-select modifiers (files only — folders always just toggle expand)
+    if ((e.metaKey || e.ctrlKey) && onFileToggleSelect) {
+      e.preventDefault()
+      onFileToggleSelect(item.path)
+      return
+    }
+    if (e.shiftKey && onFileRangeSelect) {
+      e.preventDefault()
+      onFileRangeSelect(item.path)
+      return
+    }
+    onFileClick(item.path)
   }
 
   const handleDoubleClick = () => {
@@ -585,11 +618,14 @@ function FileTreeItem({
           projectPaths={projectPaths}
           expandedFolders={expandedFolders}
           selectedPath={selectedPath}
+          selectedPaths={selectedPaths}
           loadingFolders={loadingFolders}
           renamingPath={renamingPath}
           clipboardPath={clipboardPath}
           clipboardOperation={clipboardOperation}
           onFileClick={onFileClick}
+          onFileToggleSelect={onFileToggleSelect}
+          onFileRangeSelect={onFileRangeSelect}
           onFolderToggle={onFolderToggle}
           onFolderDoubleClick={onFolderDoubleClick}
           onFileDoubleClick={onFileDoubleClick}

--- a/src/renderer/hooks/useExplorerActions.ts
+++ b/src/renderer/hooks/useExplorerActions.ts
@@ -52,6 +52,7 @@ export function useExplorerActions({
   const setClipboardPath = useFileListStore((s) => s.setClipboardPath)
   const setRenamingPath = useFileListStore((s) => s.setRenamingPath)
   const renamingPath = useFileListStore((s) => s.renamingPath)
+  const selectAll = useFileListStore((s) => s.selectAll)
 
   const api = getApi()
 
@@ -304,6 +305,19 @@ export function useExplorerActions({
         return
       }
 
+      // Cmd+A → select all visible files
+      if (e.key === 'a' && isMeta) {
+        e.preventDefault()
+        e.stopPropagation()
+        const { files, expandedFolders } = useFileListStore.getState()
+        const visible = getVisibleItems(files, expandedFolders)
+        const filePaths = visible.filter(item => !item.isDirectory).map(item => item.path)
+        if (filePaths.length > 0) {
+          selectAll(filePaths)
+        }
+        return
+      }
+
       // Arrow key navigation (no modifier keys)
       if (!isMeta && !e.shiftKey && !e.altKey) {
         const { files, expandedFolders, toggleFolder, selectFile, setExpanded } = useFileListStore.getState()
@@ -379,7 +393,7 @@ export function useExplorerActions({
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [containerRef, selectedPath, clipboardPath, renamingPath, startRename, trashSelected, copySelected, cutSelected, pasteFile, newFileInContext, onFilePreview, onFileTrash])
+  }, [containerRef, selectedPath, clipboardPath, renamingPath, startRename, trashSelected, copySelected, cutSelected, pasteFile, newFileInContext, selectAll, onFilePreview, onFileTrash])
 
   return {
     trashSelected,

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -138,6 +138,12 @@ interface FileListState {
   clipboardOperation: 'copy' | 'cut' | null
   renamingPath: string | null
 
+  // Multi-select — contains all currently selected paths (files only for now).
+  // selectedPath remains the "anchor" for single-file operations; selectedPaths
+  // is the full set for bulk actions (delete, copy, cut).
+  selectedPaths: Set<string>
+  anchorPath: string | null // Shift+click range anchor
+
   // Google Docs sync state
   isGoogleSyncing: boolean
 
@@ -183,6 +189,11 @@ interface FileListState {
   setExpanded: (path: string, expanded: boolean) => void
   toggleNotebookFolderExpanded: (folderId: string) => void
   revealAndSelectPath: (path: string) => void
+  // Multi-select actions
+  toggleSelectFile: (path: string) => void
+  rangeSelectTo: (path: string, visiblePaths: string[]) => void
+  selectAll: (paths: string[]) => void
+  clearMultiSelect: () => void
 }
 
 export const useFileListStore = create<FileListState>()(
@@ -199,6 +210,8 @@ export const useFileListStore = create<FileListState>()(
     clipboardPath: null,
     clipboardOperation: null,
     renamingPath: null,
+    selectedPaths: new Set<string>(),
+    anchorPath: null,
     isGoogleSyncing: false,
     remarkableSyncActive: false,
     remarkableSyncProgress: null,
@@ -538,7 +551,46 @@ export const useFileListStore = create<FileListState>()(
       }
     },
 
-    selectFile: (path) => set({ selectedPath: path }),
+    selectFile: (path) => set({ selectedPath: path, selectedPaths: path ? new Set([path]) : new Set(), anchorPath: path }),
+
+    toggleSelectFile: (path) => set((state) => {
+      const next = new Set(state.selectedPaths)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      // Last toggled path becomes anchor and primary selection
+      const primary = next.size > 0 ? path : null
+      return { selectedPaths: next, selectedPath: primary, anchorPath: path }
+    }),
+
+    rangeSelectTo: (path, visiblePaths) => set((state) => {
+      const anchor = state.anchorPath ?? state.selectedPath
+      if (!anchor) {
+        // No anchor — treat as plain select
+        return { selectedPaths: new Set([path]), selectedPath: path, anchorPath: path }
+      }
+      const anchorIdx = visiblePaths.indexOf(anchor)
+      const targetIdx = visiblePaths.indexOf(path)
+      if (anchorIdx === -1 || targetIdx === -1) {
+        return { selectedPaths: new Set([path]), selectedPath: path }
+      }
+      const lo = Math.min(anchorIdx, targetIdx)
+      const hi = Math.max(anchorIdx, targetIdx)
+      const rangeSet = new Set(visiblePaths.slice(lo, hi + 1))
+      return { selectedPaths: rangeSet, selectedPath: path }
+    }),
+
+    selectAll: (paths) => set((state) => {
+      const all = new Set(paths)
+      return { selectedPaths: all, selectedPath: state.selectedPath ?? paths[0] ?? null }
+    }),
+
+    clearMultiSelect: () => set((state) => ({
+      selectedPaths: state.selectedPath ? new Set([state.selectedPath]) : new Set(),
+      anchorPath: state.selectedPath,
+    })),
 
     toggleFolder: (path) => {
       const { expandedFolders, files, loadFolderChildren } = get()


### PR DESCRIPTION
## Summary

Fixes three concrete File Explorer bugs from #723:

- **Bug 1 (scroll-to-top on rename):** The rename-activation effect was calling `scrollTo(0, 0)` on the Radix scroll viewport to undo drift from `select()`. Fix: save `scrollTop` before `select()` and restore it after, so the user's scroll position is preserved when Enter-committing a rename.

- **Bug 2 (multi-select):** Add `Shift+Click` range-select, `Cmd/Ctrl+Click` toggle-select, and `Cmd+A` select-all to the file explorer. Added `selectedPaths` + `anchorPath` to `fileListStore`; wired `onFileToggleSelect` / `onFileRangeSelect` callbacks through `FileTree` / `FileTreeItem`; `Cmd+A` handler in `useExplorerActions`. Visual highlight is derived from the `selectedPaths` set.

- **Bug 3 (focus-return after delete):** `handleConfirmDelete` now calls `containerRef.current?.focus()` via `requestAnimationFrame` after the dialog closes, returning keyboard focus to the explorer panel so the user can immediately continue navigating.

## Changes

- `src/renderer/stores/fileListStore.ts` — add `selectedPaths`, `anchorPath`, and four actions (`toggleSelectFile`, `rangeSelectTo`, `selectAll`, `clearMultiSelect`); update `selectFile` to reset `selectedPaths` to the single clicked file
- `src/renderer/components/files/FileTree.tsx` — add `selectedPaths` / `onFileToggleSelect` / `onFileRangeSelect` to props; route modifier-click through multi-select handlers in `handleClick`; propagate to recursive `FileTree` call
- `src/renderer/components/files/FileListPanel.tsx` — subscribe to multi-select store slice; add `handleFileRangeSelect`; wire all three new props into the `<FileTree>` render; add `containerRef.current?.focus()` after delete
- `src/renderer/hooks/useExplorerActions.ts` — add `Cmd+A` keyboard shortcut for select-all
- `e2e/electron.file-explorer-qa.spec.ts` — new Playwright e2e spec with 5 tests in an isolated `PROSE_USER_DATA_DIR` profile: scroll preservation, Cmd+click, Cmd+A, Shift+click range-select, plain-click clears multi-select, and focus-returns-after-delete

## Test plan

- [ ] Build passes: `npm run build`
- [ ] TypeScript: no new errors (`npx tsc --noEmit`)
- [ ] E2E: `npx playwright test e2e/electron.file-explorer-qa.spec.ts`
- [ ] Manual: open a populated folder, scroll down, rename a file with Enter — list stays scrolled
- [ ] Manual: Cmd+click selects multiple files (highlighted); Cmd+A selects all; Shift+click range-selects
- [ ] Manual: delete a file via context menu → focus returns to explorer (arrow keys work immediately)

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)