### PR TITLE
feat(comments): threading — replies, real resolved state, AI participation

### DIFF
--- a/e2e/electron.activity-panel.spec.ts
+++ b/e2e/electron.activity-panel.spec.ts
@@ -126,17 +126,18 @@ test.describe('Electron — Activity panel', () => {
 
     // The superseded row + the filter funnel are present.
     await expect(page.getByTestId('annotation-detached-badge')).toBeVisible()
-    const filterBtn = page.getByRole('button', { name: 'Hide superseded edits' })
+    // Filter button covers both superseded edits and resolved comments (#699).
+    const filterBtn = page.getByRole('button', { name: 'Hide superseded and resolved' })
     await expect(filterBtn).toBeVisible()
 
     // Engage the filter → superseded hidden, badge drops to current-only (1).
     await filterBtn.click()
     await expect(badge).toHaveText('1')
     await expect(page.getByTestId('annotation-detached-badge')).toHaveCount(0)
-    await expect(page.getByRole('button', { name: 'Show superseded edits' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Show all activity' })).toBeVisible()
 
     // Toggle back → superseded reappears, badge back to 2.
-    await page.getByRole('button', { name: 'Show superseded edits' }).click()
+    await page.getByRole('button', { name: 'Show all activity' }).click()
     await expect(badge).toHaveText('2')
     await expect(page.getByTestId('annotation-detached-badge')).toBeVisible()
   })

--- a/e2e/electron.comment-threading.spec.ts
+++ b/e2e/electron.comment-threading.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * Comment threading (#699) — replies, real resolved state, AI participation.
+ *
+ * Tests:
+ * 1. reply_to_comment tool appends an AI reply to the persisted thread.
+ * 2. resolve_comment sets resolved:true in the store instead of deleting the record.
+ * 3. Resolved threads are not re-marked on restore (restoreComments skips resolved).
+ * 4. list_comments returns replies + resolved state.
+ *
+ * Uses an isolated PROSE_USER_DATA_DIR profile; runs against the out/ build.
+ * No LLM calls — all tools invoked via window.__prose_tools.executeTool.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+  executeProseTool,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaDocsDir: string
+
+test.beforeAll(async () => {
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-699-'))
+  qaDocsDir = mkdtempSync(join(tmpdir(), 'prose-699-docs-'))
+
+  const result = await launchApp({
+    env: {
+      PROSE_USER_DATA_DIR: qaUserDataDir,
+      PROSE_DOCS_DIR: qaDocsDir,
+    },
+  })
+  app = result.app
+  page = result.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page).catch(() => {})
+  await dismissOverlay(page).catch(() => {})
+  await waitForEditor(page)
+})
+
+test.afterAll(async () => {
+  await app.close().catch(() => {})
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaDocsDir, { recursive: true, force: true })
+})
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Returns the current pendingComments from the comment store. */
+async function getCommentStore(testPage: Page): Promise<Array<Record<string, unknown>>> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return testPage.evaluate(() => (window as any).__prose_tools.getCommentStore())
+}
+
+/**
+ * Find any non-empty paragraph node and add a comment to it.
+ * Returns the new comment ID.
+ */
+async function addComment(testPage: Page, commentText: string): Promise<string> {
+  const read = await executeProseTool(testPage, 'read_document', {})
+  expect(read.success, 'read_document').toBe(true)
+  interface DocNode { id: string; content?: string; children?: DocNode[] }
+  const flatten = (nodes: DocNode[]): DocNode[] =>
+    nodes.flatMap((n) => [n, ...(n.children ? flatten(n.children) : [])])
+  const node = flatten((read.data as { nodes: DocNode[] }).nodes).find(
+    (n) => n.content && n.content.trim().length > 5,
+  )
+  expect(node, 'find non-empty node').toBeTruthy()
+
+  const result = await executeProseTool(testPage, 'add_comment', {
+    nodeId: node!.id,
+    comment: commentText,
+  })
+  expect(result.success, `add_comment: ${JSON.stringify(result)}`).toBe(true)
+  return (result.data as { id: string }).id
+}
+
+/** Count live comment marks visible in the editor DOM. */
+async function countCommentMarks(testPage: Page): Promise<number> {
+  return testPage.evaluate(() => document.querySelectorAll('.comment-mark').length)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test('reply_to_comment appends AI reply to thread', async () => {
+  await page.click('.ProseMirror')
+  await page.keyboard.press('Control+a')
+  await page.keyboard.type('The quick brown fox jumps over the lazy dog.')
+
+  const commentId = await addComment(page, 'Check the rhythm of this sentence.')
+
+  const replyResult = await executeProseTool(page, 'reply_to_comment', {
+    id: commentId,
+    text: 'The rhythm is fine — the stress pattern scans well.',
+  })
+  expect(replyResult.success, `reply_to_comment: ${JSON.stringify(replyResult)}`).toBe(true)
+  const replyId = (replyResult.data as { replyId: string }).replyId
+  expect(typeof replyId).toBe('string')
+  expect(replyId.length).toBeGreaterThan(0)
+
+  // Verify the reply landed in the comment store
+  const comments = await getCommentStore(page)
+  const thread = comments.find((c) => c.id === commentId)
+  expect(thread, 'thread in store').toBeTruthy()
+  const replies = thread!.replies as Array<{ id: string; author: string; text: string }>
+  expect(replies).toHaveLength(1)
+  expect(replies[0].author).toBe('ai')
+  expect(replies[0].text).toContain('rhythm is fine')
+  expect(replies[0].id).toBe(replyId)
+})
+
+test('resolve_comment sets resolved:true and removes mark', async () => {
+  await page.click('.ProseMirror')
+  await page.keyboard.press('Control+a')
+  await page.keyboard.type('A sentence to comment on for resolve testing.')
+
+  const commentId = await addComment(page, 'Resolve this thread.')
+
+  // Mark should be present before resolve
+  const marksBefore = await countCommentMarks(page)
+  expect(marksBefore).toBeGreaterThan(0)
+
+  const resolveResult = await executeProseTool(page, 'resolve_comment', {
+    id: commentId,
+  })
+  expect(resolveResult.success, `resolve_comment: ${JSON.stringify(resolveResult)}`).toBe(true)
+
+  // Mark should be gone from the editor
+  const marksAfter = await countCommentMarks(page)
+  expect(marksAfter).toBe(0)
+
+  // Thread must persist in the store with resolved:true
+  const comments = await getCommentStore(page)
+  const thread = comments.find((c) => c.id === commentId)
+  expect(thread, 'thread persists after resolve').toBeTruthy()
+  expect(thread!.resolved).toBe(true)
+})
+
+test('list_comments includes replies and resolved state', async () => {
+  await page.click('.ProseMirror')
+  await page.keyboard.press('Control+a')
+  await page.keyboard.type('Content for list_comments threading test.')
+
+  const commentId = await addComment(page, 'List comments should show replies.')
+
+  await executeProseTool(page, 'reply_to_comment', {
+    id: commentId,
+    text: 'Acknowledged.',
+  })
+
+  const listResult = await executeProseTool(page, 'list_comments', {})
+  expect(listResult.success).toBe(true)
+  const listData = listResult.data as {
+    comments: Array<{ id: string; replies: unknown[]; resolved: boolean }>
+  }
+  const entry = listData.comments.find((c) => c.id === commentId)
+  expect(entry, 'comment in list').toBeTruthy()
+  expect(entry!.replies).toHaveLength(1)
+  expect(entry!.resolved).toBe(false)
+})
+
+test('resolved threads do not get re-marked on restoreComments', async () => {
+  // Write a markdown file so we can reopen the tab to trigger restoreComments
+  const mdPath = join(qaDocsDir, 'resolve-restore-test.md')
+  writeFileSync(mdPath, '# Restore Test\n\nThis text will be commented.\n')
+
+  const openResult = await executeProseTool(page, 'open_file', { path: mdPath })
+  expect(openResult.success, 'open_file').toBe(true)
+  await waitForEditor(page)
+
+  const commentId = await addComment(page, 'Should not re-appear after resolve.')
+  await executeProseTool(page, 'resolve_comment', { id: commentId })
+
+  // Close and reopen the file to trigger comment restoration
+  await page.keyboard.press('Control+w')
+  await waitForEditor(page)
+  const reopen = await executeProseTool(page, 'open_file', { path: mdPath })
+  expect(reopen.success).toBe(true)
+  await waitForEditor(page)
+
+  // The resolved comment must not be re-marked
+  const marksAfterReopen = await countCommentMarks(page)
+  expect(marksAfterReopen).toBe(0)
+})

--- a/e2e/electron.comment-threading.spec.ts
+++ b/e2e/electron.comment-threading.spec.ts
@@ -4,10 +4,10 @@
  * Tests:
  * 1. reply_to_comment tool appends an AI reply to the persisted thread.
  * 2. resolve_comment sets resolved:true in the store instead of deleting the record.
- * 3. Resolved threads are not re-marked on restore (restoreComments skips resolved).
- * 4. list_comments returns replies + resolved state.
+ * 3. list_comments returns replies + resolved state.
+ * 4. Resolved threads are not re-marked on restoreComments.
  *
- * Uses an isolated PROSE_USER_DATA_DIR profile; runs against the out/ build.
+ * Each test opens a fresh markdown file for isolation. No tab sharing.
  * No LLM calls — all tools invoked via window.__prose_tools.executeTool.
  */
 
@@ -64,6 +64,19 @@ async function getCommentStore(testPage: Page): Promise<Array<Record<string, unk
 }
 
 /**
+ * Open a fresh markdown file (creates + writes it) and wait for the editor.
+ * Returns the file path.
+ */
+async function openFreshFile(testPage: Page, name: string, content: string): Promise<string> {
+  const mdPath = join(qaDocsDir, name)
+  writeFileSync(mdPath, content)
+  const openResult = await executeProseTool(testPage, 'open_file', { path: mdPath })
+  expect(openResult.success, `open_file ${name}`).toBe(true)
+  await waitForEditor(testPage)
+  return mdPath
+}
+
+/**
  * Find any non-empty paragraph node and add a comment to it.
  * Returns the new comment ID.
  */
@@ -81,7 +94,7 @@ async function addComment(testPage: Page, commentText: string): Promise<string> 
   const result = await executeProseTool(testPage, 'add_comment', {
     nodeId: node!.id,
     comment: commentText,
-  })
+  }, 'editor')
   expect(result.success, `add_comment: ${JSON.stringify(result)}`).toBe(true)
   return (result.data as { id: string }).id
 }
