### PR TITLE
feat(files): explorer interactivity — New Folder, folder rename, greyed filetypes, dotfile toggle

### DIFF
--- a/e2e/electron.explorer-interactivity.spec.ts
+++ b/e2e/electron.explorer-interactivity.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Explorer interactivity (#703) — Playwright regressions for:
+ *
+ * - New Folder: context menu item appears in empty-space and folder-row menus;
+ *   dialog creates the directory and it appears in the tree.
+ * - Folder rename: right-click → Rename on a folder triggers inline rename;
+ *   committing renames the directory on disk.
+ * - Non-markdown files: always visible in the file list, greyed (not openable).
+ * - Dotfile toggle: ⌘⇧. shows/hides dotfiles while the explorer is focused.
+ *
+ * All tests run in an isolated PROSE_USER_DATA_DIR profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  ensureFileListOpen,
+  selectors,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaFilesDir: string
+let subfolderPath: string
+
+test.beforeAll(async () => {
+  test.setTimeout(90_000)
+
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-703-profile-'))
+  qaFilesDir = mkdtempSync(join(tmpdir(), 'prose-qa-703-files-'))
+  subfolderPath = join(qaFilesDir, 'my-subfolder')
+  mkdirSync(subfolderPath, { recursive: true })
+
+  // A markdown file and a non-markdown file in the root
+  writeFileSync(join(qaFilesDir, 'notes.md'), '# Notes\n')
+  writeFileSync(join(qaFilesDir, 'image.png'), 'fake png data')
+  // A dotfile
+  writeFileSync(join(qaFilesDir, '.hidden-config'), 'dotfile content')
+
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        defaultSaveDirectory: qaFilesDir,
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+  await ensureFileListOpen(page)
+
+  // Switch to the folder view
+  const filesBtn = page.locator(selectors.filesButton)
+  if (await filesBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await filesBtn.click()
+  }
+  // Wait for the markdown file to appear
+  await page.locator(selectors.fileListPanel).getByText('notes').waitFor({ state: 'visible', timeout: 10_000 })
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaFilesDir, { recursive: true, force: true })
+})
+
+test.describe('Electron — explorer interactivity (#703)', () => {
+
+  // ---------------------------------------------------------------------------
+  // Non-markdown files: always visible but greyed
+  // ---------------------------------------------------------------------------
+  test('non-markdown files (e.g. .png) are visible in the file list', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+    // image.png should appear in the list
+    await expect(panel.getByText('image.png')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('non-markdown files are greyed (have muted styling, not full-opacity)', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+    // The button for image.png should have the non-markdown cursor-default class
+    const btn = panel.locator('button[title]').filter({ hasText: 'image.png' })
+    await expect(btn).toBeVisible({ timeout: 5_000 })
+    const cls = await btn.getAttribute('class') ?? ''
+    // Should have cursor-default (applied to non-markdown items)
+    expect(cls).toContain('cursor-default')
+  })
+
+  // ---------------------------------------------------------------------------
+  // New Folder via empty-space context menu
+  // ---------------------------------------------------------------------------
+  test('New Folder via empty-space context menu creates the directory', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+    const folderName = 'qa-new-folder-703'
+
+    // Right-click in an empty area of the panel
+    await panel.locator('div.p-2.min-h-full').click({ button: 'right', position: { x: 10, y: 10 } })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
+
+    // Click "New Folder"
+    const newFolderItem = page.getByRole('menuitem', { name: 'New Folder' })
+    await newFolderItem.waitFor({ state: 'visible', timeout: 3_000 })
+    await newFolderItem.click()
+
+    // Dialog should appear
+    const dialog = page.locator('[role="dialog"]')
+    await dialog.waitFor({ state: 'visible', timeout: 5_000 })
+
+    // Type folder name
+    await page.locator('#new-folder-name').fill(folderName)
+    await page.keyboard.press('Enter')
+
+    // Dialog should close
+    await dialog.waitFor({ state: 'detached', timeout: 5_000 })
+
+    // Wait for the folder to appear in the tree
+    await panel.getByText(folderName).waitFor({ state: 'visible', timeout: 8_000 })
+
+    // Confirm it was created on disk
+    expect(existsSync(join(qaFilesDir, folderName))).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // New Folder via folder-row context menu
+  // ---------------------------------------------------------------------------
+  test('New Folder via folder right-click context menu creates subfolder', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+    const subFolderName = 'qa-child-folder-703'
+
+    // Right-click on my-subfolder
+    await panel.getByText('my-subfolder').click({ button: 'right' })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
+
+    const newFolderItem = page.getByRole('menuitem', { name: 'New Folder' })
+    await newFolderItem.waitFor({ state: 'visible', timeout: 3_000 })
+    await newFolderItem.click()
+
+    const dialog = page.locator('[role="dialog"]')
+    await dialog.waitFor({ state: 'visible', timeout: 5_000 })
+    await page.locator('#new-folder-name').fill(subFolderName)
+    await page.keyboard.press('Enter')
+    await dialog.waitFor({ state: 'detached', timeout: 5_000 })
+
+    // Confirm on disk
+    expect(existsSync(join(subfolderPath, subFolderName))).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Folder rename via context menu
+  // ---------------------------------------------------------------------------
+  test('folder right-click → Rename triggers inline rename', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+    const originalName = 'my-subfolder'
+    const newName = 'renamed-subfolder'
+
+    // Right-click the folder
+    await panel.getByText(originalName).click({ button: 'right' })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
+
+    const renameItem = page.getByRole('menuitem', { name: 'Rename' })
+    await renameItem.waitFor({ state: 'visible', timeout: 3_000 })
+    await renameItem.click()
+
+    // Inline rename input should appear — the button text becomes an input
+    await page.waitForTimeout(200) // allow rename activation delay (rAF + 50ms)
+
+    // Clear and type new name
+    await page.keyboard.press('Control+a')
+    await page.keyboard.type(newName)
+    await page.keyboard.press('Enter')
+
+    // Wait for the tree to refresh
+    await panel.getByText(newName).waitFor({ state: 'visible', timeout: 8_000 })
+
+    // Confirm on disk
+    expect(existsSync(join(qaFilesDir, newName))).toBe(true)
+    expect(existsSync(join(qaFilesDir, originalName))).toBe(false)
+
+    // Restore for test isolation (rename back)
+    await panel.getByText(newName).click({ button: 'right' })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 3_000 })
+    const reRename = page.getByRole('menuitem', { name: 'Rename' })
+    if (await reRename.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await reRename.click()
+      await page.waitForTimeout(200)
+      await page.keyboard.press('Control+a')
+      await page.keyboard.type(originalName)
+      await page.keyboard.press('Enter')
+      await panel.getByText(originalName).waitFor({ state: 'visible', timeout: 5_000 })
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Dotfile toggle: ⌘⇧. shows dotfiles when explorer is focused
+  // ---------------------------------------------------------------------------
+  test('⌘⇧. dotfile toggle shows and hides dotfiles', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Dotfile should NOT be visible by default
+    const hidden = panel.getByText('.hidden-config')
+    await expect(hidden).not.toBeVisible({ timeout: 2_000 }).catch(() => {
+      // If it is visible this test still passes below (we check the toggle)
+    })
+
+    // Focus the panel and press Cmd+Shift+.
+    await panel.click()
+    await page.keyboard.press('Meta+Shift+.')
+    await page.waitForTimeout(300)
+
+    // Dotfile should now be visible
+    await expect(panel.getByText('.hidden-config')).toBeVisible({ timeout: 5_000 })
+
+    // Press again to hide
+    await page.keyboard.press('Meta+Shift+.')
+    await page.waitForTimeout(300)
+    await expect(panel.getByText('.hidden-config')).not.toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/e2e/electron.explorer-interactivity.spec.ts
+++ b/e2e/electron.explorer-interactivity.spec.ts
@@ -175,44 +175,48 @@ test.describe('Electron — explorer interactivity (#703)', () => {
     const originalName = 'my-subfolder'
     const newName = 'renamed-subfolder'
 
-    // Right-click the folder
-    await panel.getByText(originalName).click({ button: 'right' })
+    // Right-click the folder button (use button[title] to target the exact row,
+    // not just the text span, so the ContextMenuTrigger gets the event).
+    const folderBtn = panel.locator('button[title]', { hasText: /^my-subfolder$/ })
+    await folderBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    await folderBtn.click({ button: 'right' })
     await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
 
     const renameItem = page.getByRole('menuitem', { name: 'Rename' })
     await renameItem.waitFor({ state: 'visible', timeout: 3_000 })
     await renameItem.click()
 
-    // Inline rename input should appear — the button text becomes an input
-    await page.waitForTimeout(300) // allow rename activation delay (rAF + 50ms + context-menu close)
-
-    // Select all text in the rename input and replace with the new name.
-    // Use the focused input directly via fill() to avoid OS-specific select-all
-    // keyboard shortcut differences (Cmd+A vs Ctrl+A on macOS vs Linux).
+    // The Radix context-menu close animation runs first, THEN React re-renders
+    // the FileTreeItem with isRenaming=true, and THEN the rAF+50ms timer inside
+    // the effect fires to focus the input. On CI/headless this chain can take
+    // longer than locally — wait up to 8s for the input to become visible.
     const renameInput = page.locator(`[data-testid="file-list-panel"] input`)
-    await renameInput.waitFor({ state: 'visible', timeout: 3_000 })
+    await renameInput.waitFor({ state: 'visible', timeout: 8_000 })
+
+    // Use fill() to replace the value atomically — avoids OS-specific select-all
+    // keyboard shortcut differences (Cmd+A vs Ctrl+A on macOS vs Linux CI).
     await renameInput.fill(newName)
     await page.keyboard.press('Enter')
 
     // Wait for the tree to refresh
-    await panel.getByText(newName).waitFor({ state: 'visible', timeout: 8_000 })
+    await panel.locator('button[title]', { hasText: /^renamed-subfolder$/ }).waitFor({ state: 'visible', timeout: 8_000 })
 
     // Confirm on disk
     expect(existsSync(join(qaFilesDir, newName))).toBe(true)
     expect(existsSync(join(qaFilesDir, originalName))).toBe(false)
 
     // Restore for test isolation (rename back)
-    await panel.getByText(newName).click({ button: 'right' })
+    const renamedBtn = panel.locator('button[title]', { hasText: /^renamed-subfolder$/ })
+    await renamedBtn.click({ button: 'right' })
     await page.waitForSelector(selectors.contextMenu, { timeout: 3_000 })
     const reRename = page.getByRole('menuitem', { name: 'Rename' })
     if (await reRename.isVisible({ timeout: 1_000 }).catch(() => false)) {
       await reRename.click()
-      await page.waitForTimeout(300)
       const reInput = page.locator(`[data-testid="file-list-panel"] input`)
-      await reInput.waitFor({ state: 'visible', timeout: 3_000 })
+      await reInput.waitFor({ state: 'visible', timeout: 8_000 })
       await reInput.fill(originalName)
       await page.keyboard.press('Enter')
-      await panel.getByText(originalName).waitFor({ state: 'visible', timeout: 5_000 })
+      await panel.locator('button[title]', { hasText: /^my-subfolder$/ }).waitFor({ state: 'visible', timeout: 5_000 })
     }
   })
 

--- a/e2e/electron.explorer-interactivity.spec.ts
+++ b/e2e/electron.explorer-interactivity.spec.ts
@@ -184,11 +184,14 @@ test.describe('Electron — explorer interactivity (#703)', () => {
     await renameItem.click()
 
     // Inline rename input should appear — the button text becomes an input
-    await page.waitForTimeout(200) // allow rename activation delay (rAF + 50ms)
+    await page.waitForTimeout(300) // allow rename activation delay (rAF + 50ms + context-menu close)
 
-    // Clear and type new name
-    await page.keyboard.press('Control+a')
-    await page.keyboard.type(newName)
+    // Select all text in the rename input and replace with the new name.
+    // Use the focused input directly via fill() to avoid OS-specific select-all
+    // keyboard shortcut differences (Cmd+A vs Ctrl+A on macOS vs Linux).
+    const renameInput = page.locator(`[data-testid="file-list-panel"] input`)
+    await renameInput.waitFor({ state: 'visible', timeout: 3_000 })
+    await renameInput.fill(newName)
     await page.keyboard.press('Enter')
 
     // Wait for the tree to refresh
@@ -204,9 +207,10 @@ test.describe('Electron — explorer interactivity (#703)', () => {
     const reRename = page.getByRole('menuitem', { name: 'Rename' })
     if (await reRename.isVisible({ timeout: 1_000 }).catch(() => false)) {
       await reRename.click()
-      await page.waitForTimeout(200)
-      await page.keyboard.press('Control+a')
-      await page.keyboard.type(originalName)
+      await page.waitForTimeout(300)
+      const reInput = page.locator(`[data-testid="file-list-panel"] input`)
+      await reInput.waitFor({ state: 'visible', timeout: 3_000 })
+      await reInput.fill(originalName)
       await page.keyboard.press('Enter')
       await panel.getByText(originalName).waitFor({ state: 'visible', timeout: 5_000 })
     }

--- a/e2e/electron.file-explorer-qa.spec.ts
+++ b/e2e/electron.file-explorer-qa.spec.ts
@@ -230,8 +230,10 @@ test.describe('Electron — file explorer QA (#723)', () => {
 
     // The file list sorts by localeCompare, so the visible order is:
     // alpha(0), beta(1), delta(2), epsilon(3), eta(4), gamma(5), iota(6), kappa(7), theta(8), zeta(9)
-    // Shift+click eta — should select the contiguous run alpha..eta (5 files)
-    await panel.getByText('eta').click({ modifiers: ['Shift'] })
+    // Shift+click eta — should select the contiguous run alpha..eta (5 files).
+    // Use an exact-name locator: 'eta' is a substring of beta/theta/zeta so
+    // getByText without anchoring would match 4 elements and throw in strict mode.
+    await panel.locator('button[title]', { hasText: /^eta$/ }).click({ modifiers: ['Shift'] })
     await page.waitForTimeout(100)
 
     const selected = await getSelectedPaths(page)

--- a/e2e/electron.file-explorer-qa.spec.ts
+++ b/e2e/electron.file-explorer-qa.spec.ts
@@ -228,19 +228,22 @@ test.describe('Electron — file explorer QA (#723)', () => {
     await panel.getByText('alpha').click()
     await page.waitForTimeout(100)
 
-    // Shift+click delta — should select alpha through delta
-    await panel.getByText('delta').click({ modifiers: ['Shift'] })
+    // The file list sorts by localeCompare, so the visible order is:
+    // alpha(0), beta(1), delta(2), epsilon(3), eta(4), gamma(5), iota(6), kappa(7), theta(8), zeta(9)
+    // Shift+click eta — should select the contiguous run alpha..eta (5 files)
+    await panel.getByText('eta').click({ modifiers: ['Shift'] })
     await page.waitForTimeout(100)
 
     const selected = await getSelectedPaths(page)
     const baseNames = selected.map((p) => p.split('/').pop() ?? '')
-    // alpha, beta, gamma, delta should all be selected
+    // All files alphabetically between alpha and eta should be selected
     expect(baseNames).toContain('alpha.md')
     expect(baseNames).toContain('beta.md')
-    expect(baseNames).toContain('gamma.md')
     expect(baseNames).toContain('delta.md')
-    // And selection should be at least 4
-    expect(selected.length).toBeGreaterThanOrEqual(4)
+    expect(baseNames).toContain('epsilon.md')
+    expect(baseNames).toContain('eta.md')
+    // And selection should be at least 5
+    expect(selected.length).toBeGreaterThanOrEqual(5)
   })
 
   test('Bug 2: plain click clears multi-select and selects single file', async () => {

--- a/e2e/electron.file-explorer-qa.spec.ts
+++ b/e2e/electron.file-explorer-qa.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * File Explorer QA (#723) — regression coverage for three concrete bugs:
+ *
+ * 1. Rename → Enter scrolls the file explorer to the top.
+ *    The rename-activation effect was calling scrollTo(0, 0) on the Radix
+ *    scroll viewport to undo scroll drift from select(), but that wiped the
+ *    user's scroll position. Fix: save/restore scrollTop around the select().
+ *
+ * 2. No multi-select (Shift+Click, Cmd/Ctrl+Click, Cmd+A).
+ *    Add range-select and toggle-select with Cmd+A select-all.
+ *
+ * 3. After file delete, focus does not return to the explorer.
+ *    handleConfirmDelete now calls containerRef.current?.focus() after the
+ *    file is trashed.
+ *
+ * All tests run in an isolated PROSE_USER_DATA_DIR profile with a fixture
+ * directory of markdown files so the file explorer is populated.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  ensureFileListOpen,
+  selectors,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaFilesDir: string
+
+const FILE_NAMES = [
+  'alpha.md',
+  'beta.md',
+  'gamma.md',
+  'delta.md',
+  'epsilon.md',
+  'zeta.md',
+  'eta.md',
+  'theta.md',
+  'iota.md',
+  'kappa.md',
+]
+
+test.beforeAll(async () => {
+  test.setTimeout(90_000)
+
+  // Isolated profile + populated fixture directory
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-723-profile-'))
+  qaFilesDir = mkdtempSync(join(tmpdir(), 'prose-qa-723-files-'))
+  mkdirSync(qaFilesDir, { recursive: true })
+  for (const name of FILE_NAMES) {
+    writeFileSync(join(qaFilesDir, name), `# ${name.replace('.md', '')}\n\nContent.\n`)
+  }
+
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        defaultSaveDirectory: qaFilesDir,
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+  await ensureFileListOpen(page)
+
+  // Switch to the folder view showing our fixture files
+  const filesBtn = page.locator(selectors.filesButton)
+  if (await filesBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await filesBtn.click()
+  }
+  // Wait for at least one file to appear
+  const panel = page.locator(selectors.fileListPanel)
+  await panel.getByText('alpha').waitFor({ state: 'visible', timeout: 10_000 })
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaFilesDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Helper: get the scroll viewport's current scrollTop inside the panel.
+// ---------------------------------------------------------------------------
+async function getPanelScrollTop(testPage: Page): Promise<number> {
+  return testPage.evaluate(() => {
+    const panel = document.querySelector('[data-testid="file-list-panel"]')
+    const viewport = panel?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null
+    return viewport?.scrollTop ?? 0
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Helper: get all paths currently in selectedPaths store.
+// ---------------------------------------------------------------------------
+async function getSelectedPaths(testPage: Page): Promise<string[]> {
+  return testPage.evaluate(() => {
+    // Access the Zustand store directly via the module registry isn't practical
+    // from a CDP context; instead read the visual state — items with
+    // bg-accent class that are not the "hover" state are selected.
+    const panel = document.querySelector('[data-testid="file-list-panel"]')
+    if (!panel) return []
+    const selected: string[] = []
+    const buttons = panel.querySelectorAll('button[title]')
+    for (const btn of buttons) {
+      if (btn.classList.contains('bg-accent')) {
+        const titleAttr = btn.getAttribute('title')
+        if (titleAttr) selected.push(titleAttr)
+      }
+    }
+    return selected
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: Rename → Enter must not scroll the file list to the top
+// ---------------------------------------------------------------------------
+test.describe('Electron — file explorer QA (#723)', () => {
+  test('Bug 1: rename via Enter preserves scroll position', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Scroll to the bottom of the file list so scroll position is non-zero
+    await page.evaluate(() => {
+      const fp = document.querySelector('[data-testid="file-list-panel"]')
+      const viewport = fp?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null
+      if (viewport) viewport.scrollTop = 1000
+    })
+
+    // Give scroll event a frame to settle
+    await page.waitForTimeout(100)
+
+    const scrollBefore = await getPanelScrollTop(page)
+    // Should be > 0 if the list is actually scrollable; if not, the test is
+    // still valid — we just confirm no unexpected reset occurs.
+
+    // Right-click a file near the bottom of our fixture list to open context menu
+    await panel.getByText('kappa').click({ button: 'right' })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
+
+    // Click Rename
+    const renameItem = page.getByRole('menuitem', { name: 'Rename' })
+    await renameItem.waitFor({ state: 'visible', timeout: 3_000 })
+    await renameItem.click()
+
+    // Give the rename input time to focus (there's a 50ms rAF + setTimeout delay)
+    await page.waitForTimeout(200)
+
+    // Verify scroll was not reset to 0 by the rename-activation effect
+    const scrollDuringRename = await getPanelScrollTop(page)
+    expect(scrollDuringRename).toBeGreaterThanOrEqual(scrollBefore - 10)
+
+    // Commit the rename with Enter (using the same name so no actual rename occurs)
+    await page.keyboard.press('Escape')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Bug 2: Multi-select — Cmd+Click, Shift+Click, Cmd+A
+  // ---------------------------------------------------------------------------
+  test('Bug 2: Cmd+click toggles files into multi-select', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Single-click alpha to establish anchor
+    await panel.getByText('alpha').click()
+    await page.waitForTimeout(100)
+
+    // Cmd+click beta — should add it to selection
+    await panel.getByText('beta').click({ modifiers: ['Meta'] })
+    await page.waitForTimeout(100)
+
+    // Cmd+click gamma
+    await panel.getByText('gamma').click({ modifiers: ['Meta'] })
+    await page.waitForTimeout(100)
+
+    const selected = await getSelectedPaths(page)
+    // At least alpha, beta, gamma should be selected
+    const baseNames = selected.map((p) => p.split('/').pop() ?? '')
+    expect(baseNames).toContain('alpha.md')
+    expect(baseNames).toContain('beta.md')
+    expect(baseNames).toContain('gamma.md')
+  })
+
+  test('Bug 2: Cmd+A selects all visible files', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Focus the panel
+    await panel.click()
+
+    // Ensure multi-select is cleared first via single click
+    await panel.getByText('alpha').click()
+    await page.waitForTimeout(100)
+
+    // Press Cmd+A
+    await page.keyboard.press('Meta+a')
+    await page.waitForTimeout(100)
+
+    const selected = await getSelectedPaths(page)
+    // All fixture .md files should be selected
+    expect(selected.length).toBeGreaterThanOrEqual(FILE_NAMES.length)
+  })
+
+  test('Bug 2: Shift+click range-selects from anchor to target', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Click alpha (anchor)
+    await panel.getByText('alpha').click()
+    await page.waitForTimeout(100)
+
+    // Shift+click delta — should select alpha through delta
+    await panel.getByText('delta').click({ modifiers: ['Shift'] })
+    await page.waitForTimeout(100)
+
+    const selected = await getSelectedPaths(page)
+    const baseNames = selected.map((p) => p.split('/').pop() ?? '')
+    // alpha, beta, gamma, delta should all be selected
+    expect(baseNames).toContain('alpha.md')
+    expect(baseNames).toContain('beta.md')
+    expect(baseNames).toContain('gamma.md')
+    expect(baseNames).toContain('delta.md')
+    // And selection should be at least 4
+    expect(selected.length).toBeGreaterThanOrEqual(4)
+  })
+
+  test('Bug 2: plain click clears multi-select and selects single file', async () => {
+    const panel = page.locator(selectors.fileListPanel)
+
+    // Start with Cmd+A to get multi-select
+    await panel.click()
+    await panel.getByText('alpha').click()
+    await page.keyboard.press('Meta+a')
+    await page.waitForTimeout(100)
+
+    const allSelected = await getSelectedPaths(page)
+    expect(allSelected.length).toBeGreaterThan(1)
+
+    // Plain click on beta
+    await panel.getByText('beta').click()
+    await page.waitForTimeout(100)
+
+    const afterClick = await getSelectedPaths(page)
+    // Only beta (or nothing extra) should be selected
+    expect(afterClick.length).toBeLessThanOrEqual(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Bug 3: Focus returns to explorer after delete
+  // ---------------------------------------------------------------------------
+  test('Bug 3: focus returns to file explorer panel after file deletion', async () => {
+    // Create a temp file in our fixture dir so we can safely delete it
+    const tempName = 'to-be-deleted.md'
+    writeFileSync(join(qaFilesDir, tempName), '# Temp\n')
+
+    // Wait for the file watcher to pick up the new file
+    const panel = page.locator(selectors.fileListPanel)
+    await panel.getByText('to-be-deleted').waitFor({ state: 'visible', timeout: 8_000 })
+
+    // Right-click → Move to Trash
+    await panel.getByText('to-be-deleted').click({ button: 'right' })
+    await page.waitForSelector(selectors.contextMenu, { timeout: 5_000 })
+    const trashItem = page.getByRole('menuitem', { name: 'Move to Trash' })
+    await trashItem.waitFor({ state: 'visible', timeout: 3_000 })
+    await trashItem.click()
+
+    // Confirm the delete dialog
+    const confirmBtn = page.getByRole('button', { name: 'Move to Trash' }).last()
+    await confirmBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    await confirmBtn.click()
+
+    // Wait for dialog to close
+    await page.waitForSelector('[role="dialog"]', { state: 'detached', timeout: 5_000 })
+
+    // After deletion, the explorer panel should be focused (not body/document)
+    const focusedTestId = await page.evaluate(() => {
+      return document.activeElement?.getAttribute('data-testid') ??
+             document.activeElement?.tagName?.toLowerCase() ??
+             'unknown'
+    })
+
+    // The containerRef div has data-testid="file-list-panel" and tabIndex={-1}
+    expect(focusedTestId).toBe('file-list-panel')
+  })
+})

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -490,7 +490,7 @@ export function setupIpcHandlers(): void {
   })
 
   // File: List directory contents (with lazy loading support)
-  ipcMain.handle('file:listDirectory', async (_event, dirPath: string, maxDepth: number = 1) => {
+  ipcMain.handle('file:listDirectory', async (_event, dirPath: string, maxDepth: number = 1, showDotfiles: boolean = false) => {
     interface FileItem {
       name: string
       path: string
@@ -498,7 +498,11 @@ export function setupIpcHandlers(): void {
       modifiedAt: string
       children?: FileItem[]
       hasChildren?: boolean // For lazy loading - indicates folder has content without loading it
+      isNonMarkdown?: boolean // Non-editable file, shown greyed in the explorer
+      isDotfile?: boolean    // Dot-prefixed entry (shown when showDotfiles is true)
     }
+
+    const MARKDOWN_EXTS = new Set(['.md', '.markdown', '.txt'])
 
     async function listDir(dir: string, depth: number = 0): Promise<FileItem[]> {
       try {
@@ -506,8 +510,10 @@ export function setupIpcHandlers(): void {
         const items: FileItem[] = []
 
         for (const entry of entries) {
-          // Skip hidden files
-          if (entry.name.startsWith('.')) continue
+          const isDotfile = entry.name.startsWith('.')
+
+          // Skip dotfiles unless the toggle is on
+          if (isDotfile && !showDotfiles) continue
 
           const fullPath = join(dir, entry.name)
           let stats
@@ -528,17 +534,18 @@ export function setupIpcHandlers(): void {
                 isDirectory: true,
                 modifiedAt: stats.mtime.toISOString(),
                 children,
-                hasChildren: children.length > 0
+                hasChildren: children.length > 0,
+                ...(isDotfile ? { isDotfile: true } : {})
               })
             } else {
               // Beyond depth limit - just check if folder has any relevant content
               let hasChildren = false
               try {
                 const subEntries = await readdir(fullPath, { withFileTypes: true })
-                hasChildren = subEntries.some(e =>
-                  !e.name.startsWith('.') &&
-                  (e.isDirectory() || e.name.endsWith('.md') || e.name.endsWith('.markdown') || e.name.endsWith('.txt'))
-                )
+                hasChildren = subEntries.some(e => {
+                  if (e.name.startsWith('.') && !showDotfiles) return false
+                  return e.isDirectory() || e.name.endsWith('.md') || e.name.endsWith('.markdown') || e.name.endsWith('.txt')
+                })
               } catch {
                 // Can't read folder, assume no children
               }
@@ -547,15 +554,21 @@ export function setupIpcHandlers(): void {
                 path: fullPath,
                 isDirectory: true,
                 modifiedAt: stats.mtime.toISOString(),
-                hasChildren
+                hasChildren,
+                ...(isDotfile ? { isDotfile: true } : {})
               })
             }
-          } else if (entry.name.endsWith('.md') || entry.name.endsWith('.markdown') || entry.name.endsWith('.txt')) {
+          } else {
+            const dotIdx = entry.name.lastIndexOf('.')
+            const ext = dotIdx > 0 ? entry.name.slice(dotIdx) : ''
+            const isMarkdown = MARKDOWN_EXTS.has(ext)
             items.push({
               name: entry.name,
               path: fullPath,
               isDirectory: false,
-              modifiedAt: stats.mtime.toISOString()
+              modifiedAt: stats.mtime.toISOString(),
+              ...(!isMarkdown ? { isNonMarkdown: true } : {}),
+              ...(isDotfile ? { isDotfile: true } : {})
             })
           }
         }
@@ -573,6 +586,13 @@ export function setupIpcHandlers(): void {
     // Validate and expand path
     const safePath = validatePath(dirPath)
     return listDir(safePath, 0)
+  })
+
+  // File: Create a new directory (MAS-sandbox-safe via the user-granted parent)
+  ipcMain.handle('file:createDirectory', async (_event, dirPath: string) => {
+    const safePath = validatePath(dirPath)
+    await mkdir(safePath, { recursive: true })
+    return safePath
   })
 
   // Settings: Load from userData/settings.json

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -213,11 +213,12 @@ export interface ElectronAPI {
   deleteFile: (path: string) => Promise<void>
   trashFile: (path: string) => Promise<void>
   duplicateFile: (path: string) => Promise<string>
+  createDirectory: (dirPath: string) => Promise<string>
   // Window operations
   closeWindow: () => Promise<void>
   isFullScreen: () => Promise<boolean>
   exitFullScreen: () => Promise<void>
-  listDirectory: (path: string, maxDepth?: number) => Promise<FileItem[]>
+  listDirectory: (path: string, maxDepth?: number, showDotfiles?: boolean) => Promise<FileItem[]>
   remarkableRegister: (code: string) => Promise<RemarkableRegisterResponse>
   remarkableValidate: (deviceToken: string) => Promise<boolean>
   remarkableSync: (deviceToken: string, syncDirectory: string) => Promise<RemarkableSyncResult>
@@ -401,11 +402,12 @@ const api: ElectronAPI = {
   deleteFile: (path: string) => ipcRenderer.invoke('file:delete', path),
   trashFile: (path: string) => ipcRenderer.invoke('file:trash', path),
   duplicateFile: (path: string) => ipcRenderer.invoke('file:duplicate', path),
+  createDirectory: (dirPath: string) => ipcRenderer.invoke('file:createDirectory', dirPath),
   closeWindow: () => ipcRenderer.invoke('window:close'),
   isFullScreen: () => ipcRenderer.invoke('window:isFullScreen'),
   exitFullScreen: () => ipcRenderer.invoke('window:exitFullScreen'),
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
-  listDirectory: (path: string, maxDepth?: number) => ipcRenderer.invoke('file:listDirectory', path, maxDepth),
+  listDirectory: (path: string, maxDepth?: number, showDotfiles?: boolean) => ipcRenderer.invoke('file:listDirectory', path, maxDepth, showDotfiles),
   remarkableRegister: (code: string) => ipcRenderer.invoke('remarkable:register', code),
   remarkableValidate: (deviceToken: string) => ipcRenderer.invoke('remarkable:validate', deviceToken),
   remarkableSync: (deviceToken: string, syncDirectory: string) =>

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -185,6 +185,12 @@ export function FileListPanel() {
   const renamingPath = useFileListStore((s) => s.renamingPath)
   const setRenamingPath = useFileListStore((s) => s.setRenamingPath)
 
+  // Multi-select state and actions
+  const selectedPaths = useFileListStore((s) => s.selectedPaths)
+  const toggleSelectFile = useFileListStore((s) => s.toggleSelectFile)
+  const rangeSelectTo = useFileListStore((s) => s.rangeSelectTo)
+  const clearMultiSelect = useFileListStore((s) => s.clearMultiSelect)
+
   // Delete confirmation state
   const [deleteTarget, setDeleteTarget] = useState<{
     path: string
@@ -312,8 +318,11 @@ export function FileListPanel() {
       // Refresh file list
       await loadFiles()
 
-      // Close dialog
+      // Close dialog and return focus to the explorer panel
       setDeleteTarget(null)
+      requestAnimationFrame(() => {
+        containerRef.current?.focus()
+      })
     } catch (error) {
       console.error('Failed to delete file:', error)
       setOperationError('Failed to delete file. Please try again.')
@@ -465,6 +474,24 @@ export function FileListPanel() {
   const handleRenameCancel = useCallback(() => {
     setRenamingPath(null)
   }, [setRenamingPath])
+
+  // Range-select: resolves visible file paths and delegates to the store
+  const handleFileRangeSelect = useCallback((path: string) => {
+    const { files, expandedFolders } = useFileListStore.getState()
+    // Collect visible file paths (not folders) in tree order
+    const collectVisible = (items: typeof files): string[] => {
+      const paths: string[] = []
+      for (const item of items) {
+        if (!item.isDirectory) paths.push(item.path)
+        if (item.isDirectory && expandedFolders.has(item.path) && item.children) {
+          paths.push(...collectVisible(item.children))
+        }
+      }
+      return paths
+    }
+    const visibleFilePaths = collectVisible(files)
+    rangeSelectTo(path, visibleFilePaths)
+  }, [rangeSelectTo])
 
   // Dialog-based rename (for Google Docs view where inline isn't available)
   const handleFileRename = (path: string) => {
@@ -1453,11 +1480,14 @@ export function FileListPanel() {
                       projectPaths={projectPaths}
                       expandedFolders={expandedFolders}
                       selectedPath={selectedPath}
+                      selectedPaths={selectedPaths}
                       loadingFolders={loadingFolders}
                       renamingPath={renamingPath}
                       clipboardPath={clipboardPath}
                       clipboardOperation={clipboardOperation}
                       onFileClick={handleFileClick}
+                      onFileToggleSelect={toggleSelectFile}
+                      onFileRangeSelect={handleFileRangeSelect}
                       onFileDoubleClick={handleFileDoubleClick}
                       onFolderToggle={toggleFolder}
                       onFolderDoubleClick={setRootPath}

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -40,7 +40,7 @@ import {
 } from '../ui/dialog'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronLeft, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug, Boxes, Star, MoreHorizontal } from 'lucide-react'
+import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronLeft, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, FolderPlus, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug, Boxes, Star, MoreHorizontal } from 'lucide-react'
 import { useSettings } from '../../hooks/useSettings'
 import { cn } from '../../lib/utils'
 import { getApi } from '../../lib/browserApi'
@@ -339,6 +339,47 @@ export function FileListPanel() {
     setNewFileDialogOpen(true)
   }
 
+  // New Folder dialog state
+  const [newFolderDialogOpen, setNewFolderDialogOpen] = useState(false)
+  const [newFolderTargetDir, setNewFolderTargetDir] = useState<string | null>(null)
+  const [newFolderName, setNewFolderName] = useState('')
+
+  const handleNewFolderInDir = useCallback((parentDir: string) => {
+    setNewFolderTargetDir(parentDir)
+    setNewFolderName('')
+    setOperationError(null)
+    setNewFolderDialogOpen(true)
+  }, [])
+
+  const handleNewFolder = () => {
+    setNewFolderTargetDir(rootPath)
+    setNewFolderName('')
+    setOperationError(null)
+    setNewFolderDialogOpen(true)
+  }
+
+  const handleCreateNewFolder = async () => {
+    const targetDir = newFolderTargetDir || rootPath
+    if (!targetDir || !newFolderName.trim() || !window.api?.createDirectory) return
+
+    try {
+      const folderPath = `${targetDir}/${newFolderName.trim()}`
+      await window.api.createDirectory(folderPath)
+      await loadFiles()
+      // Expand parent so the new folder is visible
+      useFileListStore.getState().setExpanded(targetDir, true)
+      setNewFolderDialogOpen(false)
+    } catch (error) {
+      console.error('Error creating folder:', error)
+      setOperationError('Failed to create folder. Please try again.')
+    }
+  }
+
+  // Open a non-markdown file externally (Show in Finder / Open with default app)
+  const handleOpenExternally = useCallback((path: string) => {
+    window.api?.showInFolder(path)
+  }, [])
+
   // Add a path to the persisted pointer list (folders → projects/favorites,
   // files → favorites). Idempotent: dedup by path so re-adding is a no-op.
   const addPathAsProject = useCallback((path: string) => {
@@ -417,15 +458,25 @@ export function FileListPanel() {
     setRenamingPath(path)
   }, [selectFile, setRenamingPath])
 
-  // Inline rename complete handler
+  // Inline rename complete handler — works for both files and directories
   const handleRenameComplete = useCallback(async (oldPath: string, newName: string) => {
     setRenamingPath(null)
     if (!newName.trim()) return
 
     try {
       const dir = oldPath.substring(0, oldPath.lastIndexOf('/'))
-      const oldExt = oldPath.match(/\.(md|markdown|txt)$/)?.[0] || '.md'
-      const finalName = newName.endsWith(oldExt) ? newName : `${newName}${oldExt}`
+      const isMarkdownFile = /\.(md|markdown|txt)$/.test(oldPath)
+
+      let finalName: string
+      if (isMarkdownFile) {
+        // File: preserve/append the extension
+        const oldExt = oldPath.match(/\.(md|markdown|txt)$/)?.[0] || '.md'
+        finalName = newName.endsWith(oldExt) ? newName : `${newName}${oldExt}`
+      } else {
+        // Directory (or non-markdown file): use the name as typed
+        finalName = newName.trim()
+      }
+
       const newPath = `${dir}/${finalName}`
 
       // Same name? No-op
@@ -434,40 +485,42 @@ export function FileListPanel() {
       // Check conflict
       const exists = await api.fileExists(newPath)
       if (exists) {
-        console.error(`File "${finalName}" already exists`)
+        console.error(`"${finalName}" already exists`)
         return
       }
 
       await api.renameFile(oldPath, newPath)
 
-      // Tab sync: update tab if file was open
-      const tab = useTabStore.getState().getTabByPath(oldPath)
-      if (tab) {
-        const newTitle = finalName.replace(/\.(md|markdown|txt)$/, '')
-        useTabStore.getState().updateTab(tab.id, { path: newPath, title: newTitle })
-      }
-
-      // If this file is tracked in Google Docs metadata, update its localPath
-      if (googleDocsMetadata && window.api?.googleUpdateSyncMetadataEntry) {
-        const trackedEntry = Object.values(googleDocsMetadata.documents).find(
-          (e) => e.localPath === oldPath
-        )
-        if (trackedEntry) {
+      if (isMarkdownFile) {
+        // Tab sync: update tab if the file was open
+        const tab = useTabStore.getState().getTabByPath(oldPath)
+        if (tab) {
           const newTitle = finalName.replace(/\.(md|markdown|txt)$/, '')
-          await window.api.googleUpdateSyncMetadataEntry({
-            ...trackedEntry,
-            localPath: newPath,
-            title: newTitle
-          })
-          await loadGoogleDocsMetadata()
+          useTabStore.getState().updateTab(tab.id, { path: newPath, title: newTitle })
+        }
+
+        // If tracked in Google Docs metadata, update its localPath
+        if (googleDocsMetadata && window.api?.googleUpdateSyncMetadataEntry) {
+          const trackedEntry = Object.values(googleDocsMetadata.documents).find(
+            (e) => e.localPath === oldPath
+          )
+          if (trackedEntry) {
+            const newTitle = finalName.replace(/\.(md|markdown|txt)$/, '')
+            await window.api.googleUpdateSyncMetadataEntry({
+              ...trackedEntry,
+              localPath: newPath,
+              title: newTitle
+            })
+            await loadGoogleDocsMetadata()
+          }
         }
       }
 
-      // Refresh file list and select the renamed file
+      // Refresh file list and select the renamed entry
       await loadFiles()
       selectFile(newPath)
     } catch (error) {
-      console.error('Error renaming file:', error)
+      console.error('Error renaming:', error)
     }
   }, [api, googleDocsMetadata, loadGoogleDocsMetadata, loadFiles, selectFile, setRenamingPath])
 
@@ -1502,6 +1555,8 @@ export function FileListPanel() {
                       onRenameComplete={handleRenameComplete}
                       onRenameCancel={handleRenameCancel}
                       onNewFile={handleNewFileInDir}
+                      onNewFolder={handleNewFolderInDir}
+                      onFileOpen={handleOpenExternally}
                       onAddProject={addPathAsProject}
                       onAddFavorite={addPathAsFavorite}
                       onRemoveProject={removePathAsProject}
@@ -1516,6 +1571,10 @@ export function FileListPanel() {
                   <FilePlus className="h-4 w-4 mr-2" />
                   New File
                   <ContextMenuShortcut>⌘N</ContextMenuShortcut>
+                </ContextMenuItem>
+                <ContextMenuItem onClick={handleNewFolder}>
+                  <FolderPlus className="h-4 w-4 mr-2" />
+                  New Folder
                 </ContextMenuItem>
                 <ContextMenuItem onClick={() => pasteFile()} disabled={!clipboardPath}>
                   <ClipboardPaste className="h-4 w-4 mr-2" />
@@ -1716,6 +1775,53 @@ export function FileListPanel() {
               Cancel
             </Button>
             <Button onClick={handleCreateNewFile} disabled={!newFileName.trim()}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* New Folder Dialog */}
+      <Dialog open={newFolderDialogOpen} onOpenChange={(open) => {
+        if (!open) {
+          setNewFolderDialogOpen(false)
+          setOperationError(null)
+        }
+      }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Folder</DialogTitle>
+            <DialogDescription>
+              Enter a name for the new folder.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="new-folder-name">Folder name</Label>
+              <Input
+                id="new-folder-name"
+                value={newFolderName}
+                onChange={(e) => {
+                  setNewFolderName(e.target.value)
+                  setOperationError(null)
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleCreateNewFolder()
+                  }
+                }}
+                autoFocus
+              />
+              {operationError && (
+                <p className="text-sm text-destructive">{operationError}</p>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setNewFolderDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreateNewFolder} disabled={!newFolderName.trim()}>
               Create
             </Button>
           </DialogFooter>

--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -21,11 +21,17 @@ interface FileTreeProps {
   projectPaths?: ReadonlySet<string>
   expandedFolders: Set<string>
   selectedPath: string | null
+  /** All currently selected paths for multi-select. */
+  selectedPaths?: ReadonlySet<string>
   loadingFolders?: Set<string>
   renamingPath?: string | null
   clipboardPath?: string | null
   clipboardOperation?: 'copy' | 'cut' | null
   onFileClick: (path: string) => void
+  /** Cmd/Ctrl+click: toggle this path in the selection set. */
+  onFileToggleSelect?: (path: string) => void
+  /** Shift+click: range-select from anchor to this path. */
+  onFileRangeSelect?: (path: string) => void
   onFolderToggle: (path: string) => void
   onFolderDoubleClick?: (path: string) => void
   onFileDoubleClick?: (path: string) => void
@@ -55,11 +61,14 @@ export function FileTree({
   projectPaths = EMPTY_PATH_SET,
   expandedFolders,
   selectedPath,
+  selectedPaths = EMPTY_PATH_SET,
   loadingFolders,
   renamingPath,
   clipboardPath,
   clipboardOperation,
   onFileClick,
+  onFileToggleSelect,
+  onFileRangeSelect,
   onFolderToggle,
   onFolderDoubleClick,
   onFileDoubleClick,
@@ -92,11 +101,14 @@ export function FileTree({
           projectPaths={projectPaths}
           expandedFolders={expandedFolders}
           selectedPath={selectedPath}
+          selectedPaths={selectedPaths}
           loadingFolders={loadingFolders}
           renamingPath={renamingPath}
           clipboardPath={clipboardPath}
           clipboardOperation={clipboardOperation}
           onFileClick={onFileClick}
+          onFileToggleSelect={onFileToggleSelect}
+          onFileRangeSelect={onFileRangeSelect}
           onFolderToggle={onFolderToggle}
           onFolderDoubleClick={onFolderDoubleClick}
           onFileDoubleClick={onFileDoubleClick}
@@ -130,11 +142,14 @@ interface FileTreeItemProps {
   projectPaths: ReadonlySet<string>
   expandedFolders: Set<string>
   selectedPath: string | null
+  selectedPaths: ReadonlySet<string>
   loadingFolders?: Set<string>
   renamingPath?: string | null
   clipboardPath?: string | null
   clipboardOperation?: 'copy' | 'cut' | null
   onFileClick: (path: string) => void
+  onFileToggleSelect?: (path: string) => void
+  onFileRangeSelect?: (path: string) => void
   onFolderToggle: (path: string) => void
   onFolderDoubleClick?: (path: string) => void
   onFileDoubleClick?: (path: string) => void
@@ -164,11 +179,14 @@ function FileTreeItem({
   projectPaths,
   expandedFolders,
   selectedPath,
+  selectedPaths,
   loadingFolders,
   renamingPath,
   clipboardPath,
   clipboardOperation,
   onFileClick,
+  onFileToggleSelect,
+  onFileRangeSelect,
   onFolderToggle,
   onFolderDoubleClick,
   onFileDoubleClick,
@@ -192,7 +210,8 @@ function FileTreeItem({
   depth
 }: FileTreeItemProps) {
   const isExpanded = expandedFolders.has(item.path)
-  const isSelected = selectedPath === item.path
+  // Primary selection (for single-file operations) OR part of multi-select set
+  const isSelected = selectedPath === item.path || selectedPaths.has(item.path)
   const isLoading = loadingFolders?.has(item.path) ?? false
   const isRenaming = renamingPath === item.path
   const isCut = clipboardOperation === 'cut' && clipboardPath === item.path
@@ -294,12 +313,15 @@ function FileTreeItem({
         setTimeout(() => {
           const input = inputRef.current
           if (!input) return
+          // Save the parent scroll position before select() can move it
+          const viewport = input.closest('[data-radix-scroll-area-viewport]') as HTMLElement | null
+          const savedScrollTop = viewport?.scrollTop ?? 0
           input.focus({ preventScroll: true })
           input.select()
-          // Reset scroll caused by select() showing cursor at end
+          // select() moves the cursor to end — reset just the input's own scroll,
+          // then restore the panel's scroll so the view stays where the user was.
           input.scrollLeft = 0
-          // Also reset parent scroll container if it shifted
-          input.closest('[data-radix-scroll-area-viewport]')?.scrollTo(0, 0)
+          if (viewport) viewport.scrollTop = savedScrollTop
         }, 50)
       })
     }
@@ -322,13 +344,24 @@ function FileTreeItem({
     e.stopPropagation()
   }
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
     if (isRenaming) return
     if (item.isDirectory) {
       onFolderToggle(item.path)
-    } else {
-      onFileClick(item.path)
+      return
     }
+    // Multi-select modifiers (files only — folders always just toggle expand)
+    if ((e.metaKey || e.ctrlKey) && onFileToggleSelect) {
+      e.preventDefault()
+      onFileToggleSelect(item.path)
+      return
+    }
+    if (e.shiftKey && onFileRangeSelect) {
+      e.preventDefault()
+      onFileRangeSelect(item.path)
+      return
+    }
+    onFileClick(item.path)
   }
 
   const handleDoubleClick = () => {
@@ -585,11 +618,14 @@ function FileTreeItem({
           projectPaths={projectPaths}
           expandedFolders={expandedFolders}
           selectedPath={selectedPath}
+          selectedPaths={selectedPaths}
           loadingFolders={loadingFolders}
           renamingPath={renamingPath}
           clipboardPath={clipboardPath}
           clipboardOperation={clipboardOperation}
           onFileClick={onFileClick}
+          onFileToggleSelect={onFileToggleSelect}
+          onFileRangeSelect={onFileRangeSelect}
           onFolderToggle={onFolderToggle}
           onFolderDoubleClick={onFolderDoubleClick}
           onFileDoubleClick={onFileDoubleClick}

--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import type { FileItem } from '../../types'
-import { ChevronRight, ChevronDown, FileText, FileType, Folder, FolderOpen, Loader2, Trash2, Edit3, ExternalLink, Copy, Scissors, ClipboardPaste, FilePlus, Boxes, Star } from 'lucide-react'
+import { ChevronRight, ChevronDown, FileText, FileType, Folder, FolderOpen, FolderPlus, Loader2, Trash2, Edit3, ExternalLink, Copy, Scissors, ClipboardPaste, FilePlus, Boxes, Star } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import {
   ContextMenu,
@@ -47,6 +47,7 @@ interface FileTreeProps {
   onRenameComplete?: (oldPath: string, newName: string) => void
   onRenameCancel?: () => void
   onNewFile?: (dirPath: string) => void
+  onNewFolder?: (parentDirPath: string) => void
   onAddProject?: (path: string) => void
   onAddFavorite?: (path: string, isDirectory: boolean) => void
   onRemoveProject?: (path: string) => void
@@ -84,6 +85,7 @@ export function FileTree({
   onRenameComplete,
   onRenameCancel,
   onNewFile,
+  onNewFolder,
   onAddProject,
   onAddFavorite,
   onRemoveProject,
@@ -124,6 +126,7 @@ export function FileTree({
           onRenameComplete={onRenameComplete}
           onRenameCancel={onRenameCancel}
           onNewFile={onNewFile}
+          onNewFolder={onNewFolder}
           onAddProject={onAddProject}
           onAddFavorite={onAddFavorite}
           onRemoveProject={onRemoveProject}
@@ -165,6 +168,7 @@ interface FileTreeItemProps {
   onRenameComplete?: (oldPath: string, newName: string) => void
   onRenameCancel?: () => void
   onNewFile?: (dirPath: string) => void
+  onNewFolder?: (parentDirPath: string) => void
   onAddProject?: (path: string) => void
   onAddFavorite?: (path: string, isDirectory: boolean) => void
   onRemoveProject?: (path: string) => void
@@ -202,6 +206,7 @@ function FileTreeItem({
   onRenameComplete,
   onRenameCancel,
   onNewFile,
+  onNewFolder,
   onAddProject,
   onAddFavorite,
   onRemoveProject,
@@ -306,7 +311,10 @@ function FileTreeItem({
 
   useEffect(() => {
     if (isRenaming) {
-      const nameWithoutExt = item.name.replace(/\.(md|markdown|txt)$/, '')
+      // Folders keep their full name; files strip the markdown extension for display
+      const nameWithoutExt = item.isDirectory
+        ? item.name
+        : item.name.replace(/\.(md|markdown|txt)$/, '')
       setRenameValue(nameWithoutExt)
       // Wait for Radix context menu close animation before focusing
       requestAnimationFrame(() => {
@@ -350,6 +358,8 @@ function FileTreeItem({
       onFolderToggle(item.path)
       return
     }
+    // Non-markdown files are not openable in the editor — clicks are inert
+    if (item.isNonMarkdown) return
     // Multi-select modifiers (files only — folders always just toggle expand)
     if ((e.metaKey || e.ctrlKey) && onFileToggleSelect) {
       e.preventDefault()
@@ -367,7 +377,7 @@ function FileTreeItem({
   const handleDoubleClick = () => {
     if (item.isDirectory && onFolderDoubleClick) {
       onFolderDoubleClick(item.path)
-    } else if (!item.isDirectory && onFileDoubleClick) {
+    } else if (!item.isDirectory && !item.isNonMarkdown && onFileDoubleClick) {
       onFileDoubleClick(item.path)
     }
   }
@@ -375,7 +385,9 @@ function FileTreeItem({
   // Remove .md extension for display
   const displayName = item.isDirectory
     ? item.name
-    : item.name.replace(/\.(md|markdown|txt)$/, '')
+    : item.isNonMarkdown
+      ? item.name  // show full filename including extension for non-markdown files
+      : item.name.replace(/\.(md|markdown|txt)$/, '')
 
   // Show chevron only if folder has or may have children
   const showChevron = item.isDirectory && (item.children?.length || item.hasChildren)
@@ -393,8 +405,11 @@ function FileTreeItem({
         onDoubleClick={handleDoubleClick}
         className={cn(
           'flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-sm text-left transition-colors outline-none',
-          'hover:bg-accent hover:text-accent-foreground',
-          isSelected && 'bg-accent text-accent-foreground',
+          // Non-markdown files are visible but greyed — not openable in the editor
+          item.isNonMarkdown
+            ? 'text-muted-foreground/50 hover:bg-accent/50 cursor-default'
+            : 'hover:bg-accent hover:text-accent-foreground',
+          isSelected && !item.isNonMarkdown && 'bg-accent text-accent-foreground',
           isCut && 'opacity-50',
           isDragOver && 'ring-1 ring-primary bg-primary/10'
         )}
@@ -551,12 +566,28 @@ function FileTreeItem({
           <ContextMenuShortcut>⌘N</ContextMenuShortcut>
         </ContextMenuItem>
       )}
-      {onFilePaste && (
-        <ContextMenuItem onClick={() => onFilePaste(item.path)} disabled={!clipboardPath}>
-          <ClipboardPaste className="h-4 w-4 mr-2" />
-          Paste
-          <ContextMenuShortcut>⌘V</ContextMenuShortcut>
+      {onNewFolder && (
+        <ContextMenuItem onClick={() => onNewFolder(item.path)}>
+          <FolderPlus className="h-4 w-4 mr-2" />
+          New Folder
         </ContextMenuItem>
+      )}
+      {onFileRename && (
+        <ContextMenuItem onClick={() => onFileRename(item.path)}>
+          <Edit3 className="h-4 w-4 mr-2" />
+          Rename
+          <ContextMenuShortcut>↵</ContextMenuShortcut>
+        </ContextMenuItem>
+      )}
+      {onFilePaste && (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem onClick={() => onFilePaste(item.path)} disabled={!clipboardPath}>
+            <ClipboardPaste className="h-4 w-4 mr-2" />
+            Paste
+            <ContextMenuShortcut>⌘V</ContextMenuShortcut>
+          </ContextMenuItem>
+        </>
       )}
       {onFileShowInFolder && (
         <>
@@ -597,6 +628,24 @@ function FileTreeItem({
     </ContextMenuContent>
   )
 
+  // Context menu for non-markdown files (greyed rows — not editable in Prose)
+  const nonMarkdownContextMenu = (
+    <ContextMenuContent>
+      {onFileShowInFolder && (
+        <ContextMenuItem onClick={() => onFileShowInFolder(item.path)}>
+          <ExternalLink className="h-4 w-4 mr-2" />
+          Show in Finder
+        </ContextMenuItem>
+      )}
+      {onFileOpen && (
+        <ContextMenuItem onClick={() => onFileOpen(item.path)}>
+          <ExternalLink className="h-4 w-4 mr-2" />
+          Open Externally
+        </ContextMenuItem>
+      )}
+    </ContextMenuContent>
+  )
+
   return (
     <div
       onDragOver={handleDragOver}
@@ -608,7 +657,7 @@ function FileTreeItem({
         <ContextMenuTrigger asChild>
           {buttonElement}
         </ContextMenuTrigger>
-        {item.isDirectory ? folderContextMenu : fileContextMenu}
+        {item.isDirectory ? folderContextMenu : item.isNonMarkdown ? nonMarkdownContextMenu : fileContextMenu}
       </ContextMenu>
 
       {item.isDirectory && isExpanded && item.children && (
@@ -641,6 +690,7 @@ function FileTreeItem({
           onRenameComplete={onRenameComplete}
           onRenameCancel={onRenameCancel}
           onNewFile={onNewFile}
+          onNewFolder={onNewFolder}
           onAddProject={onAddProject}
           onAddFavorite={onAddFavorite}
           onRemoveProject={onRemoveProject}

--- a/src/renderer/hooks/useExplorerActions.ts
+++ b/src/renderer/hooks/useExplorerActions.ts
@@ -53,6 +53,7 @@ export function useExplorerActions({
   const setRenamingPath = useFileListStore((s) => s.setRenamingPath)
   const renamingPath = useFileListStore((s) => s.renamingPath)
   const selectAll = useFileListStore((s) => s.selectAll)
+  const toggleShowDotfiles = useFileListStore((s) => s.toggleShowDotfiles)
 
   const api = getApi()
 
@@ -305,6 +306,14 @@ export function useExplorerActions({
         return
       }
 
+      // Cmd+Shift+. → toggle dotfile visibility (mirrors macOS Finder convention)
+      if (e.key === '.' && isMeta && e.shiftKey) {
+        e.preventDefault()
+        e.stopPropagation()
+        toggleShowDotfiles()
+        return
+      }
+
       // Cmd+A → select all visible files
       if (e.key === 'a' && isMeta) {
         e.preventDefault()
@@ -393,7 +402,7 @@ export function useExplorerActions({
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [containerRef, selectedPath, clipboardPath, renamingPath, startRename, trashSelected, copySelected, cutSelected, pasteFile, newFileInContext, selectAll, onFilePreview, onFileTrash])
+  }, [containerRef, selectedPath, clipboardPath, renamingPath, startRename, trashSelected, copySelected, cutSelected, pasteFile, newFileInContext, selectAll, toggleShowDotfiles, onFilePreview, onFileTrash])
 
   return {
     trashSelected,

--- a/src/renderer/hooks/useExplorerActions.ts
+++ b/src/renderer/hooks/useExplorerActions.ts
@@ -52,6 +52,7 @@ export function useExplorerActions({
   const setClipboardPath = useFileListStore((s) => s.setClipboardPath)
   const setRenamingPath = useFileListStore((s) => s.setRenamingPath)
   const renamingPath = useFileListStore((s) => s.renamingPath)
+  const selectAll = useFileListStore((s) => s.selectAll)
 
   const api = getApi()
 
@@ -304,6 +305,19 @@ export function useExplorerActions({
         return
       }
 
+      // Cmd+A → select all visible files
+      if (e.key === 'a' && isMeta) {
+        e.preventDefault()
+        e.stopPropagation()
+        const { files, expandedFolders } = useFileListStore.getState()
+        const visible = getVisibleItems(files, expandedFolders)
+        const filePaths = visible.filter(item => !item.isDirectory).map(item => item.path)
+        if (filePaths.length > 0) {
+          selectAll(filePaths)
+        }
+        return
+      }
+
       // Arrow key navigation (no modifier keys)
       if (!isMeta && !e.shiftKey && !e.altKey) {
         const { files, expandedFolders, toggleFolder, selectFile, setExpanded } = useFileListStore.getState()
@@ -379,7 +393,7 @@ export function useExplorerActions({
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [containerRef, selectedPath, clipboardPath, renamingPath, startRename, trashSelected, copySelected, cutSelected, pasteFile, newFileInContext, onFilePreview, onFileTrash])
+  }, [containerRef, selectedPath, clipboardPath, renamingPath, startRename, trashSelected, copySelected, cutSelected, pasteFile, newFileInContext, selectAll, onFilePreview, onFileTrash])
 
   return {
     trashSelected,

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -138,6 +138,12 @@ interface FileListState {
   clipboardOperation: 'copy' | 'cut' | null
   renamingPath: string | null
 
+  // Multi-select — contains all currently selected paths (files only for now).
+  // selectedPath remains the "anchor" for single-file operations; selectedPaths
+  // is the full set for bulk actions (delete, copy, cut).
+  selectedPaths: Set<string>
+  anchorPath: string | null // Shift+click range anchor
+
   // Google Docs sync state
   isGoogleSyncing: boolean
 
@@ -183,6 +189,11 @@ interface FileListState {
   setExpanded: (path: string, expanded: boolean) => void
   toggleNotebookFolderExpanded: (folderId: string) => void
   revealAndSelectPath: (path: string) => void
+  // Multi-select actions
+  toggleSelectFile: (path: string) => void
+  rangeSelectTo: (path: string, visiblePaths: string[]) => void
+  selectAll: (paths: string[]) => void
+  clearMultiSelect: () => void
 }
 
 export const useFileListStore = create<FileListState>()(
@@ -199,6 +210,8 @@ export const useFileListStore = create<FileListState>()(
     clipboardPath: null,
     clipboardOperation: null,
     renamingPath: null,
+    selectedPaths: new Set<string>(),
+    anchorPath: null,
     isGoogleSyncing: false,
     remarkableSyncActive: false,
     remarkableSyncProgress: null,
@@ -538,7 +551,46 @@ export const useFileListStore = create<FileListState>()(
       }
     },
 
-    selectFile: (path) => set({ selectedPath: path }),
+    selectFile: (path) => set({ selectedPath: path, selectedPaths: path ? new Set([path]) : new Set(), anchorPath: path }),
+
+    toggleSelectFile: (path) => set((state) => {
+      const next = new Set(state.selectedPaths)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      // Last toggled path becomes anchor and primary selection
+      const primary = next.size > 0 ? path : null
+      return { selectedPaths: next, selectedPath: primary, anchorPath: path }
+    }),
+
+    rangeSelectTo: (path, visiblePaths) => set((state) => {
+      const anchor = state.anchorPath ?? state.selectedPath
+      if (!anchor) {
+        // No anchor — treat as plain select
+        return { selectedPaths: new Set([path]), selectedPath: path, anchorPath: path }
+      }
+      const anchorIdx = visiblePaths.indexOf(anchor)
+      const targetIdx = visiblePaths.indexOf(path)
+      if (anchorIdx === -1 || targetIdx === -1) {
+        return { selectedPaths: new Set([path]), selectedPath: path }
+      }
+      const lo = Math.min(anchorIdx, targetIdx)
+      const hi = Math.max(anchorIdx, targetIdx)
+      const rangeSet = new Set(visiblePaths.slice(lo, hi + 1))
+      return { selectedPaths: rangeSet, selectedPath: path }
+    }),
+
+    selectAll: (paths) => set((state) => {
+      const all = new Set(paths)
+      return { selectedPaths: all, selectedPath: state.selectedPath ?? paths[0] ?? null }
+    }),
+
+    clearMultiSelect: () => set((state) => ({
+      selectedPaths: state.selectedPath ? new Set([state.selectedPath]) : new Set(),
+      anchorPath: state.selectedPath,
+    })),
 
     toggleFolder: (path) => {
       const { expandedFolders, files, loadFolderChildren } = get()

--- a/src/renderer/stores/fileListStore.ts
+++ b/src/renderer/stores/fileListStore.ts
@@ -144,6 +144,9 @@ interface FileListState {
   selectedPaths: Set<string>
   anchorPath: string | null // Shift+click range anchor
 
+  // Dotfile visibility — toggled by ⌘⇧. (session-only, not persisted)
+  showDotfiles: boolean
+
   // Google Docs sync state
   isGoogleSyncing: boolean
 
@@ -194,6 +197,8 @@ interface FileListState {
   rangeSelectTo: (path: string, visiblePaths: string[]) => void
   selectAll: (paths: string[]) => void
   clearMultiSelect: () => void
+  // Dotfile toggle
+  toggleShowDotfiles: () => void
 }
 
 export const useFileListStore = create<FileListState>()(
@@ -212,6 +217,7 @@ export const useFileListStore = create<FileListState>()(
     renamingPath: null,
     selectedPaths: new Set<string>(),
     anchorPath: null,
+    showDotfiles: false,
     isGoogleSyncing: false,
     remarkableSyncActive: false,
     remarkableSyncProgress: null,
@@ -413,13 +419,13 @@ export const useFileListStore = create<FileListState>()(
     },
 
     loadFiles: async () => {
-      const { rootPath, expandedFolders, files: oldFiles } = get()
+      const { rootPath, expandedFolders, files: oldFiles, showDotfiles } = get()
       if (!rootPath || !window.api) return
 
       set({ isLoading: true })
       try {
         // Use depth 1 for fast initial load - children loaded on demand
-        const fresh = await window.api.listDirectory(rootPath, 1)
+        const fresh = await window.api.listDirectory(rootPath, 1, showDotfiles)
         // The fresh listing only includes direct children. If the user had
         // any subfolders expanded (and their children fetched via
         // loadFolderChildren), those `children` arrays would be wiped on
@@ -451,7 +457,8 @@ export const useFileListStore = create<FileListState>()(
 
       try {
         // Load just this folder's children (depth 1)
-        const children = await window.api.listDirectory(folderPath, 1)
+        const { showDotfiles } = get()
+        const children = await window.api.listDirectory(folderPath, 1, showDotfiles)
 
         // Update the tree by finding and updating the folder
         const { files } = get()
@@ -591,6 +598,12 @@ export const useFileListStore = create<FileListState>()(
       selectedPaths: state.selectedPath ? new Set([state.selectedPath]) : new Set(),
       anchorPath: state.selectedPath,
     })),
+
+    toggleShowDotfiles: () => {
+      set((state) => ({ showDotfiles: !state.showDotfiles }))
+      // Reload the current directory with updated dotfile visibility
+      get().loadFiles()
+    },
 
     toggleFolder: (path) => {
       const { expandedFolders, files, loadFolderChildren } = get()

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -196,6 +196,10 @@ export interface FileItem {
   modifiedAt: string
   children?: FileItem[]
   hasChildren?: boolean // For lazy loading - indicates folder has content without loading it
+  /** True for non-markdown, non-txt files — shown greyed and not openable in the editor. */
+  isNonMarkdown?: boolean
+  /** True for dotfiles/dot-dirs (name starts with '.') when shown via dotfile toggle. */
+  isDotfile?: boolean
 }
 
 export interface RemarkableRegisterResponse {
@@ -492,12 +496,14 @@ export interface ElectronAPI {
   deleteFile: (path: string) => Promise<void>
   trashFile: (path: string) => Promise<void>
   duplicateFile: (path: string) => Promise<string>
+  /** Create a new directory at the given path. Returns the created path. */
+  createDirectory: (dirPath: string) => Promise<string>
   // Window operations
   closeWindow: () => Promise<void>
   // External URL opening (for CMD+Click on links)
   openExternal?: (url: string) => Promise<void>
   // Directory listing (with lazy loading support via maxDepth parameter)
-  listDirectory: (path: string, maxDepth?: number) => Promise<FileItem[]>
+  listDirectory: (path: string, maxDepth?: number, showDotfiles?: boolean) => Promise<FileItem[]>
   // reMarkable sync
   remarkableRegister: (code: string) => Promise<RemarkableRegisterResponse>
   remarkableValidate: (deviceToken: string) => Promise<boolean>


### PR DESCRIPTION
## Summary

- **New Folder**: `file:createDirectory` IPC handler (guarded by `validatePath`); New Folder dialog with `#new-folder-name` input; triggered from both folder-row right-click and empty-space right-click menus; tree reloads on success.
- **Folder rename**: right-click → Rename on a directory activates inline rename with the full directory name; `handleRenameComplete` skips extension re-appending for non-markdown paths, so folder renames work correctly.
- **Non-markdown files always visible but greyed**: `file:listDirectory` now emits all files with `isNonMarkdown: true` for non-markdown entries (instead of filtering them). FileTreeItem renders them with `opacity-50 cursor-default italic` styling and a restricted context menu (Show in Finder / Open Externally only — no open, no rename).
- **Dotfile toggle (`⌘⇧.`)**: `showDotfiles` boolean in `fileListStore` (session-only, default false); `listDirectory` skips dot-prefixed entries unless the flag is set; `⌘⇧.` in `useExplorerActions` calls `toggleShowDotfiles`, which flips the flag and triggers a directory reload.

## Depends on #780 (issue-723-file-explorer-qa)

This PR is branched off `issue-723-file-explorer-qa` and shares the file-rename code path with the #723 fixes. **Merge #780 first**, then merge this PR targeting `main`.

## Files changed

- `src/main/ipc.ts` — updated `file:listDirectory` (non-markdown + dotfile flags), added `file:createDirectory`
- `src/preload/index.ts` — wired `createDirectory` + `showDotfiles` param
- `src/renderer/types/index.ts` — `FileItem.isNonMarkdown`, `FileItem.isDotfile`, `ElectronAPI.createDirectory`
- `src/renderer/stores/fileListStore.ts` — `showDotfiles`, `toggleShowDotfiles`
- `src/renderer/hooks/useExplorerActions.ts` — `⌘⇧.` shortcut
- `src/renderer/components/files/FileTree.tsx` — `onNewFolder`, non-markdown styling + context menu, folder rename init
- `src/renderer/components/files/FileListPanel.tsx` — New Folder dialog, folder rename handling, `handleOpenExternally`
- `e2e/electron.explorer-interactivity.spec.ts` — Playwright regressions for all 4 features in an isolated profile

## Test plan

- [ ] Build the app (`npm run build`) and run e2e: `npx playwright test e2e/electron.explorer-interactivity.spec.ts`
- [ ] Manually: right-click an empty area in the Files panel → New Folder → enter a name → confirm it appears in the tree and on disk
- [ ] Manually: right-click a folder → New Folder → confirm subfolder created inside it
- [ ] Manually: right-click a folder → Rename → type a new name → confirm rename on disk, original name gone
- [ ] Manually: drop a `.png` file into the files directory → confirm it appears greyed in the explorer, cannot be opened, shows "Show in Finder" context menu only
- [ ] Manually: focus the Files panel → `⌘⇧.` → dotfiles appear; `⌘⇧.` again → dotfiles hidden

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)