### PR TITLE
feat(chat): extended thinking blocks + dynamic streaming verbs

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto'
 import { homedir } from 'os'
 import type { Settings } from '../renderer/types'
 import { withRetry, getNetworkErrorMessage } from '../shared/utils/retry'
-import { getDefaultModel, getDefaultHaikuModel } from '../shared/llm/models'
+import { getDefaultModel, getDefaultHaikuModel, supportsAdaptiveThinking } from '../shared/llm/models'
 import { getSettingsDir, LEGACY_SETTINGS_DIR } from './paths'
 import { clearRecentFiles } from './recentFiles'
 import { refreshMenu, setReopenClosedTabEnabled } from './menu'
@@ -967,19 +967,17 @@ export function setupIpcHandlers(): void {
 
         console.log('[LLM:stream] Creating Anthropic stream with tools:', anthropicTools.map(t => t.name))
 
-        // Extended thinking — enabled when the caller requests it (default: true
-        // for Anthropic requests with tools). budget_tokens sets the ceiling for
-        // thinking tokens; max_tokens must be larger than budget_tokens. We raise
-        // the overall ceiling so there is room for both thinking and output text.
-        const THINKING_BUDGET = 8000
-        const thinkingParam = request.thinking !== false
-          ? { type: 'enabled' as const, budget_tokens: THINKING_BUDGET }
+        // Extended thinking — adaptive mode, capability-gated per model.
+        // Only Opus 4.7+, Opus 4.8, and Fable 5 support it; Sonnet/Haiku return
+        // HTTP 400 if the param is sent. `display: "summarized"` is mandatory —
+        // the default "omitted" yields an empty thinking string. Depth is
+        // controlled by output_config.effort, not a token budget.
+        const thinkingEnabled = request.thinking !== false && supportsAdaptiveThinking(request.model)
+        const thinkingParam = thinkingEnabled
+          ? { type: 'adaptive' as const, display: 'summarized' as const }
           : undefined
 
-        // Ensure max_tokens > budget_tokens when thinking is on.
-        const maxTokens = thinkingParam
-          ? Math.max(request.maxTokens || 16000, THINKING_BUDGET + 4096)
-          : (request.maxTokens || 4096)
+        const maxTokens = request.maxTokens || 16000
 
         const streamParams: Parameters<typeof client.messages.stream>[0] = {
           model: request.model,
@@ -987,7 +985,8 @@ export function setupIpcHandlers(): void {
           system: request.system,
           messages: anthropicMessages,
           tools: anthropicTools,
-          ...(thinkingParam ? { thinking: thinkingParam } : {})
+          ...(thinkingParam ? { thinking: thinkingParam } : {}),
+          ...(thinkingEnabled ? { output_config: { effort: 'high' as const } } : {})
         }
 
         const stream = client.messages.stream(streamParams)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -61,6 +61,8 @@ interface LLMStreamRequest extends LLMRequest {
   streamId: string
   tools?: LLMToolDefinition[]
   maxToolRoundtrips?: number
+  maxTokens?: number
+  thinking?: boolean
 }
 
 // Track active streams for abort support
@@ -965,16 +967,39 @@ export function setupIpcHandlers(): void {
 
         console.log('[LLM:stream] Creating Anthropic stream with tools:', anthropicTools.map(t => t.name))
 
-        const stream = client.messages.stream({
+        // Extended thinking — enabled when the caller requests it (default: true
+        // for Anthropic requests with tools). budget_tokens sets the ceiling for
+        // thinking tokens; max_tokens must be larger than budget_tokens. We raise
+        // the overall ceiling so there is room for both thinking and output text.
+        const THINKING_BUDGET = 8000
+        const thinkingParam = request.thinking !== false
+          ? { type: 'enabled' as const, budget_tokens: THINKING_BUDGET }
+          : undefined
+
+        // Ensure max_tokens > budget_tokens when thinking is on.
+        const maxTokens = thinkingParam
+          ? Math.max(request.maxTokens || 16000, THINKING_BUDGET + 4096)
+          : (request.maxTokens || 4096)
+
+        const streamParams: Parameters<typeof client.messages.stream>[0] = {
           model: request.model,
-          max_tokens: request.maxTokens || 4096,
+          max_tokens: maxTokens,
           system: request.system,
           messages: anthropicMessages,
-          tools: anthropicTools
-        })
+          tools: anthropicTools,
+          ...(thinkingParam ? { thinking: thinkingParam } : {})
+        }
+
+        const stream = client.messages.stream(streamParams)
 
         let fullContent = ''
         const toolCalls: Array<{ id: string; name: string; args: unknown }> = []
+
+        // Track thinking block accumulation for streaming delta events.
+        // We send cumulative thinking text on each thinking_delta so the
+        // renderer can update its display without managing deltas itself.
+        let currentThinkingText = ''
+        let inThinkingBlock = false
 
         stream.on('text', (text) => {
           if (abortController.signal.aborted) return
@@ -983,25 +1008,49 @@ export function setupIpcHandlers(): void {
           event.sender.send('llm:stream:chunk', { streamId, delta: text })
         })
 
-        stream.on('contentBlockStart', (block) => {
+        // The SDK provides a dedicated `thinking` event that fires once per
+        // thinking_delta. The second argument is the cumulative snapshot, which
+        // we forward directly to the renderer as a "thinking delta" so the
+        // store doesn't need to accumulate increments itself.
+        stream.on('thinking', (_thinkingDelta, thinkingSnapshot) => {
           if (abortController.signal.aborted) return
-          console.log('[LLM:stream] Content block start:', block.content_block.type)
-          if (block.content_block.type === 'tool_use') {
-            console.log('[LLM:stream] Tool use started:', block.content_block.name)
-            // Fire a drafting event before any input_json_delta arrives — the
-            // visible latency for tools like `insert`/`edit` is the LLM
-            // composing the input, not the tool's actual execution.
-            event.sender.send('llm:stream:tool-call:start', {
-              streamId,
-              toolCallId: block.content_block.id,
-              toolName: block.content_block.name
-            })
-          }
+          inThinkingBlock = true
+          currentThinkingText = thinkingSnapshot
+          event.sender.send('llm:stream:thinking:delta', {
+            streamId,
+            thinking: thinkingSnapshot
+          })
         })
 
-        stream.on('contentBlockStop', (block) => {
+        // Use the typed `streamEvent` to detect tool_use block start (for the
+        // drafting chip) and thinking block boundaries.
+        stream.on('streamEvent', (rawEvent) => {
           if (abortController.signal.aborted) return
-          console.log('[LLM:stream] Content block stop')
+          if (rawEvent.type === 'content_block_start') {
+            const blockType = (rawEvent as { type: string; index: number; content_block: { type: string; id?: string; name?: string } }).content_block.type
+            const contentBlock = (rawEvent as { type: string; index: number; content_block: { type: string; id?: string; name?: string } }).content_block
+            console.log('[LLM:stream] Content block start:', blockType)
+            if (blockType === 'thinking') {
+              inThinkingBlock = true
+              currentThinkingText = ''
+              console.log('[LLM:stream] Thinking block started')
+            } else if (blockType === 'tool_use') {
+              console.log('[LLM:stream] Tool use started:', contentBlock.name)
+              // Fire a drafting event before any input_json_delta arrives — the
+              // visible latency for tools like `insert`/`edit` is the LLM
+              // composing the input, not the tool's actual execution.
+              event.sender.send('llm:stream:tool-call:start', {
+                streamId,
+                toolCallId: contentBlock.id,
+                toolName: contentBlock.name
+              })
+            }
+          } else if (rawEvent.type === 'content_block_stop') {
+            if (inThinkingBlock) {
+              inThinkingBlock = false
+              console.log('[LLM:stream] Thinking block complete, length:', currentThinkingText.length)
+            }
+          }
         })
 
         stream.on('error', (err) => {
@@ -1017,7 +1066,11 @@ export function setupIpcHandlers(): void {
         const finalMessage = await stream.finalMessage()
         console.log('[LLM:stream] Got finalMessage, stop_reason:', finalMessage.stop_reason)
 
-        // Extract tool calls from the final message
+        // Extract tool calls and thinking blocks from the final message.
+        // Thinking blocks are passed back so useChat can embed them verbatim
+        // in the assistant content array for tool-loop continuations — the
+        // Anthropic API requires thinking blocks to be preserved unmodified.
+        const thinkingBlocks: Array<{ type: 'thinking'; thinking: string; signature?: string }> = []
         for (const block of finalMessage.content) {
           if (block.type === 'tool_use') {
             const toolCall = {
@@ -1027,14 +1080,21 @@ export function setupIpcHandlers(): void {
             }
             toolCalls.push(toolCall)
             event.sender.send('llm:stream:tool-call', { streamId, toolCall })
+          } else if (block.type === 'thinking') {
+            thinkingBlocks.push({
+              type: 'thinking',
+              thinking: block.thinking,
+              ...(block.signature ? { signature: block.signature } : {})
+            })
           }
         }
 
-        console.log('[LLM:stream] Sending complete:', fullContent.length, 'chars, toolCalls:', toolCalls.length)
+        console.log('[LLM:stream] Sending complete:', fullContent.length, 'chars, toolCalls:', toolCalls.length, 'thinkingBlocks:', thinkingBlocks.length)
         event.sender.send('llm:stream:complete', {
           streamId,
           content: fullContent,
-          toolCalls: toolCalls.length > 0 ? toolCalls : undefined
+          toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+          thinkingBlocks: thinkingBlocks.length > 0 ? thinkingBlocks : undefined
         })
 
         return { success: true }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -36,6 +36,9 @@ export interface LLMStreamRequest extends LLMRequest {
   streamId: string
   tools?: LLMToolDefinition[]
   maxToolRoundtrips?: number
+  maxTokens?: number
+  /** Enable adaptive thinking (Anthropic-only). Defaults to true when omitted in the main handler. */
+  thinking?: boolean
 }
 
 export interface LLMStreamChunk {
@@ -58,6 +61,22 @@ export interface LLMStreamToolCallStart {
   toolName: string
 }
 
+/**
+ * Thinking block from the Anthropic API. Preserved verbatim in assistant
+ * content for tool-loop continuations; never modified by the renderer.
+ */
+export interface LLMThinkingBlock {
+  type: 'thinking'
+  thinking: string
+  signature?: string
+}
+
+export interface LLMStreamThinkingDelta {
+  streamId: string
+  /** Cumulative thinking text so far (not a bare delta — simpler store handling). */
+  thinking: string
+}
+
 export interface LLMStreamComplete {
   streamId: string
   content: string
@@ -66,6 +85,8 @@ export interface LLMStreamComplete {
     name: string
     args: unknown
   }>
+  /** Full thinking blocks from this turn, preserved for tool-loop continuations. */
+  thinkingBlocks?: LLMThinkingBlock[]
 }
 
 export interface LLMStreamError {
@@ -201,6 +222,7 @@ export interface ElectronAPI {
   onLLMStreamToolCallStart: (callback: (start: LLMStreamToolCallStart) => void) => () => void
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => () => void
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
+  onLLMStreamThinkingDelta: (callback: (delta: LLMStreamThinkingDelta) => void) => () => void
   // Folder operations for quick save
   selectFolder: (defaultPath?: string, message?: string) => Promise<{ path: string; bookmark: string | null } | null>
   activateBookmark: (kind: 'project' | 'favorite', id: string, bookmark: string) => Promise<boolean>
@@ -519,6 +541,15 @@ const api: ElectronAPI = {
     ipcRenderer.on('llm:stream:error', handler)
     return () => {
       ipcRenderer.removeListener('llm:stream:error', handler)
+    }
+  },
+  onLLMStreamThinkingDelta: (callback: (delta: LLMStreamThinkingDelta) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, delta: LLMStreamThinkingDelta): void => {
+      callback(delta)
+    }
+    ipcRenderer.on('llm:stream:thinking:delta', handler)
+    return () => {
+      ipcRenderer.removeListener('llm:stream:thinking:delta', handler)
     }
   },
   // File association

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { cn } from '../../lib/utils'
 import type { ChatMessage as ChatMessageType } from '../../types'
-import { User, AlertCircle, Sparkles, CheckCircle2, XCircle, RotateCcw, ChevronDown } from 'lucide-react'
+import { User, AlertCircle, Sparkles, CheckCircle2, XCircle, RotateCcw, ChevronDown, Brain } from 'lucide-react'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { CopyButton } from '../ui/copy-button'
@@ -9,6 +9,38 @@ import { jumpToLine } from '../../lib/lineNavigation'
 import { getAISuggestions } from '../../extensions/ai-suggestions/extension'
 import { renderToolResult } from './toolResultRenderers'
 import { PROSE_ICONS, IconThumb } from '../../lib/prose-icons'
+
+/**
+ * Collapsible thinking block — shown above the assistant's main reply when the
+ * model produced thinking content. Collapsed by default; streaming state shown
+ * via a subtle pulsing indicator on the header when `isStreaming` is true.
+ */
+function ThinkingBlock({ text, isStreaming }: { text: string; isStreaming: boolean }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="rounded-md border border-border/50 bg-muted/10 overflow-hidden mb-2">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-muted-foreground hover:text-foreground hover:bg-muted/20 transition-colors"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Brain className={cn('h-3 w-3 shrink-0', isStreaming && 'animate-pulse text-primary/70')} />
+        <span className="flex-1 font-medium">
+          {isStreaming ? 'Thinking…' : 'Thought process'}
+        </span>
+        <ChevronDown
+          className={cn('h-3 w-3 shrink-0 transition-transform', open && 'rotate-180')}
+        />
+      </button>
+      {open && text && (
+        <div className="px-3 pb-3 pt-1 text-xs text-muted-foreground leading-relaxed whitespace-pre-wrap break-words border-t border-border/30">
+          {text}
+        </div>
+      )}
+    </div>
+  )
+}
 
 // Single source of truth for the "drafting" verb shown while the LLM is
 // composing tool arguments. Update here to tune copy app-wide.
@@ -477,6 +509,11 @@ export function ChatMessage({ message, isStreaming, onRetry }: ChatMessageProps)
           </div>
         )}
         <div className="text-sm leading-relaxed">
+          {/* Collapsible thinking block — only shown on assistant messages that
+              have thinking text (either streamed in progress or complete). */}
+          {!isUser && message.thinkingText && (
+            <ThinkingBlock text={message.thinkingText} isStreaming={!!isStreaming} />
+          )}
           {isUser ? (
             <p className="whitespace-pre-wrap break-words font-mono">{message.content}</p>
           ) : message.isError ? (

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '../ui/dropdown-menu'
-import { MessageSquare, History, Plus, Trash2, Sparkles, Info, Loader2, Filter } from 'lucide-react'
+import { MessageSquare, History, Plus, Trash2, Sparkles, Info, Loader2, Filter, Brain } from 'lucide-react'
 import { useChatStore } from '../../stores/chatStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
@@ -24,9 +24,15 @@ import { AIEditsHistoryPanel } from '../editor/AIEditsHistoryPanel'
 import { useAnnotationStore } from '../../extensions/ai-annotations/store'
 import { MODE_SWITCH_RUN_EVENT } from './toolResultRenderers/RequestModeSwitchResult'
 import { cn } from '../../lib/utils'
+import { supportsAdaptiveThinking } from '../../../shared/llm/models'
+import { useSettingsStore } from '../../stores/settingsStore'
 
 export function ChatPanel() {
   const { messages, isLoading, isStreaming, sendMessage, stopGeneration, clearMessages } = useChat()
+  const { thinkingEnabled, setThinkingEnabled } = useChatStore()
+  const { settings } = useSettingsStore()
+  // Only show the thinking toggle for models that support adaptive thinking
+  const showThinkingToggle = supportsAdaptiveThinking(settings.llm.model)
   const scrollRef = useRef<HTMLDivElement>(null)
   const chatTabRef = useRef<HTMLButtonElement>(null)
   const activityTabRef = useRef<HTMLButtonElement>(null)
@@ -294,6 +300,31 @@ export function ChatPanel() {
         {/* Chat actions — always visible (independent of the active tab).
             Actions whose effect lives in the chat view switch back to it. */}
         <div className="flex items-center gap-0.5">
+            {/* Extended thinking toggle — only shown for thinking-capable models */}
+            {showThinkingToggle && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                      'h-7 w-7',
+                      thinkingEnabled
+                        ? 'bg-accent text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    onClick={() => setThinkingEnabled(!thinkingEnabled)}
+                    aria-pressed={thinkingEnabled}
+                    aria-label={thinkingEnabled ? 'Extended thinking on' : 'Extended thinking off'}
+                  >
+                    <Brain className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {thinkingEnabled ? 'Extended thinking on · click to disable' : 'Extended thinking off · click to enable'}
+                </TooltipContent>
+              </Tooltip>
+            )}
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -153,6 +153,7 @@ export function useChat() {
     isPanelOpen,
     context,
     toolMode,
+    thinkingEnabled,
     activeConversationId,
     isStreaming,
     isInitializing,
@@ -470,7 +471,7 @@ export function useChat() {
             tools,
             maxToolRoundtrips: 5,
             maxTokens: state.toolMode === 'chat' ? 16000 : 16000,
-            thinking: true
+            thinking: state.thinkingEnabled
           })
         } catch (error) {
           console.error('[Chat] Tool loop error:', error)
@@ -687,7 +688,7 @@ export function useChat() {
           tools,
           maxToolRoundtrips: 5,
           maxTokens: 16000,
-          thinking: true
+          thinking: thinkingEnabled
         })
       } catch (error) {
         console.error('[Chat] Error:', error)

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -12,7 +12,7 @@ import { getSuggestionsWithFeedback } from '../extensions/ai-suggestions'
 import { executeTool, resolveToolPosition } from '../lib/tools'
 import { getToolsForClaudeAPI } from '../../shared/tools/registry'
 import { resolveModelName } from '../../shared/llm/models'
-import type { LLMMessage, LLMStreamToolCall, LLMStreamToolCallStart, LLMContentBlock } from '../types'
+import type { LLMMessage, LLMStreamToolCall, LLMStreamToolCallStart, LLMContentBlock, LLMThinkingBlock } from '../types'
 
 // Chat Mode gets a read-only tool subset rather than the full read+write
 // surface, so the agent can ground itself in the document without proposing
@@ -125,6 +125,12 @@ const toolLoopContextRef = {
     // hallucinating "I'm still in <old> Mode" despite the tool list
     // and per-mode instructions reflecting the new mode.
     modeJustSwitched: boolean
+    // Thinking blocks from the most recent stream turn. The Anthropic
+    // API requires these to be embedded verbatim in the assistant content
+    // array of tool-loop continuations — dropping or modifying them
+    // causes a 400 error. We accumulate them here and prepend them to
+    // assistantContentBlocks before pushing the continuation message.
+    thinkingBlocks: LLMThinkingBlock[]
   } | null,
   streamId: null as string | null
 }
@@ -194,6 +200,15 @@ export function useChat() {
       } else {
         console.log('[useChat:chunk] ✗ REJECTED - streamId mismatch')
       }
+    })
+
+    // Thinking delta: the main process sends cumulative thinking text on each
+    // thinking_delta event. We write it directly to the streaming message so
+    // the ThinkingBlock component can show live updates while the model thinks.
+    const unsubThinkingDelta = api.onLLMStreamThinkingDelta?.((delta) => {
+      const state = useChatStore.getState()
+      if (delta.streamId !== state.currentStreamId || !state.streamingMessageId) return
+      state.updateMessage(state.streamingMessageId, { thinkingText: delta.thinking })
     })
 
     const unsubToolCall = api.onLLMStreamToolCall((toolCallEvent: LLMStreamToolCall) => {
@@ -274,9 +289,18 @@ export function useChat() {
 
         // Build assistant message content with text AND tool_use blocks
         // The Anthropic API requires tool_use blocks in the assistant message
-        // for the subsequent tool_result to be valid
+        // for the subsequent tool_result to be valid.
+        //
+        // Thinking blocks MUST come first and be preserved unmodified. The
+        // API rejects continuations that drop or modify them (#700).
         const assistantText = state.messages.find((m) => m.id === assistantMsgId)?.content || ''
         const assistantContentBlocks: LLMContentBlock[] = []
+
+        // Prepend thinking blocks from this turn — required by the API
+        const priorThinking = toolLoopContextRef.current?.thinkingBlocks ?? []
+        for (const tb of priorThinking) {
+          assistantContentBlocks.push(tb)
+        }
 
         // Add text block if there's any text content
         if (assistantText.trim()) {
@@ -395,13 +419,16 @@ export function useChat() {
         // Update context for potential next tool loop with new streamId.
         // Preserve `modeJustSwitched` across the whole turn so subsequent
         // continuations keep the "you just switched" notice.
+        // Store thinking blocks so the NEXT continuation can prepend them
+        // to its assistant content array (the API requires them preserved).
         const priorTurnContext = toolLoopContextRef.current
         toolLoopContextRef.current = {
           apiMessages: updatedMessages,
           assistantMsgId,
           roundtripCount: roundtripCount + 1,
           lastErrorSignature: currentErrorSignature,
-          modeJustSwitched: priorTurnContext?.modeJustSwitched ?? false
+          modeJustSwitched: priorTurnContext?.modeJustSwitched ?? false,
+          thinkingBlocks: (complete.thinkingBlocks as LLMThinkingBlock[] | undefined) ?? []
         }
         toolLoopContextRef.streamId = newStreamId
         pendingToolCallsRef.streamId = newStreamId
@@ -442,7 +469,8 @@ export function useChat() {
             streamId: newStreamId,
             tools,
             maxToolRoundtrips: 5,
-            maxTokens: state.toolMode === 'chat' ? 3072 : 4096
+            maxTokens: state.toolMode === 'chat' ? 16000 : 16000,
+            thinking: true
           })
         } catch (error) {
           console.error('[Chat] Tool loop error:', error)
@@ -497,6 +525,7 @@ export function useChat() {
     return () => {
       console.log('[useChat:listeners] CLEANUP - unsubscribing all listeners')
       unsubChunk()
+      unsubThinkingDelta?.()
       unsubToolCall()
       unsubToolCallStart()
       unsubComplete()
@@ -629,7 +658,8 @@ export function useChat() {
           assistantMsgId,
           roundtripCount: 0,
           lastErrorSignature: null,
-          modeJustSwitched
+          modeJustSwitched,
+          thinkingBlocks: [] // populated by the first complete event
         }
         toolLoopContextRef.streamId = streamId
         pendingToolCallsRef.streamId = streamId
@@ -656,7 +686,8 @@ export function useChat() {
           streamId,
           tools,
           maxToolRoundtrips: 5,
-          maxTokens: toolMode === 'chat' ? 3072 : 4096
+          maxTokens: 16000,
+          thinking: true
         })
       } catch (error) {
         console.error('[Chat] Error:', error)

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -71,6 +71,12 @@ interface ChatState {
   appendStreamChunk: (delta: string) => void
   completeStreaming: () => void
 
+  // Extended thinking toggle — controls whether the model is asked to use
+  // adaptive thinking. Only Opus 4.7+ and Fable 5 honour the param; the
+  // main-process handler capability-gates by model ID automatically.
+  thinkingEnabled: boolean
+  setThinkingEnabled: (enabled: boolean) => void
+
   // Initialization actions
   setInitializing: (isInitializing: boolean) => void
 
@@ -101,6 +107,7 @@ export const useChatStore = create<ChatState>()(
     isStreaming: false,
     currentStreamId: null,
     streamingMessageId: null,
+    thinkingEnabled: true,
 
     setConversations: (conversations) => set({ conversations }),
 
@@ -300,6 +307,8 @@ export const useChatStore = create<ChatState>()(
         streamingMessageId: null,
         isLoading: false
       }),
+
+    setThinkingEnabled: (enabled) => set({ thinkingEnabled: enabled }),
 
     setInitializing: (isInitializing) => set({ isInitializing }),
 

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -182,6 +182,14 @@ export interface ChatMessage {
    * decisions already made.
    */
   toolActions?: Record<number, 'switched' | 'dismissed'>
+  /**
+   * Accumulated thinking text for this assistant turn (concatenated from
+   * all thinking blocks the model produced). Stored separately from
+   * `content` so it can be rendered in a collapsible UI block without
+   * polluting the text that goes through the tool-tag parser.
+   * Only set on assistant messages when the model produced thinking blocks.
+   */
+  thinkingText?: string
 }
 
 export interface FileResult {
@@ -358,7 +366,20 @@ export interface LLMToolResultBlock {
   content: string
 }
 
-export type LLMContentBlock = LLMTextBlock | LLMToolUseBlock | LLMToolResultBlock
+/**
+ * Thinking block returned by the Anthropic API when adaptive thinking is enabled.
+ * Preserved unmodified in assistant messages passed to continuations (required
+ * by the API — dropping or modifying thinking blocks in tool-use continuations
+ * causes a 400 error). The `signature` field is an opaque integrity token that
+ * the API generates and validates; we store it but never inspect it.
+ */
+export interface LLMThinkingBlock {
+  type: 'thinking'
+  thinking: string
+  signature?: string
+}
+
+export type LLMContentBlock = LLMTextBlock | LLMToolUseBlock | LLMToolResultBlock | LLMThinkingBlock
 
 export interface LLMMessage {
   role: 'user' | 'assistant' | 'tool'
@@ -391,6 +412,8 @@ export interface LLMStreamRequest extends LLMRequest {
   tools?: LLMToolDefinition[]
   maxToolRoundtrips?: number
   maxTokens?: number
+  /** Enable adaptive thinking (Anthropic-only). Defaults to true when omitted. */
+  thinking?: boolean
 }
 
 export interface LLMStreamChunk {
@@ -413,6 +436,12 @@ export interface LLMStreamToolCallStart {
   toolName: string
 }
 
+export interface LLMStreamThinkingDelta {
+  streamId: string
+  /** Cumulative thinking text so far (not an incremental delta — simpler to handle in the store). */
+  thinking: string
+}
+
 export interface LLMStreamComplete {
   streamId: string
   content: string
@@ -421,6 +450,13 @@ export interface LLMStreamComplete {
     name: string
     args: unknown
   }>
+  /**
+   * Full thinking blocks from this turn, if the model produced any.
+   * Passed back so `useChat` can embed them verbatim in the assistant
+   * content array for tool-loop continuations (the API requires them
+   * to be preserved unmodified).
+   */
+  thinkingBlocks?: LLMThinkingBlock[]
 }
 
 export interface LLMStreamError {
@@ -475,6 +511,7 @@ export interface ElectronAPI {
   onLLMStreamToolCallStart: (callback: (start: LLMStreamToolCallStart) => void) => () => void
   onLLMStreamComplete: (callback: (complete: LLMStreamComplete) => void) => () => void
   onLLMStreamError: (callback: (error: LLMStreamError) => void) => () => void
+  onLLMStreamThinkingDelta: (callback: (delta: LLMStreamThinkingDelta) => void) => () => void
   // Folder operations for quick save
   selectFolder: (defaultPath?: string, message?: string) => Promise<{ path: string; bookmark: string | null } | null>
   /** Activate a MAS security-scoped bookmark in-session (#654). Optional: older

--- a/src/shared/llm/models.ts
+++ b/src/shared/llm/models.ts
@@ -44,6 +44,22 @@ export function getDefaultHaikuModel(): string {
 }
 
 /**
+ * Model IDs that support the adaptive thinking API
+ * (`thinking: {type: "adaptive", display: "summarized"}`).
+ * Claude Opus 4.7+, Opus 4.8, and Fable 5 support it.
+ * Sonnet 4.6 and Haiku 4.5 do NOT — sending the param returns HTTP 400.
+ */
+const THINKING_CAPABLE_PREFIXES = [
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+  'claude-fable-5',
+]
+
+export function supportsAdaptiveThinking(modelId: string): boolean {
+  return THINKING_CAPABLE_PREFIXES.some(prefix => modelId.startsWith(prefix))
+}
+
+/**
  * Resolve a model ID to its human-readable display name. Prefers the live-fetched
  * list (which the provider updates as new models ship), falls back to the static
  * seed, and finally to the raw model ID.

--- a/src/shared/llm/models.ts
+++ b/src/shared/llm/models.ts
@@ -46,10 +46,13 @@ export function getDefaultHaikuModel(): string {
 /**
  * Model IDs that support the adaptive thinking API
  * (`thinking: {type: "adaptive", display: "summarized"}`).
- * Claude Opus 4.7+, Opus 4.8, and Fable 5 support it.
- * Sonnet 4.6 and Haiku 4.5 do NOT — sending the param returns HTTP 400.
+ * Sonnet 4.6, Opus 4.6+, and Fable 5 support it.
+ * Haiku 4.5 and older Sonnets (4.5/4.0) do NOT — sending the param
+ * returns HTTP 400 on those models.
  */
 const THINKING_CAPABLE_PREFIXES = [
+  'claude-sonnet-4-6',
+  'claude-opus-4-6',
   'claude-opus-4-7',
   'claude-opus-4-8',
   'claude-fable-5',


### PR DESCRIPTION
## Summary

- Enable Anthropic extended thinking in the \`llm:stream\` IPC handler (\`src/main/ipc.ts\`): uses the correct \`thinking: {type: 'adaptive', display: 'summarized'}\` shape (Sonnet 4.6, Opus 4.6+, Fable 5). The old \`enabled\` + \`budget_tokens\` form is removed on those models and returns HTTP 400.
- Add \`supportsAdaptiveThinking(modelId)\` to \`src/shared/llm/models.ts\` — capability-gates by model ID prefix: Sonnet 4.6, Opus 4.6+, Opus 4.7+, Opus 4.8, Fable 5. Only Haiku 4.5 and older Sonnets (4.5/4.0) are excluded — those return HTTP 400 when the thinking param is sent.
- Control thinking depth via \`output_config: { effort: 'high' }\` (replaces the removed budget-token ceiling logic; \`max_tokens\` stays at a flat 16000).
- \`display: 'summarized'\` is mandatory — the default \`'omitted'\` yields empty thinking text even when the model thinks.
- Stream thinking text to the renderer via a new \`llm:stream:thinking:delta\` IPC event; plumbed through preload and consumed in \`useChat.ts\` to update \`message.thinkingText\` in real time.
- Render a collapsible \`ThinkingBlock\` component in \`ChatMessage.tsx\` (Brain icon, collapsed by default, pulsing during active stream). Only shown when the model produces thinking content.
- **Thinking block preservation across tool loops**: \`useChat.ts\` stores thinking blocks from each turn in \`toolLoopContextRef\` and prepends them verbatim to the assistant content array on every continuation — required by the Anthropic API (400 error otherwise).
- Add \`thinkingEnabled\` toggle to \`chatStore\` (defaults true). Both \`sendMessage\` and the tool-loop continuation read it from the store — replaces the hardcoded \`thinking: true\` at both call sites.
- Add a Brain icon toggle button in \`ChatPanel\` header next to the Info/History actions, visible only when the current model supports adaptive thinking. Shows \`aria-pressed\` for a11y consistency. No keyboard shortcut (⌘⌥T is taken by Convert to Plain Text in menu.ts:181 — deferred to a follow-up).

Closes #700
Supersedes #556

## Changed files

- \`src/shared/llm/models.ts\` — \`supportsAdaptiveThinking()\` with model-prefix capability gate (Sonnet 4.6, Opus 4.6+, Fable 5)
- \`src/main/ipc.ts\` — adaptive thinking param (\`type:'adaptive', display:'summarized'\`), \`output_config:{effort:'high'}\`, remove budget logic, import \`supportsAdaptiveThinking\`
- \`src/preload/index.ts\` — \`LLMThinkingBlock\`, \`LLMStreamThinkingDelta\`, \`onLLMStreamThinkingDelta\` bridge
- \`src/renderer/types/index.ts\` — \`LLMThinkingBlock\`, \`LLMStreamThinkingDelta\`, updated \`LLMStreamComplete\`, \`ChatMessage.thinkingText\`, \`LLMStreamRequest.thinking\`
- \`src/renderer/stores/chatStore.ts\` — \`thinkingEnabled\` state + \`setThinkingEnabled\` action
- \`src/renderer/hooks/useChat.ts\` — read \`thinkingEnabled\` from store, thinking delta listener, thinking block preservation in tool loop
- \`src/renderer/components/chat/ChatMessage.tsx\` — \`ThinkingBlock\` component, renders above main content
- \`src/renderer/components/chat/ChatPanel.tsx\` — Brain toggle button, model-gated via \`supportsAdaptiveThinking\`

## Verification

Build passes cleanly (no TypeScript errors, only pre-existing Radix UI "use client" warnings that pre-date this PR).

To verify:
1. Configure an Anthropic API key + select Claude Opus 4.7 in Settings
2. Open the Chat panel — a Brain icon toggle appears in the toolbar; click to toggle thinking on/off
3. Send a substantive question with thinking on — a pulsing "Thinking…" block appears above the response during streaming; collapses to "Thought process" when complete
4. Toggle thinking off — no ThinkingBlock renders, LLM is called without the thinking param
5. Switch to Sonnet 4.6 — Brain toggle **remains visible** (Sonnet 4.6 supports adaptive thinking); switch to Haiku 4.5 — toggle disappears
6. In Editor Mode, ask the agent to "read the document and then make an edit" — no 400 error (thinking blocks preserved across tool-use → tool-result → continuation)

## Test plan

- [ ] Brain icon toggle appears for Sonnet 4.6 and Opus 4.7; hidden for Haiku 4.5
- [ ] Thinking block renders and collapses correctly during streaming
- [ ] Thinking block header changes from "Thinking…" to "Thought process" after stream completes
- [ ] Toggling off skips the thinking param entirely
- [ ] No API errors on multi-tool-roundtrip flows (thinking block preservation)
- [ ] Build passes with no new errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)