@@ -94,16 +107,14 @@ async function countCommentMarks(testPage: Page): Promise<number> {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 test('reply_to_comment appends AI reply to thread', async () => {
-  await page.click('.ProseMirror')
-  await page.keyboard.press('Control+a')
-  await page.keyboard.type('The quick brown fox jumps over the lazy dog.')
+  await openFreshFile(page, 'reply-test.md', '# Reply Test\n\nThe quick brown fox jumps over the lazy dog.\n')
 
   const commentId = await addComment(page, 'Check the rhythm of this sentence.')
 
   const replyResult = await executeProseTool(page, 'reply_to_comment', {
     id: commentId,
     text: 'The rhythm is fine — the stress pattern scans well.',
-  })
+  }, 'editor')
   expect(replyResult.success, `reply_to_comment: ${JSON.stringify(replyResult)}`).toBe(true)
   const replyId = (replyResult.data as { replyId: string }).replyId
   expect(typeof replyId).toBe('string')
@@ -121,9 +132,7 @@ test('reply_to_comment appends AI reply to thread', async () => {
 })
 
 test('resolve_comment sets resolved:true and removes mark', async () => {
-  await page.click('.ProseMirror')
-  await page.keyboard.press('Control+a')
-  await page.keyboard.type('A sentence to comment on for resolve testing.')
+  await openFreshFile(page, 'resolve-test.md', '# Resolve Test\n\nA sentence to comment on for resolve testing.\n')
 
   const commentId = await addComment(page, 'Resolve this thread.')
 
@@ -133,7 +142,7 @@ test('resolve_comment sets resolved:true and removes mark', async () => {
 
   const resolveResult = await executeProseTool(page, 'resolve_comment', {
     id: commentId,
-  })
+  }, 'editor')
   expect(resolveResult.success, `resolve_comment: ${JSON.stringify(resolveResult)}`).toBe(true)
 
   // Mark should be gone from the editor
@@ -148,16 +157,14 @@ test('resolve_comment sets resolved:true and removes mark', async () => {
 })
 
 test('list_comments includes replies and resolved state', async () => {
-  await page.click('.ProseMirror')
-  await page.keyboard.press('Control+a')
-  await page.keyboard.type('Content for list_comments threading test.')
+  await openFreshFile(page, 'list-test.md', '# List Test\n\nContent for list_comments threading test.\n')
 
   const commentId = await addComment(page, 'List comments should show replies.')
 
   await executeProseTool(page, 'reply_to_comment', {
     id: commentId,
     text: 'Acknowledged.',
-  })
+  }, 'editor')
 
   const listResult = await executeProseTool(page, 'list_comments', {})
   expect(listResult.success).toBe(true)
@@ -171,25 +178,31 @@ test('list_comments includes replies and resolved state', async () => {
 })
 
 test('resolved threads do not get re-marked on restoreComments', async () => {
-  // Write a markdown file so we can reopen the tab to trigger restoreComments
-  const mdPath = join(qaDocsDir, 'resolve-restore-test.md')
-  writeFileSync(mdPath, '# Restore Test\n\nThis text will be commented.\n')
-
-  const openResult = await executeProseTool(page, 'open_file', { path: mdPath })
-  expect(openResult.success, 'open_file').toBe(true)
-  await waitForEditor(page)
+  // Write the initial file
+  const mdPath = await openFreshFile(
+    page,
+    'resolve-restore-test.md',
+    '# Restore Test\n\nThis text will be commented then the thread resolved.\n'
+  )
 
   const commentId = await addComment(page, 'Should not re-appear after resolve.')
-  await executeProseTool(page, 'resolve_comment', { id: commentId })
 
-  // Close and reopen the file to trigger comment restoration
+  // Resolve the comment (sets resolved:true, removes mark, persists to IDB)
+  const resolveResult = await executeProseTool(page, 'resolve_comment', { id: commentId }, 'editor')
+  expect(resolveResult.success, 'resolve_comment').toBe(true)
+
+  // Confirm no mark in editor right now
+  expect(await countCommentMarks(page)).toBe(0)
+
+  // Close this tab (triggers save) then reopen the file to trigger restoreComments
   await page.keyboard.press('Control+w')
   await waitForEditor(page)
+
   const reopen = await executeProseTool(page, 'open_file', { path: mdPath })
-  expect(reopen.success).toBe(true)
+  expect(reopen.success, 'open_file reopen').toBe(true)
   await waitForEditor(page)
 
-  // The resolved comment must not be re-marked
+  // restoreComments must skip the resolved thread — no mark in the editor
   const marksAfterReopen = await countCommentMarks(page)
   expect(marksAfterReopen).toBe(0)
 })

--- a/src/renderer/components/CommentPopover.tsx
+++ b/src/renderer/components/CommentPopover.tsx
@@ -1,15 +1,22 @@
 /**
- * Comment Popover — shows an existing comment's text with a Remove action.
- * Mirrors the visual language of AISuggestionPopover.
+ * Comment Popover — thread view for an existing comment.
+ *
+ * Shows the original comment, any replies (user + AI), a reply input, a
+ * resolve control, and a remove button. Mirrors the visual language of
+ * AISuggestionPopover.
  */
 
 import { useEffect, useRef, useState, useCallback, useLayoutEffect } from 'react'
 import { createPortal } from 'react-dom'
 import type { Editor } from '@tiptap/core'
-import { Trash2, X, Sparkles } from 'lucide-react'
+import { Trash2, X, Sparkles, CheckCheck, Send, Bot, User } from 'lucide-react'
 import { useChat } from '../hooks/useChat'
 import { useAIConfigured } from '../hooks/useAIConfigured'
 import { aiUnavailableMessage } from '../lib/llm'
+import { useCommentStore } from '../extensions/comments/store'
+import type { CommentData, CommentReply } from '../extensions/comments/types'
+import { generateId } from '../lib/persistence'
+import { cn } from '../lib/utils'
 
 const NAV_BAR_HEIGHT = 48
 const VIEWPORT_PADDING = 16
@@ -33,9 +40,20 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
     position: { x: 0, y: 0 },
   })
   const [adjustedPosition, setAdjustedPosition] = useState<{ x: number; y: number } | null>(null)
+  const [replyText, setReplyText] = useState('')
   const popoverRef = useRef<HTMLDivElement>(null)
+  const replyInputRef = useRef<HTMLTextAreaElement>(null)
   const { processComment } = useChat()
   const ai = useAIConfigured()
+
+  // Get persisted comment data (replies + resolved state)
+  const pendingComments = useCommentStore((s) => s.pendingComments)
+  const documentId = useCommentStore((s) => s.documentId)
+  const saveComments = useCommentStore((s) => s.saveComments)
+
+  const currentComment: CommentData | undefined = popover.commentId
+    ? pendingComments.find((c) => c.id === popover.commentId)
+    : undefined
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
@@ -61,6 +79,7 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
           commentText: text,
           position: { x: rect.left + rect.width / 2, y: rect.bottom + 8 },
         })
+        setReplyText('')
         return
       }
 
@@ -115,11 +134,29 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
   }, [popover.isOpen, popover.position, adjustedPosition])
 
   const handleRemove = useCallback(() => {
-    if (popover.commentId) {
-      editor.commands.unsetComment(popover.commentId)
-      setPopover((prev) => ({ ...prev, isOpen: false }))
-    }
-  }, [editor, popover.commentId])
+    if (!popover.commentId) return
+    const id = popover.commentId
+    // Remove the editor mark and drop the persisted record entirely.
+    editor.commands.unsetComment(id)
+    const { pendingComments: current } = useCommentStore.getState()
+    const updated = current.filter((c) => c.id !== id)
+    useCommentStore.setState({ pendingComments: updated })
+    if (documentId) saveComments(documentId, updated)
+    setPopover((prev) => ({ ...prev, isOpen: false }))
+  }, [editor, popover.commentId, documentId, saveComments])
+
+  const handleResolve = useCallback(() => {
+    if (!popover.commentId) return
+    const id = popover.commentId
+    // Mark resolved:true in the store (thread persists as history),
+    // then remove the editor mark so the highlight disappears.
+    const { pendingComments: current } = useCommentStore.getState()
+    const updated = current.map((c) => c.id === id ? { ...c, resolved: true } : c)
+    useCommentStore.setState({ pendingComments: updated })
+    if (documentId) saveComments(documentId, updated)
+    editor.commands.unsetComment(id)
+    setPopover((prev) => ({ ...prev, isOpen: false }))
+  }, [editor, popover.commentId, documentId, saveComments])
 
   const handleProcess = useCallback(() => {
     if (popover.commentId) {
@@ -133,9 +170,42 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
     setPopover((prev) => ({ ...prev, isOpen: false }))
   }, [])
 
+  // Add a user reply to the thread
+  const handleAddReply = useCallback(() => {
+    const text = replyText.trim()
+    if (!text || !popover.commentId) return
+    const id = popover.commentId
+    const reply: CommentReply = {
+      id: generateId(),
+      author: 'user',
+      text,
+      createdAt: Date.now(),
+    }
+    const { pendingComments: current } = useCommentStore.getState()
+    const updated = current.map((c) =>
+      c.id === id ? { ...c, replies: [...(c.replies ?? []), reply] } : c
+    )
+    useCommentStore.setState({ pendingComments: updated })
+    if (documentId) saveComments(documentId, updated)
+    setReplyText('')
+    replyInputRef.current?.focus()
+  }, [replyText, popover.commentId, documentId, saveComments])
+
+  const handleReplyKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        handleAddReply()
+      }
+    },
+    [handleAddReply]
+  )
+
   if (!popover.isOpen) return null
 
   const displayPosition = adjustedPosition || popover.position
+  const replies = currentComment?.replies ?? []
+  const isResolved = currentComment?.resolved === true
 
   return createPortal(
     <div
@@ -149,17 +219,59 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
         visibility: adjustedPosition ? 'visible' : 'hidden',
       }}
     >
+      {/* Original comment */}
       <div className="comment-label">Comment:</div>
       <div className="comment-text">{popover.commentText}</div>
+
+      {/* Thread replies */}
+      {replies.length > 0 && (
+        <div className="comment-replies">
+          {replies.map((reply) => (
+            <ReplyRow key={reply.id} reply={reply} />
+          ))}
+        </div>
+      )}
+
+      {/* Reply input (hidden for resolved threads) */}
+      {!isResolved && (
+        <div className="comment-reply-input">
+          <textarea
+            ref={replyInputRef}
+            className="reply-textarea"
+            value={replyText}
+            onChange={(e) => setReplyText(e.target.value)}
+            onKeyDown={handleReplyKeyDown}
+            placeholder="Reply… (Enter to send)"
+            rows={2}
+          />
+          <button
+            className="reply-send-btn"
+            onClick={handleAddReply}
+            disabled={!replyText.trim()}
+            aria-label="Send reply"
+          >
+            <Send size={14} />
+          </button>
+        </div>
+      )}
+
+      {/* Actions */}
       <div className="actions">
         <button
           className="process-btn"
           onClick={handleProcess}
-          disabled={!ai.available}
+          disabled={!ai.available || isResolved}
+          title={isResolved ? 'Thread is resolved' : undefined}
         >
           <Sparkles size={16} />
           Process
         </button>
+        {!isResolved && (
+          <button className="resolve-btn" onClick={handleResolve}>
+            <CheckCheck size={16} />
+            Resolve
+          </button>
+        )}
         <button className="remove-btn" onClick={handleRemove}>
           <Trash2 size={16} />
           Remove
@@ -174,5 +286,19 @@ export function CommentPopover({ editor }: CommentPopoverProps) {
       )}
     </div>,
     document.body
+  )
+}
+
+// ─── Sub-components ────────────────────────────────────────────────────────────
+
+function ReplyRow({ reply }: { reply: CommentReply }) {
+  const isAI = reply.author === 'ai'
+  return (
+    <div className={cn('comment-reply', isAI ? 'reply-ai' : 'reply-user')}>
+      <span className="reply-author-icon" aria-label={isAI ? 'AI' : 'You'}>
+        {isAI ? <Bot size={12} /> : <User size={12} />}
+      </span>
+      <span className="reply-text">{reply.text}</span>
+    </div>
   )
 }

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -22,6 +22,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { ReviewContainer } from '../review/ReviewContainer'
 import { AIEditsHistoryPanel } from '../editor/AIEditsHistoryPanel'
 import { useAnnotationStore } from '../../extensions/ai-annotations/store'
+import { useCommentStore } from '../../extensions/comments/store'
 import { MODE_SWITCH_RUN_EVENT } from './toolResultRenderers/RequestModeSwitchResult'
 import { cn } from '../../lib/utils'
 
@@ -37,6 +38,8 @@ export function ChatPanel() {
   // because the toggle lives in this header but the filtering happens in
   // AIEditsHistoryPanel.
   const [hideSuperseded, setHideSuperseded] = useState(false)
+  // Filter resolved comment threads in the Activity list.
+  const [hideResolved, setHideResolved] = useState(false)
 
   const {
     conversations,
@@ -95,9 +98,23 @@ export function ChatPanel() {
     () => annotations.reduce((n, a) => (a.detached ? n + 1 : n), 0),
     [annotations]
   )
+
+  // Comment thread counts for the Activity tab badge.
+  const pendingComments = useCommentStore((s) => s.pendingComments)
+  const commentActivityCount = useMemo(
+    () => pendingComments.reduce((n, c) => n + (c.replies?.length ?? 0), 0),
+    [pendingComments]
+  )
+  const resolvedCount = useMemo(
+    () => pendingComments.filter((c) => c.resolved).length,
+    [pendingComments]
+  )
+
   // Badge reflects what's currently shown: total when including superseded,
   // current-only when the filter is engaged.
-  const activityCount = hideSuperseded ? annotations.length - supersededCount : annotations.length
+  const activityCount =
+    (hideSuperseded ? annotations.length - supersededCount : annotations.length) +
+    commentActivityCount
 
   // Track pending suggestion count
   const suggestionCount = useMemo(() => {
@@ -264,8 +281,8 @@ export function ChatPanel() {
             </button>
           </div>
 
-          {/* Filter: hide/show superseded — only when there's something to filter */}
-          {sidebarMode === 'activity' && supersededCount > 0 && (
+          {/* Filter: hide/show superseded + resolved — only when there's something to filter */}
+          {sidebarMode === 'activity' && (supersededCount > 0 || resolvedCount > 0) && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -273,19 +290,23 @@ export function ChatPanel() {
                   size="icon"
                   className={cn(
                     'h-6 w-6',
-                    hideSuperseded ? 'bg-accent text-primary' : 'text-muted-foreground hover:text-foreground'
+                    (hideSuperseded || hideResolved) ? 'bg-accent text-primary' : 'text-muted-foreground hover:text-foreground'
                   )}
-                  onClick={() => setHideSuperseded((v) => !v)}
-                  aria-pressed={hideSuperseded}
-                  aria-label={hideSuperseded ? 'Show superseded edits' : 'Hide superseded edits'}
+                  onClick={() => {
+                    const filtering = hideSuperseded || hideResolved
+                    setHideSuperseded(!filtering)
+                    setHideResolved(!filtering)
+                  }}
+                  aria-pressed={hideSuperseded || hideResolved}
+                  aria-label={(hideSuperseded || hideResolved) ? 'Show all activity' : 'Hide superseded and resolved'}
                 >
                   <Filter className="h-3.5 w-3.5" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                {hideSuperseded
-                  ? 'Showing current edits · click to include superseded'
-                  : 'Hide superseded edits'}
+                {(hideSuperseded || hideResolved)
+                  ? 'Showing current activity · click to include superseded and resolved'
+                  : 'Hide superseded edits and resolved comments'}
               </TooltipContent>
             </Tooltip>
           )}
@@ -418,7 +439,8 @@ export function ChatPanel() {
         {sidebarMode === 'activity' ? (
           <AIEditsHistoryPanel
             hideSuperseded={hideSuperseded}
-            onShowAll={() => setHideSuperseded(false)}
+            hideResolved={hideResolved}
+            onShowAll={() => { setHideSuperseded(false); setHideResolved(false) }}
           />
         ) : (
           <>

--- a/src/renderer/components/editor/AIEditsHistoryPanel.tsx
+++ b/src/renderer/components/editor/AIEditsHistoryPanel.tsx
@@ -1,63 +1,104 @@
 /**
  * AI Edits History Panel
  *
- * A live view of the AI authorship annotations on the current document, grouped
- * by date. This is a direct projection of the annotation store (single source of
- * truth) — there is no separate ledger. Removing a row removes the underlying
- * annotation (un-marks the AI authorship; the text itself is left untouched), and
- * un-marking in the document removes the row. Fully idempotent in both directions.
+ * A live view of the AI authorship annotations and comment threads on the
+ * current document, grouped by date. Annotations derive from the annotation
+ * store; comment activity (replies + resolutions) derives from the comment store.
  *
  * Surface: rendered inside the chat sidebar when the user selects the Activity
- * tab in the ChatPanel header. The superseded filter lives in that tab header;
- * this panel receives the resulting `hideSuperseded` flag as a prop.
+ * tab in the ChatPanel header. The superseded + resolved filters live in that
+ * tab header; this panel receives the resulting flags as props.
  */
 
 import { useCallback, useMemo } from 'react'
-import { Wand2, Crosshair, X, Eye, EyeOff, Filter } from 'lucide-react'
+import { Wand2, Crosshair, X, Eye, EyeOff, Filter, MessageSquare, CheckCheck, Bot, User } from 'lucide-react'
 import { useAnnotationStore } from '../../extensions/ai-annotations/store'
+import { useCommentStore } from '../../extensions/comments/store'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
 import { formatAge } from '../../types/annotations'
 import type { AIAnnotation, AnnotationType } from '../../types/annotations'
+import type { CommentData, CommentReply } from '../../extensions/comments/types'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { cn } from '../../lib/utils'
 
 interface AIEditsHistoryPanelProps {
-  /** Hide superseded (detached) entries. Owned by ChatPanel's tab header. */
+  /** Hide superseded (detached) AI edit entries. Owned by ChatPanel's tab header. */
   hideSuperseded: boolean
-  /** Clear the filter (wired to the filtered-empty "Show all" affordance). */
+  /** Hide resolved comment threads. Owned by ChatPanel's tab header. */
+  hideResolved: boolean
+  /** Clear all filters (wired to the filtered-empty "Show all" affordance). */
   onShowAll: () => void
 }
 
-export function AIEditsHistoryPanel({ hideSuperseded, onShowAll }: AIEditsHistoryPanelProps) {
+// Unified activity item for the mixed feed
+type ActivityItem =
+  | { kind: 'annotation'; annotation: AIAnnotation; createdAt: number }
+  | { kind: 'comment'; comment: CommentData; createdAt: number }
+
+interface ActivityDateGroup {
+  label: string
+  items: ActivityItem[]
+}
+
+export function AIEditsHistoryPanel({ hideSuperseded, hideResolved, onShowAll }: AIEditsHistoryPanelProps) {
   const annotations = useAnnotationStore((s) => s.annotations)
   const removeAnnotation = useAnnotationStore((s) => s.removeAnnotation)
+  const pendingComments = useCommentStore((s) => s.pendingComments)
+  const documentId = useCommentStore((s) => s.documentId)
+  const saveComments = useCommentStore((s) => s.saveComments)
   const editor = useEditorInstanceStore((s) => s.editor)
 
-  // Superseded (detached) entries are history-only — their annotated text was
-  // replaced by a later edit (#674). The filter toggle lives in ChatPanel's
-  // tab header; this panel just honours the resulting flag.
+  // Filter annotations by superseded flag.
   const visibleAnnotations = useMemo(
     () => (hideSuperseded ? annotations.filter((a) => !a.detached) : annotations),
     [annotations, hideSuperseded]
   )
 
-  // Newest first, grouped by calendar day.
-  const groups = useMemo(
-    () => groupAnnotationsByDate([...visibleAnnotations].sort((a, b) => b.createdAt - a.createdAt)),
-    [visibleAnnotations]
-  )
+  // Filter comments: show those with replies or that are resolved.
+  // Active (unresolved) comments with no replies live in the popover only.
+  const visibleComments = useMemo(() => {
+    return pendingComments.filter((c) => {
+      const hasActivity = (c.replies?.length ?? 0) > 0 || c.resolved
+      if (!hasActivity) return false
+      if (hideResolved && c.resolved) return false
+      return true
+    })
+  }, [pendingComments, hideResolved])
+
+  // Build a unified sorted feed, newest-first
+  const items: ActivityItem[] = useMemo(() => {
+    const annotationItems: ActivityItem[] = visibleAnnotations.map((a) => ({
+      kind: 'annotation',
+      annotation: a,
+      createdAt: a.createdAt,
+    }))
+    const commentItems: ActivityItem[] = visibleComments.map((c) => ({
+      kind: 'comment',
+      comment: c,
+      // Key timestamp is the most recent activity (last reply, or creation)
+      createdAt:
+        c.replies && c.replies.length > 0
+          ? c.replies[c.replies.length - 1].createdAt
+          : c.createdAt,
+    }))
+    return [...annotationItems, ...commentItems].sort((a, b) => b.createdAt - a.createdAt)
+  }, [visibleAnnotations, visibleComments])
+
+  const hasAnyActivity =
+    annotations.length > 0 ||
+    pendingComments.some((c) => (c.replies?.length ?? 0) > 0 || c.resolved)
+  const nothingVisible = items.length === 0
+
+  const groups = useMemo(() => groupActivityByDate(items), [items])
 
   const handleJump = useCallback(
     (annotation: AIAnnotation) => {
       if (!editor) return
-      // Detached entries are history-only (#674): the annotated text was
-      // replaced by a later edit, so the stored positions are stale.
+      // Detached entries are history-only (#674)
       if (annotation.detached) return
       editor.commands.setTextSelection({ from: annotation.from, to: annotation.to })
       editor.commands.focus()
-
-      // Scroll the selection into view
       const { selection } = editor.state
       const domAtPos = editor.view.domAtPos(selection.from)
       const el = domAtPos.node instanceof Element ? domAtPos.node : domAtPos.node.parentElement
@@ -66,23 +107,43 @@ export function AIEditsHistoryPanel({ hideSuperseded, onShowAll }: AIEditsHistor
     [editor]
   )
 
+  const handleRemoveAnnotation = useCallback(
+    (id: string) => {
+      removeAnnotation(id)
+    },
+    [removeAnnotation]
+  )
+
+  const handleRemoveComment = useCallback(
+    (id: string) => {
+      const { pendingComments: current } = useCommentStore.getState()
+      const updated = current.filter((c) => c.id !== id)
+      useCommentStore.setState({ pendingComments: updated })
+      if (documentId) saveComments(documentId, updated)
+      // Remove the editor mark if it's still live
+      editor?.commands.unsetComment(id)
+    },
+    [editor, documentId, saveComments]
+  )
+
   return (
     <div className="flex flex-col h-full">
       {/* Content */}
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {annotations.length === 0 ? (
+        {!hasAnyActivity ? (
           <EmptyState />
-        ) : visibleAnnotations.length === 0 ? (
+        ) : nothingVisible ? (
           <FilteredEmptyState onShowAll={onShowAll} />
         ) : (
           <div className="py-1">
             {groups.map((group) => (
-              <DateGroup
+              <ActivityDateGroup
                 key={group.label}
                 label={group.label}
-                annotations={group.annotations}
-                onJump={handleJump}
-                onRemove={removeAnnotation}
+                items={group.items}
+                onJumpAnnotation={handleJump}
+                onRemoveAnnotation={handleRemoveAnnotation}
+                onRemoveComment={handleRemoveComment}
               />
             ))}
           </div>
@@ -101,21 +162,20 @@ function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center h-full p-6 text-center gap-2">
       <Wand2 className="h-8 w-8 text-muted-foreground/30" />
-      <p className="text-xs text-muted-foreground">No AI edits yet</p>
+      <p className="text-xs text-muted-foreground">No activity yet</p>
       <p className="text-[10px] text-muted-foreground/60 max-w-[180px] leading-relaxed">
-        AI-applied edits to this document will appear here. Remove one to clear its
-        AI-authored marking — the text stays.
+        AI edits and comment thread activity will appear here.
       </p>
     </div>
   )
 }
 
-/** Shown when the superseded filter is on and every remaining entry is superseded. */
+/** Shown when every entry is hidden by the active filters. */
 function FilteredEmptyState({ onShowAll }: { onShowAll: () => void }) {
   return (
     <div className="flex flex-col items-center justify-center h-full p-6 text-center gap-2">
       <Filter className="h-8 w-8 text-muted-foreground/30" />
-      <p className="text-xs text-muted-foreground">All edits are superseded</p>
+      <p className="text-xs text-muted-foreground">All activity is filtered</p>
       <button
         onClick={onShowAll}
         className="text-[10px] text-muted-foreground/80 underline-offset-2 hover:underline"
@@ -126,32 +186,49 @@ function FilteredEmptyState({ onShowAll }: { onShowAll: () => void }) {
   )
 }
 
-interface DateGroupProps {
+interface ActivityDateGroupProps {
   label: string
-  annotations: AIAnnotation[]
-  onJump: (annotation: AIAnnotation) => void
-  onRemove: (id: string) => void
+  items: ActivityItem[]
+  onJumpAnnotation: (annotation: AIAnnotation) => void
+  onRemoveAnnotation: (id: string) => void
+  onRemoveComment: (id: string) => void
 }
 
-function DateGroup({ label, annotations, onJump, onRemove }: DateGroupProps) {
+function ActivityDateGroup({
+  label,
+  items,
+  onJumpAnnotation,
+  onRemoveAnnotation,
+  onRemoveComment,
+}: ActivityDateGroupProps) {
   return (
     <div>
       <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 sticky top-0 bg-background z-10 border-b border-border/40">
         {label}
       </div>
       <div className="divide-y divide-border/30">
-        {annotations.map((annotation) => (
-          <HistoryEntryRow
-            key={annotation.id}
-            annotation={annotation}
-            onJump={onJump}
-            onRemove={onRemove}
-          />
-        ))}
+        {items.map((item) =>
+          item.kind === 'annotation' ? (
+            <HistoryEntryRow
+              key={item.annotation.id}
+              annotation={item.annotation}
+              onJump={onJumpAnnotation}
+              onRemove={onRemoveAnnotation}
+            />
+          ) : (
+            <CommentActivityRow
+              key={item.comment.id}
+              comment={item.comment}
+              onRemove={onRemoveComment}
+            />
+          )
+        )}
       </div>
     </div>
   )
 }
+
+// ─── Annotation row ────────────────────────────────────────────────────────────
 
 interface HistoryEntryRowProps {
   annotation: AIAnnotation
@@ -257,6 +334,89 @@ function TypeBadge({ type }: { type: AnnotationType }) {
   )
 }
 
+// ─── Comment activity row ──────────────────────────────────────────────────────
+
+interface CommentActivityRowProps {
+  comment: CommentData
+  onRemove: (id: string) => void
+}
+
+function CommentActivityRow({ comment, onRemove }: CommentActivityRowProps) {
+  const replies = comment.replies ?? []
+  const isResolved = comment.resolved === true
+
+  return (
+    <div className="group px-4 py-3 hover:bg-muted/40 transition-colors">
+      {/* Meta row: badge · age · remove */}
+      <div className="flex items-center gap-2 mb-2">
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+            isResolved
+              ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+              : 'border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-400'
+          )}
+        >
+          {isResolved ? <CheckCheck className="h-2.5 w-2.5" /> : <MessageSquare className="h-2.5 w-2.5" />}
+          {isResolved ? 'resolved' : 'thread'}
+        </span>
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground/60">
+          {formatAge(comment.createdAt)}
+        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onRemove(comment.id)
+              }}
+              className="shrink-0 rounded p-0.5 opacity-0 group-hover:opacity-100 hover:bg-muted text-muted-foreground hover:text-destructive transition-all"
+              aria-label="Remove comment thread"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">Remove comment thread</TooltipContent>
+        </Tooltip>
+      </div>
+
+      {/* Original comment text */}
+      <p className="text-[13px] leading-snug text-foreground/80 line-clamp-2 mb-1.5 italic">
+        "{comment.comment}"
+      </p>
+
+      {/* Replies (up to 3, truncated) */}
+      {replies.length > 0 && (
+        <div className="flex flex-col gap-1">
+          {replies.slice(0, 3).map((reply) => (
+            <ReplyChip key={reply.id} reply={reply} />
+          ))}
+          {replies.length > 3 && (
+            <span className="text-[10px] text-muted-foreground/60">
+              +{replies.length - 3} more
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReplyChip({ reply }: { reply: CommentReply }) {
+  const isAI = reply.author === 'ai'
+  return (
+    <div className="flex items-start gap-1.5">
+      <span
+        className="mt-0.5 shrink-0 text-muted-foreground/60"
+        aria-label={isAI ? 'AI' : 'You'}
+      >
+        {isAI ? <Bot className="h-3 w-3" /> : <User className="h-3 w-3" />}
+      </span>
+      <span className="text-[11px] text-muted-foreground line-clamp-2">{reply.text}</span>
+    </div>
+  )
+}
+
 /**
  * Footer: toggle AI annotation visibility in the editor. Shares a single source of
  * truth with the toolbar's "Hide AI annotations" button (editorStore.annotationsVisible)
@@ -295,18 +455,13 @@ function AnnotationVisibilityFooter() {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
-interface AnnotationDateGroup {
-  label: string
-  annotations: AIAnnotation[]
-}
-
-/** Group annotations by calendar day (newest-first input → newest-first groups). */
-function groupAnnotationsByDate(annotations: AIAnnotation[]): AnnotationDateGroup[] {
-  const groups = new Map<string, AnnotationDateGroup>()
-  for (const annotation of annotations) {
-    const label = formatGroupLabel(annotation.createdAt)
-    if (!groups.has(label)) groups.set(label, { label, annotations: [] })
-    groups.get(label)!.annotations.push(annotation)
+/** Group activity items by calendar day (newest-first input → newest-first groups). */
+function groupActivityByDate(items: ActivityItem[]): ActivityDateGroup[] {
+  const groups = new Map<string, ActivityDateGroup>()
+  for (const item of items) {
+    const label = formatGroupLabel(item.createdAt)
+    if (!groups.has(label)) groups.set(label, { label, items: [] })
+    groups.get(label)!.items.push(item)
   }
   return Array.from(groups.values())
 }
@@ -331,8 +486,6 @@ function formatGroupLabel(timestamp: number): string {
  * Compact display name for a model string.
  * e.g. "claude-sonnet-4-6" → "Sonnet 4.6", "claude-haiku-4-5-20251001" → "Haiku 4.5",
  * "external" → "External", "Imported" → "Imported".
- * Treats the first token as the name (title-cased) and joins the remaining
- * version tokens with dots, after dropping any trailing date stamp.
  */
 function formatModelName(model: string): string {
   if (!model || model === 'external') return 'External'

--- a/src/renderer/extensions/comments/extension.ts
+++ b/src/renderer/extensions/comments/extension.ts
@@ -222,27 +222,40 @@ export const Comment = Mark.create<CommentOptions>({
           const { doc, schema } = state
           let restored = 0
 
+          // doc.textContent has no block separators; textBetween stored the
+          // markedText with a space separator. Normalise before searching so
+          // cross-block comments match (#665 fix).
+          const docText = doc.textContent
+
           for (const comment of comments) {
-            // Use the stored marked text to locate where the comment mark should be applied.
-            // We search for the first occurrence of the marked text in the document.
-            const searchText = comment.markedText
-            if (!searchText) {
+            // Resolved threads are stored but must not be re-marked in the
+            // editor — they're history only.
+            if (comment.resolved) continue
+
+            const rawSearchText = comment.markedText
+            if (!rawSearchText) {
               console.warn('[Comment] Cannot restore comment without markedText:', comment.id)
               continue
             }
 
-            const docText = doc.textContent
-            // Walk occurrences of searchText and stop at the Nth one, where N is
-            // comment.occurrenceIndex (default 0 for backward-compat with older data).
+            // Normalise the stored markedText to the same representation as
+            // textContent (strip the space block-separators injected by
+            // textBetween). Single-block comments are unaffected.
+            const searchText = rawSearchText.replace(/ /g, '')
+
+            // Walk occurrences of searchText and stop at the Nth one, where N
+            // is comment.occurrenceIndex (default 0 for backward-compat).
+            // We also search textContent with the normalised text.
+            const docTextNorm = docText.replace(/ /g, '')
             const targetOccurrence = comment.occurrenceIndex ?? 0
             let currentOccurrence = 0
             let searchOffset = 0
-            let textIndex = -1
+            let normIndex = -1
             let foundTarget = false
             while (true) {
-              const matchIdx = docText.indexOf(searchText, searchOffset)
+              const matchIdx = docTextNorm.indexOf(searchText, searchOffset)
               if (matchIdx === -1) break
-              textIndex = matchIdx // track last found as fallback
+              normIndex = matchIdx // track last found as fallback
               if (currentOccurrence === targetOccurrence) {
                 foundTarget = true
                 break
@@ -250,10 +263,10 @@ export const Comment = Mark.create<CommentOptions>({
               currentOccurrence++
               searchOffset = matchIdx + searchText.length
             }
-            if (textIndex === -1) {
+            if (normIndex === -1) {
               console.warn('[Comment] Cannot find markedText in document:', {
                 id: comment.id,
-                markedText: searchText.substring(0, 50)
+                markedText: rawSearchText.substring(0, 50)
               })
               continue
             }
@@ -266,30 +279,36 @@ export const Comment = Mark.create<CommentOptions>({
               })
             }
 
-            // Walk the document to map char index → ProseMirror positions
-            let charCount = 0
+            // Map the normalised char index back to a ProseMirror position by
+            // walking text nodes and accumulating the char count without spaces
+            // (matching the normalised search above).
+            let normCount = 0
             let foundStart = -1
             let foundEnd = -1
+            const normEnd = normIndex + searchText.length
 
             doc.descendants((node, nodePos) => {
               if (foundStart !== -1 && foundEnd !== -1) return false
 
               if (node.isText && node.text) {
-                const nodeText = node.text
-                const nodeStart = charCount
-                const nodeEnd = charCount + nodeText.length
+                const nodeNorm = node.text.replace(/ /g, '')
+                const nodeNormStart = normCount
+                const nodeNormEnd = normCount + nodeNorm.length
 
-                if (foundStart === -1 && textIndex >= nodeStart && textIndex < nodeEnd) {
-                  foundStart = nodePos + (textIndex - nodeStart)
+                if (foundStart === -1 && normIndex >= nodeNormStart && normIndex < nodeNormEnd) {
+                  // Offset within this text node in original chars.
+                  // We need to map normIndex back to a char offset inside node.text.
+                  const charOffset = mapNormOffsetToChar(node.text, normIndex - nodeNormStart)
+                  foundStart = nodePos + charOffset
                 }
 
-                const targetEnd = textIndex + searchText.length
-                if (foundStart !== -1 && targetEnd > nodeStart && targetEnd <= nodeEnd) {
-                  foundEnd = nodePos + (targetEnd - nodeStart)
+                if (foundStart !== -1 && normEnd > nodeNormStart && normEnd <= nodeNormEnd) {
+                  const charOffset = mapNormOffsetToChar(node.text, normEnd - nodeNormStart)
+                  foundEnd = nodePos + charOffset
                   return false
                 }
 
-                charCount += nodeText.length
+                normCount += nodeNorm.length
               }
             })
 
@@ -399,6 +418,25 @@ export function getComments(editor: { state: { doc: { descendants: (fn: (node: {
   })
 
   return comments
+}
+
+/**
+ * Map a normalised char offset (spaces stripped) back to the real char offset
+ * within an original string. Used by restoreComments when matching comment text
+ * across block boundaries (#665).
+ *
+ * Example: original = "hello world", stripped = "helloworld"
+ *   mapNormOffsetToChar(original, 5) → 6 (the 'w' after the space)
+ */
+function mapNormOffsetToChar(original: string, normOffset: number): number {
+  let norm = 0
+  for (let i = 0; i < original.length; i++) {
+    if (original[i] !== ' ') {
+      if (norm === normOffset) return i
+      norm++
+    }
+  }
+  return original.length
 }
 
 export default Comment

--- a/src/renderer/extensions/comments/index.ts
+++ b/src/renderer/extensions/comments/index.ts
@@ -1,3 +1,3 @@
 export { Comment, getComments, commentMarkdownSerializer } from './extension'
-export type { CommentMark, CommentData, CommentOptions } from './types'
+export type { CommentMark, CommentData, CommentReply, CommentOptions } from './types'
 export { useCommentStore } from './store'

--- a/src/renderer/extensions/comments/types.ts
+++ b/src/renderer/extensions/comments/types.ts
@@ -8,6 +8,15 @@ export interface CommentMark {
   createdAt: number
 }
 
+/** A single reply within a comment thread. */
+export interface CommentReply {
+  id: string
+  /** 'user' for human replies, 'ai' for AI-generated replies. */
+  author: 'user' | 'ai'
+  text: string
+  createdAt: number
+}
+
 export interface CommentData {
   id: string
   markedText: string
@@ -17,10 +26,20 @@ export interface CommentData {
   occurrenceIndex?: number
   from: number
   to: number
+  /** Ordered list of replies in the thread. Missing in older data → treated as []. */
+  replies?: CommentReply[]
+  /**
+   * True when the comment has been resolved. Resolved threads persist in the
+   * store (collapsed) rather than being deleted. Missing in older data → treated
+   * as false (active thread).
+   */
+  resolved?: boolean
 }
 
 export interface CommentOptions {
   HTMLAttributes?: Record<string, unknown>
   onCommentAdded?: (comment: CommentData) => void
   onCommentRemoved?: (id: string) => void
+  onCommentResolved?: (id: string) => void
+  onCommentReplied?: (id: string, reply: CommentReply) => void
 }

--- a/src/renderer/hooks/useChat.ts
+++ b/src/renderer/hooks/useChat.ts
@@ -736,18 +736,17 @@ export function useChat() {
     const comments = getComments(editor)
     if (comments.length === 0) return
 
-    // Build the prompt from comments
+    // Build the prompt from comments. The AI uses reply_to_comment /
+    // suggest_edit / resolve_comment to act on each thread — marks are not
+    // removed here; the AI resolves them via tools when done.
     const commentsPrompt = buildCommentsPrompt(comments)
-
-    // Only remove comments if the message was actually dispatched to the AI (#631)
-    const dispatched = await sendMessage(commentsPrompt)
-    if (dispatched) {
-      editor.commands.unsetAllComments()
-    }
+    await sendMessage(commentsPrompt)
   }, [sendMessage])
 
-  // Process a single comment by id — same prompt shape as processComments,
-  // but scoped to just one mark so the user can act per-comment from the popover.
+  // Process a single comment by id — launches the AI to read the thread and
+  // decide: reply, suggest_edit, or both, then resolve when done.
+  // The AI uses list_comments / reply_to_comment / suggest_edit / resolve_comment
+  // rather than the host deleting the mark immediately.
   const processComment = useCallback(async (commentId: string) => {
     const editor = useEditorInstanceStore.getState().editor
     if (!editor) return
@@ -756,10 +755,8 @@ export function useChat() {
     if (!target) return
 
     const commentsPrompt = buildCommentsPrompt([target])
-    const dispatched = await sendMessage(commentsPrompt)
-    if (dispatched) {
-      editor.commands.unsetComment(commentId)
-    }
+    // Do NOT delete the mark before or after — the AI decides when to resolve.
+    await sendMessage(commentsPrompt)
   }, [sendMessage])
 
   // Helper to get current comment count

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -956,6 +956,121 @@
   background: hsl(var(--accent));
 }
 
+/* ── Comment thread replies ──────────────────────────────────────────────── */
+
+.comment-popover .comment-replies {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+  border-left: 2px solid hsl(var(--border));
+  padding-left: 0.75rem;
+}
+
+.comment-popover .comment-reply {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.comment-popover .reply-author-icon {
+  display: flex;
+  align-items: center;
+  margin-top: 0.125rem;
+  color: hsl(var(--muted-foreground));
+  flex-shrink: 0;
+}
+
+.comment-popover .reply-text {
+  color: hsl(var(--foreground));
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.comment-popover .reply-ai .reply-author-icon {
+  color: hsl(var(--ai-action));
+}
+
+/* Reply input area */
+.comment-popover .comment-reply-input {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.comment-popover .reply-textarea {
+  flex: 1;
+  background: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.625rem;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: hsl(var(--foreground));
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.comment-popover .reply-textarea:focus {
+  border-color: hsl(var(--ring));
+}
+
+.comment-popover .reply-textarea::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+
+.comment-popover .reply-send-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  background: hsl(var(--ai-action));
+  color: white;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+
+.comment-popover .reply-send-btn:hover {
+  background: hsl(var(--ai-action-hover));
+}
+
+.comment-popover .reply-send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Resolve button */
+.comment-popover .resolve-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--border));
+}
+
+.comment-popover .resolve-btn:hover {
+  background: hsl(142 50% 45% / 0.15);
+  color: hsl(142 60% 40%);
+  border-color: hsl(142 50% 45% / 0.4);
+}
+
 /* AI Suggestion Marks - Purple highlighting for AI edit suggestions */
 .prose-editor .ai-suggestion-mark {
   background: hsl(var(--ai-suggest-mark-bg) / 0.4);

--- a/src/renderer/lib/prompts.ts
+++ b/src/renderer/lib/prompts.ts
@@ -104,10 +104,11 @@ If the user asks for direct drafting — verbs like "rewrite", "write", "draft",
 
 - \`read_document\` — Returns document nodes with unique IDs
 - \`get_outline\` — Headings-only structural skim
-- \`list_comments\` — Existing comments in the document
+- \`list_comments\` — Existing comment threads (with replies + resolved state)
 - \`suggest_edit\` — Inline diff for a copy edit the user can accept or reject
 - \`add_comment\` — Editorial note attached to a range; the user decides the replacement
-- \`resolve_comment\` — Remove a comment by ID
+- \`reply_to_comment\` — Add an AI reply to a comment thread; use before or instead of editing
+- \`resolve_comment\` — Mark a comment thread resolved (it persists as history, not deleted)
 - \`move_cursor\` — Park the user's cursor at a specific node (no content change)
 - \`request_mode_switch\` — Offer the user a one-click switch to Create Mode for drafting requests
 
@@ -141,7 +142,7 @@ The user has opted in to LLM-authored prose. The no-authorship rule is lifted �
 
 - \`read_document\` — Returns document nodes with unique IDs
 - \`get_outline\` — Headings-only structural skim
-- \`list_comments\` / \`add_comment\` / \`resolve_comment\` — Editorial notes
+- \`list_comments\` / \`add_comment\` / \`reply_to_comment\` / \`resolve_comment\` — Comment threads: read, reply, and resolve
 - \`suggest_edit\` — Inline diff the user can accept or reject (use when the user should review)
 - \`edit\` — Directly replaces a node's content (the default tool for "edit X to be Y", "rewrite this paragraph", or other in-place rewrites the user has requested)
 - \`insert\` — Insert text at a position. Use \`position=after_node\` paired with a heading \`nodeId\` from \`read_document\` when adding to a specific section. Use \`position=cursor\` when the user said "here" — OR when the user has a non-empty selection and asks to replace it: \`position=cursor\` over a selection deletes the selection and inserts the new text in its place. (\`insert\` is the correct tool for "use insert to replace this with X" — don't redirect to \`edit\`.)
@@ -237,19 +238,31 @@ export function buildSystemPrompt(
 }
 
 /**
- * Build a prompt for processing comments
+ * Build a prompt for processing comments.
+ *
+ * The AI participates as a real collaborator: it replies, edits, or both,
+ * and calls resolve_comment when a thread is fully addressed.
  */
 export function buildCommentsPrompt(comments: CommentData[]): string {
   if (comments.length === 0) return ''
 
-  let prompt = `Process the following comments from the document. Each comment is an instruction for how to edit the marked text.\n\n`
+  let prompt = `The following comment${comments.length > 1 ? 's need' : ' needs'} your attention. For each thread:\n`
+  prompt += `- Call \`list_comments\` first to see the full thread context (replies, resolved state).\n`
+  prompt += `- Decide the right response: reply with \`reply_to_comment\`, propose an edit with \`suggest_edit\`, or both.\n`
+  prompt += `- Call \`resolve_comment\` when the thread is fully addressed — resolved threads persist as history.\n`
+  prompt += `- Use \`read_document\` for node IDs before editing.\n\n`
 
   comments.forEach((comment, index) => {
-    prompt += `${index + 1}. Text: "${comment.markedText}"\n`
-    prompt += `   Instruction: ${comment.comment}\n\n`
+    prompt += `${index + 1}. Comment ID: ${comment.id}\n`
+    prompt += `   Text: "${comment.markedText}"\n`
+    prompt += `   Instruction: ${comment.comment}\n`
+    if (comment.replies && comment.replies.length > 0) {
+      prompt += `   Replies so far: ${comment.replies.length}\n`
+    }
+    prompt += '\n'
   })
 
-  prompt += `Apply each comment as an edit. Use read_document for node IDs. Preserve the author's voice.`
+  prompt += `Preserve the author's voice. A reply alone is enough when an edit isn't warranted.`
 
   return prompt
 }

--- a/src/renderer/lib/tools/executors/document.ts
+++ b/src/renderer/lib/tools/executors/document.ts
@@ -10,7 +10,8 @@ import { useEditorInstanceStore } from '../../../stores/editorInstanceStore'
 import { useAnnotationStore } from '../../../extensions/ai-annotations'
 import { getNodesWithIds, findNodeById } from '../../../extensions/node-ids'
 import type { NodeWithId } from '../../../extensions/node-ids'
-import { getComments } from '../../../extensions/comments'
+import { getComments, useCommentStore } from '../../../extensions/comments'
+import type { CommentReply } from '../../../extensions/comments/types'
 import { getAISuggestions } from '../../../extensions/ai-suggestions'
 import { isEditorReadOnly } from './editor'
 import { getApi } from '../../browserApi'
@@ -367,7 +368,7 @@ export function executeGetOutline(): ToolResult<{ outline: OutlineEntry[]; summa
 // Comment tools
 // ============================================================================
 
-/** Minimal comment shape returned by list_comments */
+/** Comment shape returned by list_comments (includes thread data). */
 interface CommentEntry {
   id: string
   markedText: string
@@ -375,10 +376,16 @@ interface CommentEntry {
   createdAt: number
   from: number
   to: number
+  replies: CommentReply[]
+  resolved: boolean
 }
 
 /**
  * list_comments - Get all comments in the active document.
+ *
+ * Merges the live editor marks (positions) with persisted thread data
+ * (replies, resolved state) from the comment store so the AI gets the
+ * full thread context.
  */
 export function executeListComments(): ToolResult<{ comments: CommentEntry[] }> {
   const editor = getEditor()
@@ -387,15 +394,42 @@ export function executeListComments(): ToolResult<{ comments: CommentEntry[] }> 
     return toolError('Editor not available', 'EDITOR_NOT_AVAILABLE')
   }
 
-  const raw = getComments(editor)
-  const comments: CommentEntry[] = raw.map((c) => ({
-    id: c.id,
-    markedText: c.markedText,
-    comment: c.comment,
-    createdAt: c.createdAt,
-    from: c.from,
-    to: c.to,
-  }))
+  // Live marks give us current positions.
+  const liveMarks = getComments(editor)
+
+  // Persisted store holds replies + resolved state not carried by the mark.
+  const persistedComments = useCommentStore.getState().pendingComments
+
+  const comments: CommentEntry[] = liveMarks.map((c) => {
+    const persisted = persistedComments.find((p) => p.id === c.id)
+    return {
+      id: c.id,
+      markedText: c.markedText,
+      comment: c.comment,
+      createdAt: c.createdAt,
+      from: c.from,
+      to: c.to,
+      replies: persisted?.replies ?? [],
+      resolved: persisted?.resolved ?? false,
+    }
+  })
+
+  // Also include resolved threads (mark removed, but store still has them).
+  const resolvedIds = new Set(liveMarks.map((c) => c.id))
+  for (const p of persistedComments) {
+    if (!resolvedIds.has(p.id) && p.resolved) {
+      comments.push({
+        id: p.id,
+        markedText: p.markedText,
+        comment: p.comment,
+        createdAt: p.createdAt,
+        from: p.from,
+        to: p.to,
+        replies: p.replies ?? [],
+        resolved: true,
+      })
+    }
+  }
 
   return toolSuccess({ comments })
 }
@@ -472,7 +506,10 @@ export function executeAddComment(args: {
 }
 
 /**
- * resolve_comment - Remove a comment by its ID.
+ * resolve_comment - Mark a comment thread as resolved.
+ *
+ * Sets resolved:true on the persisted CommentData and removes the editor mark.
+ * The thread remains in the store as collapsed history — it is not deleted.
  */
 export function executeResolveComment(args: {
   id: string
@@ -493,11 +530,73 @@ export function executeResolveComment(args: {
     return toolError('Comment ID is required', 'INVALID_INPUT')
   }
 
-  const success = editor.commands.unsetComment(id)
-
-  if (!success) {
+  // Update the persisted thread (set resolved:true) before removing the mark.
+  const store = useCommentStore.getState()
+  const existing = store.pendingComments.find((c) => c.id === id)
+  if (!existing) {
     return toolError(`Comment with ID "${id}" not found`, 'COMMENT_NOT_FOUND')
   }
 
+  const documentId = store.documentId
+  if (documentId) {
+    const updated = store.pendingComments.map((c) =>
+      c.id === id ? { ...c, resolved: true } : c
+    )
+    store.saveComments(documentId, updated)
+    // Keep the in-memory list in sync so the store reflects the change
+    // immediately (Zustand state is immutable — we reach through to a re-set).
+    useCommentStore.setState({ pendingComments: updated })
+  }
+
+  // Remove the editor mark so the highlight disappears.
+  editor.commands.unsetComment(id)
+
   return toolSuccess({ resolved: true })
+}
+
+/**
+ * reply_to_comment - Append an AI reply to a comment thread.
+ */
+export function executeReplyToComment(args: {
+  id: string
+  text: string
+}): ToolResult<{ replyId: string }> {
+  if (isEditorReadOnly()) {
+    return toolError('Document is read-only in this mode', 'EDITOR_READ_ONLY')
+  }
+
+  const { id, text } = args
+
+  if (!id) {
+    return toolError('Comment ID is required', 'INVALID_INPUT')
+  }
+  if (!text?.trim()) {
+    return toolError('Reply text is required', 'INVALID_INPUT')
+  }
+
+  const store = useCommentStore.getState()
+  const existing = store.pendingComments.find((c) => c.id === id)
+  if (!existing) {
+    return toolError(`Comment with ID "${id}" not found`, 'COMMENT_NOT_FOUND')
+  }
+
+  const reply: CommentReply = {
+    id: generateId(),
+    author: 'ai',
+    text: text.trim(),
+    createdAt: Date.now(),
+  }
+
+  const documentId = store.documentId
+  const updated = store.pendingComments.map((c) =>
+    c.id === id ? { ...c, replies: [...(c.replies ?? []), reply] } : c
+  )
+
+  useCommentStore.setState({ pendingComments: updated })
+
+  if (documentId) {
+    store.saveComments(documentId, updated)
+  }
+
+  return toolSuccess({ replyId: reply.id })
 }

--- a/src/renderer/lib/tools/executors/document.ts
+++ b/src/renderer/lib/tools/executors/document.ts
@@ -502,7 +502,69 @@ export function executeAddComment(args: {
     return toolError('Failed to apply comment mark — the range may not contain markable content', 'COMMENT_FAILED')
   }
 
+  // Immediately mirror the new comment into the store so reply_to_comment /
+  // resolve_comment can find it by ID in the same session without waiting for
+  // a tab-switch save (which is normally where the store gets populated).
+  const storeState = useCommentStore.getState()
+  const newEntry = {
+    id,
+    markedText: rangeText,
+    comment,
+    createdAt: Date.now(),
+    occurrenceIndex: 0,
+    from,
+    to,
+    replies: [] as CommentReply[],
+    resolved: false,
+  }
+  const updatedComments = [...storeState.pendingComments, newEntry]
+  useCommentStore.setState({ pendingComments: updatedComments })
+  if (storeState.documentId) {
+    storeState.saveComments(storeState.documentId, updatedComments)
+  }
+
   return toolSuccess({ id })
+}
+
+/**
+ * Resolve the comment store entry for a given ID, falling back to the live
+ * editor marks when the store doesn't have it yet.
+ *
+ * The comment store is only populated on tab-load (from IndexedDB) and on
+ * explicit saves (tab switch, resolve, reply). When `add_comment` creates a
+ * new mark inside the same "session" the mark exists only in the TipTap
+ * document — `pendingComments` won't have it until the next save. This helper
+ * bridges that gap so tools can act on freshly-created comments.
+ */
+function ensureInStore(
+  id: string,
+  store: ReturnType<typeof useCommentStore.getState>,
+  editor: ReturnType<typeof getEditor>
+): boolean {
+  const alreadyInStore = store.pendingComments.some((c) => c.id === id)
+  if (alreadyInStore) return true
+
+  // Fall back to live editor marks
+  if (!editor) return false
+  const liveMark = getComments(editor).find((c) => c.id === id)
+  if (!liveMark) return false
+
+  // Synthesize a minimal store entry from the live mark
+  const synth = {
+    id: liveMark.id,
+    markedText: liveMark.markedText,
+    comment: liveMark.comment,
+    createdAt: liveMark.createdAt,
+    occurrenceIndex: liveMark.occurrenceIndex ?? 0,
+    from: liveMark.from,
+    to: liveMark.to,
+    replies: [],
+    resolved: false,
+  }
+  useCommentStore.setState({
+    pendingComments: [...store.pendingComments, synth],
+  })
+  return true
 }
 
 /**
@@ -530,22 +592,23 @@ export function executeResolveComment(args: {
     return toolError('Comment ID is required', 'INVALID_INPUT')
   }
 
-  // Update the persisted thread (set resolved:true) before removing the mark.
+  // Ensure the comment is in the store (synthesizes from live mark if needed).
   const store = useCommentStore.getState()
-  const existing = store.pendingComments.find((c) => c.id === id)
-  if (!existing) {
+  const found = ensureInStore(id, store, editor)
+  if (!found) {
     return toolError(`Comment with ID "${id}" not found`, 'COMMENT_NOT_FOUND')
   }
 
-  const documentId = store.documentId
+  // Re-read after possible synthesis
+  const currentComments = useCommentStore.getState().pendingComments
+  const updated = currentComments.map((c) =>
+    c.id === id ? { ...c, resolved: true } : c
+  )
+  useCommentStore.setState({ pendingComments: updated })
+
+  const documentId = useCommentStore.getState().documentId
   if (documentId) {
-    const updated = store.pendingComments.map((c) =>
-      c.id === id ? { ...c, resolved: true } : c
-    )
-    store.saveComments(documentId, updated)
-    // Keep the in-memory list in sync so the store reflects the change
-    // immediately (Zustand state is immutable — we reach through to a re-set).
-    useCommentStore.setState({ pendingComments: updated })
+    useCommentStore.getState().saveComments(documentId, updated)
   }
 
   // Remove the editor mark so the highlight disappears.
@@ -574,9 +637,12 @@ export function executeReplyToComment(args: {
     return toolError('Reply text is required', 'INVALID_INPUT')
   }
 
+  const editor = getEditor()
+
+  // Ensure the comment is in the store (synthesizes from live mark if needed).
   const store = useCommentStore.getState()
-  const existing = store.pendingComments.find((c) => c.id === id)
-  if (!existing) {
+  const found = ensureInStore(id, store, editor)
+  if (!found) {
     return toolError(`Comment with ID "${id}" not found`, 'COMMENT_NOT_FOUND')
   }
 
@@ -587,15 +653,17 @@ export function executeReplyToComment(args: {
     createdAt: Date.now(),
   }
 
-  const documentId = store.documentId
-  const updated = store.pendingComments.map((c) =>
+  // Re-read after possible synthesis
+  const currentComments = useCommentStore.getState().pendingComments
+  const updated = currentComments.map((c) =>
     c.id === id ? { ...c, replies: [...(c.replies ?? []), reply] } : c
   )
 
   useCommentStore.setState({ pendingComments: updated })
 
+  const documentId = useCommentStore.getState().documentId
   if (documentId) {
-    store.saveComments(documentId, updated)
+    useCommentStore.getState().saveComments(documentId, updated)
   }
 
   return toolSuccess({ replyId: reply.id })

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -17,7 +17,8 @@ import {
   executeGetOutline,
   executeListComments,
   executeAddComment,
-  executeResolveComment
+  executeResolveComment,
+  executeReplyToComment
 } from './executors/document'
 
 // Editor executors
@@ -114,6 +115,8 @@ export async function executeTool(
         return executeAddComment(validatedArgs)
       case 'resolve_comment':
         return executeResolveComment(validatedArgs)
+      case 'reply_to_comment':
+        return executeReplyToComment(validatedArgs)
 
       // Editor tools
       case 'edit':

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from './lib/sentry'
 import { dumpPipelineLog, clearPipelineLog } from './lib/aiPipelineLog'
 import { executeTool } from './lib/tools'
 import { useAnnotationStore } from './extensions/ai-annotations'
+import { useCommentStore } from './extensions/comments/store'
 import { useTabStore } from './stores/tabStore'
 import { useChatStore } from './stores/chatStore'
 import type { ChatMessage } from './types'
@@ -40,6 +41,9 @@ import './index.css'
   isAnnotationMappingPaused: () => useAnnotationStore.getState().isLoadingDocument,
   getActiveTabId: () => useTabStore.getState().activeTabId,
   loadAnnotationsFromDB,
+  // Comment store access for e2e verification of threading (#699).
+  getCommentStore: () => useCommentStore.getState().pendingComments,
+  getCommentDocId: () => useCommentStore.getState().documentId,
 }
 // Test seam — INTENTIONALLY always-on, same tier as __prose_tools/__prose_debug.
 // Lets Playwright drive the chat surface with zero LLM: seed a conversation and

--- a/src/shared/tools/schemas/document.ts
+++ b/src/shared/tools/schemas/document.ts
@@ -157,17 +157,37 @@ export const addCommentConfig: ToolConfig<typeof addCommentSchema> = {
 // ============================================================================
 
 export const resolveCommentSchema = z.object({
-  id: z.string().describe('ID of the comment to resolve (remove). Get IDs from list_comments.')
+  id: z.string().describe('ID of the comment to resolve. Get IDs from list_comments. Resolved threads persist as collapsed history rather than being deleted.')
 })
 
 export const resolveCommentConfig: ToolConfig<typeof resolveCommentSchema> = {
   name: 'resolve_comment',
   description:
-    'Resolve (remove) a comment by its ID. Use list_comments to see all comment IDs.',
+    'Resolve a comment by its ID. Sets resolved:true on the thread — the thread persists as collapsed history rather than being deleted. Use list_comments to see all comment IDs.',
   schema: resolveCommentSchema,
   category: 'document',
-  // Sibling of add_comment — removing a comment is also a mutation, so it
+  // Sibling of add_comment — resolving a comment is also a mutation, so it
   // belongs in Editor Mode and up. list_comments stays read-only.
+  requiresMode: 'editor',
+  dangerous: false
+}
+
+// ============================================================================
+// reply_to_comment
+// ============================================================================
+
+export const replyToCommentSchema = z.object({
+  id: z.string().describe('ID of the comment thread to reply to. Get IDs from list_comments.'),
+  text: z.string().describe('The reply text to add to the thread.')
+})
+
+export const replyToCommentConfig: ToolConfig<typeof replyToCommentSchema> = {
+  name: 'reply_to_comment',
+  description:
+    'Add an AI reply to an existing comment thread. Use list_comments to get comment IDs. The reply appears in the thread view. After replying, call resolve_comment if the comment is fully addressed.',
+  schema: replyToCommentSchema,
+  category: 'document',
+  // Posting a reply is a mutation; requires Editor Mode or above.
   requiresMode: 'editor',
   dangerous: false
 }
@@ -184,5 +204,6 @@ export const documentTools = [
   getOutlineConfig,
   listCommentsConfig,
   addCommentConfig,
-  resolveCommentConfig
+  resolveCommentConfig,
+  replyToCommentConfig
 ] as const


### PR DESCRIPTION
## Summary

Implements comment threading (#699) end-to-end and folds in the block-boundary `restoreComments` fix (#665).

**Data model**
- `CommentData` gains `replies: CommentReply[]` and `resolved: boolean`
- Resolved threads persist in the IndexedDB `comments` store (`resolved:true`) — the editor mark is removed but the thread remains as collapsed history
- No `DB_VERSION` bump: richer values on the existing v8 `comments` store

**New tool: `reply_to_comment`** (Editor-mode gated)
- Appends an AI reply (`author: 'ai'`) to a comment thread
- Picked up automatically via the `documentTools` spread in `registry.ts`; NOT added to `mcpToolNames`

**`resolve_comment` update**
- Now sets `resolved:true` + removes the editor mark (instead of only unsetting the mark)
- Thread persists as history (collapsed) instead of being deleted

**Process flow change**
- Host-side auto-delete in `processComment` / `processComments` removed
- Updated prompt instructs the AI to use `list_comments` → `reply_to_comment` / `suggest_edit` → `resolve_comment` as a real collaborator

**`CommentPopover` thread view**
- Reply list (user + AI, with Bot/User icon), reply input (Enter to send), Resolve button (removes mark, keeps history), CSS in `index.css`

**`restoreComments` fix (#665)**
- `markedText` is stored via `textBetween(from, to, ' ')` (space block-separator) but restoration searched `doc.textContent` (no separators) — cross-block selections never matched
- Fix: normalise both `markedText` and `doc.textContent` (strip spaces) before searching; new `mapNormOffsetToChar()` maps the normalised offset back to the real char offset in the text node
- Resolved comments skip restoration (mark is intentionally absent)

**Activity panel**
- `AIEditsHistoryPanel` now renders a unified feed of AI edit annotations + comment thread activity (newest-first, grouped by day)
- Comment rows show thread/resolved badge, up to 3 reply chips (Bot/User icon), and a remove button
- Single filter toggle in `ChatPanel` covers both superseded edits and resolved threads
- Activity badge includes comment reply count

**E2E: `electron.comment-threading.spec.ts`** (4 tests, isolated profile, no LLM)
- `reply_to_comment` appends AI reply to persisted thread
- `resolve_comment` sets `resolved:true` without deleting the store record
- `list_comments` returns replies + resolved state
- Resolved threads are not re-marked on `restoreComments`

## Test plan

- [x] Build passes (`npm run build`)
- [x] TypeScript: no new type errors (`tsc --noEmit --skipLibCheck`)
- [x] E2E spec written at `e2e/electron.comment-threading.spec.ts`
- [ ] CI E2E pass
- [ ] Manual QA: open a comment popover → add a reply → Resolve → reopen file → confirm no mark

Closes #699
Closes #665