### PR TITLE
feat(menus): customizable '…' menus with wiggle edit mode

### DIFF
--- a/e2e/electron.customizable-menus.spec.ts
+++ b/e2e/electron.customizable-menus.spec.ts
@@ -54,7 +54,7 @@ test.describe('toolbar-more customizable menu', () => {
 
     // Default items should be present
     await expect(page.getByRole('menuitem', { name: 'New Document' })).toBeVisible()
-    await expect(page.getByRole('menuitem', { name: /^Open/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Open...' })).toBeVisible()
     await expect(page.getByRole('menuitem', { name: 'Save' }).first()).toBeVisible()
     await expect(page.getByRole('menuitem', { name: 'Settings' })).toBeVisible()
     // Customize trigger should always be present
@@ -88,10 +88,10 @@ test.describe('toolbar-more customizable menu', () => {
     await page.getByRole('menuitem', { name: /Customize/i }).click()
     await expect(page.locator('text=Customize menu')).toBeVisible()
 
-    // Hide the "New Document" item (first eye button next to its wiggle row)
-    const newDocRow = page.locator('.animate-wiggle', { hasText: 'New Document' }).locator('..')
-    await expect(newDocRow.locator('button[aria-label*="Hide New Document"]')).toBeVisible()
-    await newDocRow.locator('button[aria-label*="Hide New Document"]').click()
+    // Hide the "New Document" item via its eye toggle button
+    const hideNewDocBtn = page.locator('button[aria-label="Hide New Document"]')
+    await expect(hideNewDocBtn).toBeVisible()
+    await hideNewDocBtn.click()
 
     // Done to save
     await page.getByRole('menuitem', { name: /Done/i }).click()
@@ -100,17 +100,24 @@ test.describe('toolbar-more customizable menu', () => {
     await page.click('[aria-label="More options"]')
     await page.waitForSelector('[role="menu"]')
     await expect(page.getByRole('menuitem', { name: 'New Document' })).not.toBeVisible()
+    // Close before reopening for restore
+    await page.keyboard.press('Escape')
+    await expect(page.locator('[role="menu"]')).not.toBeVisible()
 
     // Restore: enter edit mode again and re-show New Document
     await page.click('[aria-label="More options"]')
     await page.waitForSelector('[role="menu"]')
     await page.getByRole('menuitem', { name: /Customize/i }).click()
     await expect(page.locator('text=Customize menu')).toBeVisible()
-    const newDocRowRestored = page.locator('.animate-wiggle', { hasText: 'New Document' }).locator('..')
-    await newDocRowRestored.locator('button[aria-label*="Show New Document"]').click()
+    const showNewDocBtn = page.locator('button[aria-label="Show New Document"]')
+    await expect(showNewDocBtn).toBeVisible()
+    await showNewDocBtn.click()
+    // Wait for the eye toggle state to update before saving
+    await expect(page.locator('button[aria-label="Hide New Document"]')).toBeVisible()
     await page.getByRole('menuitem', { name: /Done/i }).click()
+    // Wait for menu to fully close before reopening
+    await expect(page.locator('[role="menu"]')).not.toBeVisible()
 
-    // Confirm "New Document" is back
     await page.click('[aria-label="More options"]')
     await page.waitForSelector('[role="menu"]')
     await expect(page.getByRole('menuitem', { name: 'New Document' })).toBeVisible()

--- a/e2e/electron.customizable-menus.spec.ts
+++ b/e2e/electron.customizable-menus.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Customizable menus (#701) — regression coverage for the wiggle edit mode,
+ * item persistence (order + hidden state), and the three target menus:
+ *
+ *   1. Toolbar "More options" (toolbar-more)
+ *   2. FileListPanel header view-toggle overflow (files-header)
+ *   3. ChatPanel history dropdown footer (chat-history)
+ *
+ * Tests run against the built `out/` in an isolated PROSE_USER_DATA_DIR so
+ * no real settings files are touched. All assertions are negative-controlled
+ * (open → check default → customize → close → reopen → verify).
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+
+test.beforeAll(async () => {
+  test.setTimeout(120_000)
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-customizable-menus-'))
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+})
+
+test.afterAll(async () => {
+  await app.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Toolbar "More options" — toolbar-more
+// ---------------------------------------------------------------------------
+
+test.describe('toolbar-more customizable menu', () => {
+  test('shows expected items and Customize… trigger by default', async () => {
+    await page.click('[aria-label="More options"]')
+    await page.waitForSelector('[role="menu"]')
+
+    // Default items should be present
+    await expect(page.getByRole('menuitem', { name: 'New Document' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /^Open/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Save' }).first()).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Settings' })).toBeVisible()
+    // Customize trigger should always be present
+    await expect(page.getByRole('menuitem', { name: /Customize/i })).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.locator('[role="menu"]')).not.toBeVisible()
+  })
+
+  test('enters and exits edit mode via Customize… and Done', async () => {
+    await page.click('[aria-label="More options"]')
+    await page.waitForSelector('[role="menu"]')
+
+    // Click "Customize…" — should NOT close the dropdown (we call e.preventDefault())
+    await page.getByRole('menuitem', { name: /Customize/i }).click()
+
+    // Edit mode: heading + Done button visible, menu still open
+    await expect(page.locator('[role="menu"]')).toBeVisible()
+    await expect(page.locator('text=Customize menu')).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Done/i })).toBeVisible()
+
+    // Click Done — closes the menu
+    await page.getByRole('menuitem', { name: /Done/i }).click()
+    await expect(page.locator('[role="menu"]')).not.toBeVisible()
+  })
+
+  test('hides an item and persists across close/reopen', async () => {
+    // Open → edit mode
+    await page.click('[aria-label="More options"]')
+    await page.waitForSelector('[role="menu"]')
+    await page.getByRole('menuitem', { name: /Customize/i }).click()
+    await expect(page.locator('text=Customize menu')).toBeVisible()
+
+    // Hide the "New Document" item (first eye button next to its wiggle row)
+    const newDocRow = page.locator('.animate-wiggle', { hasText: 'New Document' }).locator('..')
+    await expect(newDocRow.locator('button[aria-label*="Hide New Document"]')).toBeVisible()
+    await newDocRow.locator('button[aria-label*="Hide New Document"]').click()
+
+    // Done to save
+    await page.getByRole('menuitem', { name: /Done/i }).click()
+
+    // Reopen — "New Document" should be gone
+    await page.click('[aria-label="More options"]')
+    await page.waitForSelector('[role="menu"]')
+    await expect(page.getByRole('menuitem', { name: 'New Document' })).not.toBeVisible()
+
+    // Restore: enter edit mode again and re-show New Document
+    await page.click('[aria-label="More options"]')
+    await page.waitForSelector('[role="menu"]')
+    await page.getByRole('menuitem', { name: /Customize/i }).click()
+    await expect(page.locator('text=Customize menu')).toBeVisible()
+    const newDocRowRestored = page.locator('.animate-wiggle', { hasText: 'New Document' }).locator('..')
+    await newDocRowRestored.locator('button[aria-label*="Show New Document"]').click()
+    await page.getByRole('menuitem', { name: /Done/i }).click()
+
+    // Confirm "New Document" is back
+    await page.click('[aria-label="More options"]')
+    await page.waitForSelector('[role="menu"]')
+    await expect(page.getByRole('menuitem', { name: 'New Document' })).toBeVisible()
+    await page.keyboard.press('Escape')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FileListPanel header — files-header
+// ---------------------------------------------------------------------------
+
+test.describe('files-header customizable views', () => {
+  test.beforeEach(async () => {
+    // Ensure file panel is open
+    const panelVisible = await page.locator('[data-testid="file-list-panel"]').isVisible()
+    if (!panelVisible) {
+      await page.click('[aria-label="Show files"], [aria-label="Hide files"]')
+      await page.waitForSelector('[data-testid="file-list-panel"]')
+    }
+  })
+
+  test('shows the "More views" button with Customize… option', async () => {
+    await page.click('[aria-label="More views"]')
+    await page.waitForSelector('[role="menu"]')
+    await expect(page.getByRole('menuitem', { name: /Customize/i })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.locator('[role="menu"]')).not.toBeVisible()
+  })
+
+  test('enters and exits edit mode for view toggles', async () => {
+    await page.click('[aria-label="More views"]')
+    await page.waitForSelector('[role="menu"]')
+
+    await page.getByRole('menuitem', { name: /Customize/i }).click()
+    await expect(page.locator('text=Customize views')).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Done/i })).toBeVisible()
+
+    // Exit via Done
+    await page.getByRole('menuitem', { name: /Done/i }).click()
+    await expect(page.locator('[role="menu"]')).not.toBeVisible()
+  })
+})

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -10,7 +10,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '../ui/dropdown-menu'
-import { MessageSquare, History, Plus, Trash2, Sparkles, Info, Loader2, Filter } from 'lucide-react'
+import { MessageSquare, History, Plus, Trash2, Sparkles, Info, Loader2, Filter, SlidersHorizontal, Eye, EyeOff, Check, ChevronUp, ChevronDown } from 'lucide-react'
+import { useMenuCustomization } from '../../hooks/useMenuCustomization'
+import type { MenuItemDescriptor } from '../../hooks/useMenuCustomization'
 import { useChatStore } from '../../stores/chatStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useEditorInstanceStore } from '../../stores/editorInstanceStore'
@@ -204,6 +206,22 @@ export function ChatPanel() {
     deleteConversation(conversationId)
   }
 
+  // Customizable footer items in the chat history dropdown.
+  // Only static items are customizable — the conversation list is not.
+  const chatHistoryFooterDescriptors: MenuItemDescriptor[] = [
+    { id: 'new-chat', label: 'New Chat' },
+  ]
+  const {
+    visibleIds: chatHistoryVisibleIds,
+    hiddenIds: chatHistoryHiddenIds,
+    orderedAllIds: chatHistoryOrderedIds,
+    toggleHidden: toggleChatHistoryHidden,
+    moveUp: moveChatHistoryUp,
+    moveDown: moveChatHistoryDown,
+  } = useMenuCustomization('chat-history', chatHistoryFooterDescriptors)
+  const [isChatHistoryEditMode, setIsChatHistoryEditMode] = useState(false)
+  const showNewChat = chatHistoryVisibleIds.includes('new-chat')
+
   if (reviewMode) {
     return (
       <div className="flex h-full flex-col bg-muted/20">
@@ -318,7 +336,7 @@ export function ChatPanel() {
               <TooltipContent>Document info</TooltipContent>
             </Tooltip>
             {conversations.length > 0 && (
-              <DropdownMenu>
+              <DropdownMenu onOpenChange={(open) => { if (!open) setIsChatHistoryEditMode(false) }}>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <DropdownMenuTrigger asChild>
@@ -334,43 +352,121 @@ export function ChatPanel() {
                   </TooltipTrigger>
                   <TooltipContent>Chat history</TooltipContent>
                 </Tooltip>
-                <DropdownMenuContent align="end" className="w-64">
-                  {conversations.map((conversation) => (
-                    <DropdownMenuItem
-                      key={conversation.id}
-                      className="flex items-center justify-between gap-2 cursor-pointer"
-                      onClick={() => handleSelectConversation(conversation.id)}
-                    >
-                      <span
-                        className={`truncate flex-1 ${
-                          conversation.id === activeConversationId
-                            ? 'font-medium'
-                            : ''
-                        }`}
-                      >
-                        {conversation.title ?? 'New Chat'}
-                      </span>
-                      {conversations.length > 1 && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-6 w-6 shrink-0 opacity-50 hover:opacity-100"
-                          onClick={(e) =>
-                            handleDeleteConversation(e, conversation.id)
-                          }
-                          aria-label="Delete conversation"
+                {isChatHistoryEditMode ? (
+                  <DropdownMenuContent
+                    align="end"
+                    className="w-52"
+                    onCloseAutoFocus={(e) => e.preventDefault()}
+                    onInteractOutside={() => setIsChatHistoryEditMode(false)}
+                    onEscapeKeyDown={() => setIsChatHistoryEditMode(false)}
+                  >
+                    <div className="px-2 py-1 text-xs font-medium text-muted-foreground select-none">
+                      Customize menu
+                    </div>
+                    {chatHistoryOrderedIds.map((id, idx) => {
+                      const isHidden = chatHistoryHiddenIds.includes(id)
+                      const label = id === 'new-chat' ? 'New Chat' : id
+                      return (
+                        <div
+                          key={id}
+                          className={`flex items-center gap-1 px-1 py-0.5 rounded-sm${isHidden ? ' opacity-40' : ''}`}
                         >
-                          <Trash2 className="h-3 w-3" />
-                        </Button>
-                      )}
+                          <div className="flex flex-col shrink-0">
+                            <button
+                              type="button"
+                              className="h-3.5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-25 focus:outline-none"
+                              onClick={(e) => { e.stopPropagation(); moveChatHistoryUp(id) }}
+                              disabled={idx === 0}
+                              aria-label={`Move ${label} up`}
+                              tabIndex={-1}
+                            >
+                              <ChevronUp className="h-3 w-3" />
+                            </button>
+                            <button
+                              type="button"
+                              className="h-3.5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-25 focus:outline-none"
+                              onClick={(e) => { e.stopPropagation(); moveChatHistoryDown(id) }}
+                              disabled={idx === chatHistoryOrderedIds.length - 1}
+                              aria-label={`Move ${label} down`}
+                              tabIndex={-1}
+                            >
+                              <ChevronDown className="h-3 w-3" />
+                            </button>
+                          </div>
+                          <div className="flex flex-1 items-center gap-2 px-1 py-1 text-sm animate-wiggle select-none">
+                            <Plus className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <span className="truncate">{label}</span>
+                          </div>
+                          <button
+                            type="button"
+                            className="shrink-0 h-6 w-6 flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent focus:outline-none"
+                            onClick={(e) => { e.stopPropagation(); toggleChatHistoryHidden(id) }}
+                            aria-label={isHidden ? `Show ${label}` : `Hide ${label}`}
+                            aria-pressed={isHidden}
+                            tabIndex={-1}
+                          >
+                            {isHidden ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                          </button>
+                        </div>
+                      )
+                    })}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="cursor-pointer font-medium"
+                      onSelect={() => setIsChatHistoryEditMode(false)}
+                    >
+                      <Check className="mr-2 h-4 w-4" />
+                      Done
                     </DropdownMenuItem>
-                  ))}
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={handleNewChat} className="cursor-pointer">
-                    <Plus className="h-4 w-4 mr-2" />
-                    New Chat
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
+                  </DropdownMenuContent>
+                ) : (
+                  <DropdownMenuContent align="end" className="w-64">
+                    {conversations.map((conversation) => (
+                      <DropdownMenuItem
+                        key={conversation.id}
+                        className="flex items-center justify-between gap-2 cursor-pointer"
+                        onClick={() => handleSelectConversation(conversation.id)}
+                      >
+                        <span
+                          className={`truncate flex-1 ${
+                            conversation.id === activeConversationId
+                              ? 'font-medium'
+                              : ''
+                          }`}
+                        >
+                          {conversation.title ?? 'New Chat'}
+                        </span>
+                        {conversations.length > 1 && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 shrink-0 opacity-50 hover:opacity-100"
+                            onClick={(e) =>
+                              handleDeleteConversation(e, conversation.id)
+                            }
+                            aria-label="Delete conversation"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </DropdownMenuItem>
+                    ))}
+                    <DropdownMenuSeparator />
+                    {showNewChat && (
+                      <DropdownMenuItem onClick={handleNewChat} className="cursor-pointer">
+                        <Plus className="h-4 w-4 mr-2" />
+                        New Chat
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      className="cursor-pointer text-muted-foreground"
+                      onSelect={(e) => { e.preventDefault(); setIsChatHistoryEditMode(true) }}
+                    >
+                      <SlidersHorizontal className="mr-2 h-4 w-4" />
+                      Customize…
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                )}
               </DropdownMenu>
             )}
             <Tooltip>

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
 import {
@@ -40,7 +41,7 @@ import {
 } from '../ui/dialog'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronLeft, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug, Boxes, Star, MoreHorizontal } from 'lucide-react'
+import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronLeft, ChevronRight, ChevronDown, Folder, FolderOpen, FolderInput, Download, Trash2, FilePlus, ClipboardPaste, ExternalLink, X, Globe, Edit3, RefreshCw, Loader2, AlertTriangle, Bug, Boxes, Star, MoreHorizontal, Eye, EyeOff, SlidersHorizontal, Check } from 'lucide-react'
 import { useSettings } from '../../hooks/useSettings'
 import { cn } from '../../lib/utils'
 import { getApi } from '../../lib/browserApi'
@@ -48,6 +49,8 @@ import { requestBugReport } from '../EnableLoggingDialog'
 import type { RemarkableNotebookMetadata, RemarkableCloudNotebook, GoogleDocEntry } from '../../types'
 import { ProjectsPanel } from './ProjectsPanel'
 import { useProjects, useFavorites, useProjectsStore } from '../../stores/projectsStore'
+import { useMenuCustomization } from '../../hooks/useMenuCustomization'
+import type { MenuItemDescriptor } from '../../hooks/useMenuCustomization'
 
 export function FileListPanel() {
   const {
@@ -130,7 +133,8 @@ export function FileListPanel() {
   }, [])
 
   // View toggles in priority order (earliest stay inline longest).
-  const viewToggles = [
+  // All possible toggles — feature-gated ones are only present when enabled.
+  const allViewToggles = [
     {
       key: 'folder', Icon: Folder, label: 'Files', active: viewMode === 'folder',
       onClick: () => {
@@ -156,6 +160,27 @@ export function FileListPanel() {
         : setViewMode('notebooks'),
     }] : []),
   ]
+
+  // Apply user-saved customization: order + visibility.
+  // Unknown/new toggle IDs append visible so upgrades never hide new toggles.
+  const toggleDescriptors: MenuItemDescriptor[] = allViewToggles.map((t) => ({ id: t.key, label: t.label }))
+  const {
+    visibleIds: toggleVisibleIds,
+    hiddenIds: toggleHiddenIds,
+    orderedAllIds: toggleOrderedAllIds,
+    toggleHidden: toggleViewToggleHidden,
+    moveUp: moveToggleUp,
+    moveDown: moveToggleDown,
+  } = useMenuCustomization('files-header', toggleDescriptors)
+  const toggleById = new Map(allViewToggles.map((t) => [t.key, t]))
+  // viewToggles is the filtered + ordered set fed into the responsive layout below
+  const viewToggles = toggleVisibleIds
+    .map((id) => toggleById.get(id))
+    .filter((t): t is (typeof allViewToggles)[number] => !!t)
+
+  // Edit mode for the header view-toggle customization overlay
+  const [isToggleEditMode, setIsToggleEditMode] = useState(false)
+
   const TOGGLE_PX = 36 // 32px button + 4px gap
   // Title gets a real min-width: shown at >=120px, otherwise hidden entirely
   // (rather than shrinking to a sliver) so the toggles collapse into ··· sooner.
@@ -1123,32 +1148,111 @@ export function FileListPanel() {
               <TooltipContent>{t.label}</TooltipContent>
             </Tooltip>
           ))}
-          {overflowToggles.length > 0 && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className={cn("h-8 w-8", overflowToggles.some((t) => t.active) && "bg-accent text-accent-foreground")}
-                  aria-label="More views"
+          <DropdownMenu onOpenChange={(open) => { if (!open) setIsToggleEditMode(false) }}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn("h-8 w-8", overflowToggles.some((t) => t.active) && "bg-accent text-accent-foreground")}
+                aria-label="More views"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            {isToggleEditMode ? (
+              <DropdownMenuContent
+                align="end"
+                className="w-52"
+                onCloseAutoFocus={(e) => e.preventDefault()}
+                onInteractOutside={() => setIsToggleEditMode(false)}
+                onEscapeKeyDown={() => setIsToggleEditMode(false)}
+              >
+                <div className="px-2 py-1 text-xs font-medium text-muted-foreground select-none">
+                  Customize views
+                </div>
+                {toggleOrderedAllIds.map((id, idx) => {
+                  const toggle = toggleById.get(id)
+                  if (!toggle) return null
+                  const isHidden = toggleHiddenIds.includes(id)
+                  return (
+                    <div
+                      key={id}
+                      className={cn(
+                        'flex items-center gap-1 px-1 py-0.5 rounded-sm',
+                        isHidden && 'opacity-40'
+                      )}
+                    >
+                      <div className="flex flex-col shrink-0">
+                        <button
+                          type="button"
+                          className="h-3.5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-25 focus:outline-none"
+                          onClick={(e) => { e.stopPropagation(); moveToggleUp(id) }}
+                          disabled={idx === 0}
+                          aria-label={`Move ${toggle.label} up`}
+                          tabIndex={-1}
+                        >
+                          <ChevronUp className="h-3 w-3" />
+                        </button>
+                        <button
+                          type="button"
+                          className="h-3.5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-25 focus:outline-none"
+                          onClick={(e) => { e.stopPropagation(); moveToggleDown(id) }}
+                          disabled={idx === toggleOrderedAllIds.length - 1}
+                          aria-label={`Move ${toggle.label} down`}
+                          tabIndex={-1}
+                        >
+                          <ChevronDown className="h-3 w-3" />
+                        </button>
+                      </div>
+                      <div className="flex flex-1 items-center gap-2 px-1 py-1 text-sm animate-wiggle select-none">
+                        <toggle.Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate">{toggle.label}</span>
+                      </div>
+                      <button
+                        type="button"
+                        className="shrink-0 h-6 w-6 flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent focus:outline-none"
+                        onClick={(e) => { e.stopPropagation(); toggleViewToggleHidden(id) }}
+                        aria-label={isHidden ? `Show ${toggle.label}` : `Hide ${toggle.label}`}
+                        aria-pressed={isHidden}
+                        tabIndex={-1}
+                      >
+                        {isHidden ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                      </button>
+                    </div>
+                  )
+                })}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="cursor-pointer font-medium"
+                  onSelect={() => setIsToggleEditMode(false)}
                 >
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
+                  <Check className="mr-2 h-4 w-4" />
+                  Done
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            ) : (
               <DropdownMenuContent align="end">
                 {overflowToggles.map((t) => (
                   <DropdownMenuItem
                     key={t.key}
-                    className={cn(t.active && "bg-muted")}
+                    className={cn(t.active && "bg-muted", "cursor-pointer")}
                     onClick={t.onClick}
                   >
                     <t.Icon className="h-4 w-4 mr-2" />
                     {t.label}
                   </DropdownMenuItem>
                 ))}
+                {overflowToggles.length > 0 && <DropdownMenuSeparator />}
+                <DropdownMenuItem
+                  className="cursor-pointer text-muted-foreground"
+                  onSelect={(e) => { e.preventDefault(); setIsToggleEditMode(true) }}
+                >
+                  <SlidersHorizontal className="mr-2 h-4 w-4" />
+                  Customize…
+                </DropdownMenuItem>
               </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+            )}
+          </DropdownMenu>
         </div>
       </div>
 

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -313,10 +313,10 @@ export function Toolbar() {
     const isMas = window.api?.isMasBuild ?? false
     return [
       { id: 'new-document', label: 'New Document', icon: <FilePlus />, onSelect: handleNewFile },
-      { id: 'open', label: 'Open…', icon: <FolderOpen />, onSelect: () => openFile() },
+      { id: 'open', label: 'Open...', icon: <FolderOpen />, onSelect: () => openFile() },
       { id: 'save', label: 'Save', icon: <Save />, onSelect: saveFile },
-      { id: 'save-as', label: 'Save as…', icon: <FileDown />, onSelect: saveFileAs },
-      { id: 'export-html', label: 'Export HTML…', icon: <FileCode />, disabled: !document.content, onSelect: handleExportHtml },
+      { id: 'save-as', label: 'Save as...', icon: <FileDown />, onSelect: saveFileAs },
+      { id: 'export-html', label: 'Export HTML...', icon: <FileCode />, disabled: !document.content, onSelect: handleExportHtml },
       { id: 'settings', label: 'Settings', icon: <Settings />, separatorBefore: true, onSelect: () => setDialogOpen(true) },
       ...(!isMas
         ? [{ id: 'download-skill', label: 'Download Claude Skill', icon: <Sparkles />, onSelect: () => downloadSkillWithAlert() }]

--- a/src/renderer/components/layout/Toolbar.tsx
+++ b/src/renderer/components/layout/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, type KeyboardEvent } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo, type KeyboardEvent } from 'react'
 import { downloadSkillWithAlert } from '../../lib/skillDownload'
 import { requestBugReport } from '../EnableLoggingDialog'
 import { useEditor } from '../../hooks/useEditor'
@@ -18,9 +18,6 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import {
   DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '../ui/dropdown-menu'
 import {
@@ -39,6 +36,8 @@ import {
   AlertDialogTitle
 } from '../ui/alert-dialog'
 import { TabBar } from './TabBar'
+import { CustomizableMenu } from '../ui/CustomizableMenu'
+import type { CustomizableMenuItem } from '../ui/CustomizableMenu'
 import {
   Moon,
   Monitor,
@@ -307,6 +306,32 @@ export function Toolbar() {
     await createNewTab()
   }
 
+  // Build the items list for the "More options" customizable menu.
+  // Items are computed once per render — stable ids let the customization hook
+  // merge saved order/hidden with any new items added in future releases.
+  const moreMenuItems = useMemo((): CustomizableMenuItem[] => {
+    const isMas = window.api?.isMasBuild ?? false
+    return [
+      { id: 'new-document', label: 'New Document', icon: <FilePlus />, onSelect: handleNewFile },
+      { id: 'open', label: 'Open…', icon: <FolderOpen />, onSelect: () => openFile() },
+      { id: 'save', label: 'Save', icon: <Save />, onSelect: saveFile },
+      { id: 'save-as', label: 'Save as…', icon: <FileDown />, onSelect: saveFileAs },
+      { id: 'export-html', label: 'Export HTML…', icon: <FileCode />, disabled: !document.content, onSelect: handleExportHtml },
+      { id: 'settings', label: 'Settings', icon: <Settings />, separatorBefore: true, onSelect: () => setDialogOpen(true) },
+      ...(!isMas
+        ? [{ id: 'download-skill', label: 'Download Claude Skill', icon: <Sparkles />, onSelect: () => downloadSkillWithAlert() }]
+        : []),
+      ...(isMas
+        ? [{ id: 'support', label: 'Request Support', icon: <LifeBuoy />, separatorBefore: true, onSelect: () => window.open('https://solo.ist/prose/support', '_blank', 'noopener,noreferrer') }]
+        : [{ id: 'report-bug', label: 'Report a Bug', icon: <Bug />, separatorBefore: true, onSelect: () => requestBugReport('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml') }]),
+      { id: 'request-feature', label: 'Request a Feature', icon: <MessageSquarePlus />, onSelect: () => window.open('https://github.com/solo-ist/prose/issues/new?template=feature-request.yml', '_blank', 'noopener,noreferrer') },
+      { id: 'discuss-ideas', label: 'Discuss Ideas', icon: <MessagesSquare />, onSelect: () => window.open('https://github.com/solo-ist/prose/discussions/categories/ideas', '_blank', 'noopener,noreferrer') },
+      // Close is pinned: always last, not customizable
+      { id: 'close', label: 'Close', icon: <X />, onSelect: handleClose, pinned: true },
+    ]
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [document.content, handleExportHtml, handleClose, openFile, saveFile, saveFileAs, setDialogOpen])
+
   // Add left padding on macOS to clear traffic lights (less when fullscreen)
   const leftPadding = isMacOS() ? (isFullscreen ? 'pl-4' : 'pl-[88px]') : 'pl-4'
 
@@ -572,64 +597,7 @@ export function Toolbar() {
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleNewFile}>
-                <FilePlus className="mr-2 h-4 w-4" />
-                New Document
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => openFile()}>
-                <FolderOpen className="mr-2 h-4 w-4" />
-                Open...
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={saveFile}>
-                <Save className="mr-2 h-4 w-4" />
-                Save
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={saveFileAs}>
-                <FileDown className="mr-2 h-4 w-4" />
-                Save as...
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleExportHtml} disabled={!document.content}>
-                <FileCode className="mr-2 h-4 w-4" />
-                Export HTML...
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => setDialogOpen(true)}>
-                <Settings className="mr-2 h-4 w-4" />
-                Settings
-              </DropdownMenuItem>
-              {!window.api?.isMasBuild && (
-                <DropdownMenuItem onClick={() => downloadSkillWithAlert()}>
-                  <Sparkles className="mr-2 h-4 w-4" />
-                  Download Claude Skill
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuSeparator />
-              {window.api?.isMasBuild ? (
-                <DropdownMenuItem onClick={() => window.open('https://solo.ist/prose/support', '_blank', 'noopener,noreferrer')}>
-                  <LifeBuoy className="mr-2 h-4 w-4" />
-                  Request Support
-                </DropdownMenuItem>
-              ) : (
-                <DropdownMenuItem onClick={() => requestBugReport('https://github.com/solo-ist/prose/issues/new?template=bug-report.yml')}>
-                  <Bug className="mr-2 h-4 w-4" />
-                  Report a Bug
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem onClick={() => window.open('https://github.com/solo-ist/prose/issues/new?template=feature-request.yml', '_blank', 'noopener,noreferrer')}>
-                <MessageSquarePlus className="mr-2 h-4 w-4" />
-                Request a Feature
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => window.open('https://github.com/solo-ist/prose/discussions/categories/ideas', '_blank', 'noopener,noreferrer')}>
-                <MessagesSquare className="mr-2 h-4 w-4" />
-                Discuss Ideas
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleClose}>
-                <X className="mr-2 h-4 w-4" />
-                Close
-              </DropdownMenuItem>
-            </DropdownMenuContent>
+            <CustomizableMenu menuId="toolbar-more" items={moreMenuItems} align="end" />
           </DropdownMenu>
         </div>
       </div>

--- a/src/renderer/components/ui/CustomizableMenu.tsx
+++ b/src/renderer/components/ui/CustomizableMenu.tsx
@@ -28,7 +28,7 @@
  *     the menu on interaction. "Done" is a DropdownMenuItem which closes normally.
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, Fragment } from 'react'
 import type { ReactNode } from 'react'
 import { Eye, EyeOff, ChevronUp, ChevronDown, SlidersHorizontal, Check } from 'lucide-react'
 import {
@@ -208,7 +208,7 @@ export function CustomizableMenu({ menuId, items, align = 'end', className }: Pr
   return (
     <DropdownMenuContent align={align} className={className}>
       {visibleItems.map((item, idx) => (
-        <span key={item.id}>
+        <Fragment key={item.id}>
           {item.separatorBefore && idx > 0 && <DropdownMenuSeparator />}
           <DropdownMenuItem
             onClick={item.onSelect}
@@ -220,7 +220,7 @@ export function CustomizableMenu({ menuId, items, align = 'end', className }: Pr
             )}
             {item.label}
           </DropdownMenuItem>
-        </span>
+        </Fragment>
       ))}
 
       {/* Pinned items at the bottom, separated */}

--- a/src/renderer/components/ui/CustomizableMenu.tsx
+++ b/src/renderer/components/ui/CustomizableMenu.tsx
@@ -1,0 +1,253 @@
+/**
+ * CustomizableMenu — a DropdownMenuContent wrapper that adds iOS-style wiggle
+ * edit mode for reordering and hiding/showing menu items.
+ *
+ * Usage:
+ *
+ *   const items: CustomizableMenuItem[] = [
+ *     { id: 'new-file', label: 'New Document', icon: <FilePlus />, onSelect: handleNewFile },
+ *     { id: 'separator-1', separatorBefore: true },
+ *     { id: 'settings', label: 'Settings', icon: <Settings />, onSelect: openSettings },
+ *   ]
+ *
+ *   <DropdownMenu>
+ *     <DropdownMenuTrigger asChild>...</DropdownMenuTrigger>
+ *     <CustomizableMenu
+ *       menuId="toolbar-more"
+ *       items={items}
+ *       align="end"
+ *     />
+ *   </DropdownMenu>
+ *
+ * Notes:
+ *   - separatorBefore: true on an item renders a separator above it in the normal view.
+ *   - Pinned items (pinned: true) always appear at the bottom above "Customize…"
+ *     and cannot be hidden or reordered.
+ *   - The "Customize…" trigger is appended at the very bottom, below pinned items.
+ *   - In edit mode, regular <button> elements are used so Radix does not auto-close
+ *     the menu on interaction. "Done" is a DropdownMenuItem which closes normally.
+ */
+
+import { useState, useCallback } from 'react'
+import type { ReactNode } from 'react'
+import { Eye, EyeOff, ChevronUp, ChevronDown, SlidersHorizontal, Check } from 'lucide-react'
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from './dropdown-menu'
+import { cn } from '../../lib/utils'
+import { useMenuCustomization } from '../../hooks/useMenuCustomization'
+import type { MenuItemDescriptor } from '../../hooks/useMenuCustomization'
+
+export interface CustomizableMenuItem {
+  /** Stable, unique ID. Required for all items. */
+  id: string
+  label?: string
+  /** Icon element (16×16 recommended, pass raw JSX) */
+  icon?: ReactNode
+  /** When true, renders a separator above this item in the normal (non-edit) view. */
+  separatorBefore?: boolean
+  /** Callback on selection (normal mode only; not called in edit mode) */
+  onSelect?: () => void
+  /**
+   * Pinned items appear at the bottom (above "Customize…") and cannot be
+   * hidden or reordered. Use for structural items like "Close".
+   */
+  pinned?: boolean
+  /** When true, the item is rendered disabled. */
+  disabled?: boolean
+}
+
+interface Props {
+  menuId: string
+  items: CustomizableMenuItem[]
+  /** Forwarded to DropdownMenuContent */
+  align?: 'start' | 'center' | 'end'
+  className?: string
+}
+
+export function CustomizableMenu({ menuId, items, align = 'end', className }: Props) {
+  const [isEditing, setIsEditing] = useState(false)
+
+  // Separate pinned from customizable
+  const pinnedItems = items.filter((i) => i.pinned)
+  const customizableItems = items.filter((i) => !i.pinned)
+
+  const descriptors: MenuItemDescriptor[] = customizableItems.map((i) => ({
+    id: i.id,
+    label: i.label ?? i.id,
+  }))
+
+  const { visibleIds, hiddenIds, orderedAllIds, toggleHidden, moveUp, moveDown } =
+    useMenuCustomization(menuId, descriptors)
+
+  const itemById = new Map(customizableItems.map((i) => [i.id, i]))
+
+  const enterEdit = useCallback((e: Event) => {
+    // Prevent Radix from closing the dropdown when "Customize…" is selected
+    e.preventDefault()
+    setIsEditing(true)
+  }, [])
+
+  // --- Edit mode ---
+  if (isEditing) {
+    return (
+      <DropdownMenuContent
+        align={align}
+        className={cn('w-56', className)}
+        // Prevent closing when the user clicks inside (on the edit buttons)
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        onInteractOutside={() => setIsEditing(false)}
+        onEscapeKeyDown={() => setIsEditing(false)}
+      >
+        <div className="px-1 py-0.5 text-xs font-medium text-muted-foreground select-none mb-1">
+          Customize menu
+        </div>
+
+        {orderedAllIds.map((id, idx) => {
+          const item = itemById.get(id)
+          if (!item) return null
+          const isHidden = hiddenIds.includes(id)
+          return (
+            <div
+              key={id}
+              className={cn(
+                'flex items-center gap-1 px-1 py-0.5 rounded-sm',
+                isHidden && 'opacity-40'
+              )}
+            >
+              {/* Up / down reorder buttons */}
+              <div className="flex flex-col shrink-0 gap-0">
+                <button
+                  type="button"
+                  className="h-3.5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-25 focus:outline-none"
+                  onClick={(e) => { e.stopPropagation(); moveUp(id) }}
+                  disabled={idx === 0}
+                  aria-label={`Move ${item.label} up`}
+                  tabIndex={-1}
+                >
+                  <ChevronUp className="h-3 w-3" />
+                </button>
+                <button
+                  type="button"
+                  className="h-3.5 w-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-25 focus:outline-none"
+                  onClick={(e) => { e.stopPropagation(); moveDown(id) }}
+                  disabled={idx === orderedAllIds.length - 1}
+                  aria-label={`Move ${item.label} down`}
+                  tabIndex={-1}
+                >
+                  <ChevronDown className="h-3 w-3" />
+                </button>
+              </div>
+
+              {/* Item icon + label — wiggle in edit mode */}
+              <div className="flex flex-1 items-center gap-2 px-1 py-1 text-sm rounded-sm animate-wiggle select-none">
+                {item.icon && (
+                  <span className="[&_svg]:h-4 [&_svg]:w-4 shrink-0 text-muted-foreground">
+                    {item.icon}
+                  </span>
+                )}
+                <span className="truncate">{item.label}</span>
+              </div>
+
+              {/* Eye toggle */}
+              <button
+                type="button"
+                className="shrink-0 h-6 w-6 flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent focus:outline-none"
+                onClick={(e) => { e.stopPropagation(); toggleHidden(id) }}
+                aria-label={isHidden ? `Show ${item.label}` : `Hide ${item.label}`}
+                aria-pressed={isHidden}
+                tabIndex={-1}
+              >
+                {isHidden
+                  ? <EyeOff className="h-3.5 w-3.5" />
+                  : <Eye className="h-3.5 w-3.5" />
+                }
+              </button>
+            </div>
+          )
+        })}
+
+        {/* Pinned items shown greyed out (not customizable) */}
+        {pinnedItems.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            {pinnedItems.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground/50 select-none"
+              >
+                {item.icon && (
+                  <span className="[&_svg]:h-4 [&_svg]:w-4 shrink-0">{item.icon}</span>
+                )}
+                <span className="truncate">{item.label}</span>
+              </div>
+            ))}
+          </>
+        )}
+
+        <DropdownMenuSeparator />
+        {/* Done closes the menu via Radix's natural onSelect behaviour */}
+        <DropdownMenuItem
+          className="cursor-pointer font-medium"
+          onSelect={() => setIsEditing(false)}
+        >
+          <Check className="mr-2 h-4 w-4" />
+          Done
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    )
+  }
+
+  // --- Normal mode ---
+  const visibleItems = visibleIds
+    .map((id) => itemById.get(id))
+    .filter((i): i is CustomizableMenuItem => !!i)
+
+  return (
+    <DropdownMenuContent align={align} className={className}>
+      {visibleItems.map((item, idx) => (
+        <span key={item.id}>
+          {item.separatorBefore && idx > 0 && <DropdownMenuSeparator />}
+          <DropdownMenuItem
+            onClick={item.onSelect}
+            disabled={item.disabled}
+            className="cursor-pointer"
+          >
+            {item.icon && (
+              <span className="[&_svg]:h-4 [&_svg]:w-4 shrink-0">{item.icon}</span>
+            )}
+            {item.label}
+          </DropdownMenuItem>
+        </span>
+      ))}
+
+      {/* Pinned items at the bottom, separated */}
+      {pinnedItems.length > 0 && visibleItems.length > 0 && <DropdownMenuSeparator />}
+      {pinnedItems.map((item) => (
+        <DropdownMenuItem
+          key={item.id}
+          onClick={item.onSelect}
+          disabled={item.disabled}
+          className="cursor-pointer"
+        >
+          {item.icon && (
+            <span className="[&_svg]:h-4 [&_svg]:w-4 shrink-0">{item.icon}</span>
+          )}
+          {item.label}
+        </DropdownMenuItem>
+      ))}
+
+      {/* Customize trigger — always last */}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        className="cursor-pointer text-muted-foreground"
+        onSelect={enterEdit}
+      >
+        <SlidersHorizontal className="mr-2 h-4 w-4" />
+        Customize…
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  )
+}

--- a/src/renderer/hooks/useMenuCustomization.ts
+++ b/src/renderer/hooks/useMenuCustomization.ts
@@ -1,0 +1,92 @@
+import { useCallback, useMemo } from 'react'
+import { useSettingsStore } from '../stores/settingsStore'
+
+export interface MenuItemDescriptor {
+  /** Stable string ID — used as the key in the customization registry. */
+  id: string
+  label: string
+}
+
+/**
+ * Returns the ordered, filtered set of visible item IDs for a given menu,
+ * plus helpers to persist changes.
+ *
+ * Rules:
+ *  - Items unknown to the saved config append **visible** at the tail, so
+ *    upgrades that add new menu items never hide them for existing users.
+ *  - `hidden` items are excluded from `visibleIds`; they are presented
+ *    separately in the "Hidden" section of the customization UI.
+ */
+export function useMenuCustomization(menuId: string, allItems: MenuItemDescriptor[]) {
+  const menuCustomization = useSettingsStore((s) => s.settings.menuCustomization)
+  const setMenuCustomization = useSettingsStore((s) => s.setMenuCustomization)
+
+  const saved = menuCustomization?.[menuId]
+
+  // Merge saved config with the canonical item list.
+  // Items absent from the saved order append at the end.
+  const { visibleIds, hiddenIds, orderedAllIds } = useMemo(() => {
+    const allIds = allItems.map((i) => i.id)
+
+    if (!saved) {
+      return { visibleIds: allIds, hiddenIds: [] as string[], orderedAllIds: allIds }
+    }
+
+    const { order, hidden } = saved
+    // Start with saved order, filtered to only known ids
+    const knownOrdered = order.filter((id) => allIds.includes(id))
+    // Append ids that are new (not in saved order) so upgrades stay visible
+    const newIds = allIds.filter((id) => !order.includes(id))
+    const full = [...knownOrdered, ...newIds]
+
+    return {
+      visibleIds: full.filter((id) => !hidden.includes(id)),
+      hiddenIds: hidden.filter((id) => allIds.includes(id)),
+      orderedAllIds: full,
+    }
+  }, [allItems, saved])
+
+  const save = useCallback(
+    (order: string[], hidden: string[]) => {
+      setMenuCustomization(menuId, { order, hidden })
+    },
+    [menuId, setMenuCustomization]
+  )
+
+  /** Toggle a single item's hidden state. */
+  const toggleHidden = useCallback(
+    (id: string) => {
+      const currentHidden = hiddenIds.includes(id)
+        ? hiddenIds.filter((h) => h !== id)
+        : [...hiddenIds, id]
+      save(orderedAllIds, currentHidden)
+    },
+    [hiddenIds, orderedAllIds, save]
+  )
+
+  /** Move an item one position earlier in the order. */
+  const moveUp = useCallback(
+    (id: string) => {
+      const idx = orderedAllIds.indexOf(id)
+      if (idx <= 0) return
+      const next = [...orderedAllIds]
+      ;[next[idx - 1], next[idx]] = [next[idx], next[idx - 1]]
+      save(next, hiddenIds)
+    },
+    [orderedAllIds, hiddenIds, save]
+  )
+
+  /** Move an item one position later in the order. */
+  const moveDown = useCallback(
+    (id: string) => {
+      const idx = orderedAllIds.indexOf(id)
+      if (idx < 0 || idx >= orderedAllIds.length - 1) return
+      const next = [...orderedAllIds]
+      ;[next[idx], next[idx + 1]] = [next[idx + 1], next[idx]]
+      save(next, hiddenIds)
+    },
+    [orderedAllIds, hiddenIds, save]
+  )
+
+  return { visibleIds, hiddenIds, orderedAllIds, toggleHidden, moveUp, moveDown, save }
+}

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -106,6 +106,8 @@ interface SettingsState {
   addFavorite: (favorite: Favorite) => void
   removeFavorite: (id: string) => void
   updateFavorite: (id: string, patch: Partial<Omit<Favorite, 'id'>>) => void
+  // Menu customization
+  setMenuCustomization: (menuId: string, config: { order: string[]; hidden: string[] }) => void
 }
 
 const defaultSettings: Settings = {
@@ -620,6 +622,23 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
         favorites: (state.settings.favorites ?? []).map((f) =>
           f.id === id ? { ...f, ...patch } : f
         )
+      }
+    }))
+    get().saveSettings()
+  },
+
+  // -------------------------------------------------------------------------
+  // Menu customization
+  // -------------------------------------------------------------------------
+
+  setMenuCustomization: (menuId, config) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        menuCustomization: {
+          ...(state.settings.menuCustomization ?? {}),
+          [menuId]: config
+        }
       }
     }))
     get().saveSettings()

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -134,6 +134,12 @@ interface SettingsBase {
    * tied to a specific project; they appear in every project's file explorer.
    */
   favorites?: Favorite[]
+  /**
+   * Per-menu customization: visibility and ordering of items.
+   * Keys are stable menu IDs (e.g. 'toolbar-more', 'files-overflow', 'chat-history').
+   * Unknown/new item IDs append visible so upgrades never hide new menu items.
+   */
+  menuCustomization?: Record<string, { order: string[]; hidden: string[] }>
 }
 
 /**

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -67,11 +67,16 @@ module.exports = {
           "0%": { transform: "translateX(-100%)" },
           "100%": { transform: "translateX(400%)" },
         },
+        "wiggle": {
+          "0%, 100%": { transform: "rotate(-1deg)" },
+          "50%": { transform: "rotate(1deg)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "loading-bar": "loading-bar 1.5s ease-in-out infinite",
+        "wiggle": "wiggle 0.3s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Adds iOS-style **wiggle edit mode** to all three `…` menus: Toolbar "More options", FileListPanel header view-toggle overflow, and ChatPanel history dropdown footer
- Shared `useMenuCustomization` hook persists `{ order, hidden }` per menu in `settings.json`; new/unknown item IDs always append visible so upgrades never hide new items
- New `CustomizableMenu` component handles Toolbar's static items with full reorder + hide/show support
- FileListPanel composes customization with the existing width-responsive overflow logic — the filtered/ordered toggle set feeds directly into the existing `maxInlineToggles` calculation
- Added `animate-wiggle` Tailwind keyframe (±1° rotation)

## How it works

Each target menu now has a **"Customize…"** item pinned at the bottom. Clicking it enters edit mode (in-place, same dropdown stays open via `e.preventDefault()` on the Radix `onSelect`). Edit mode shows:
- Up/Down chevron buttons to reorder
- Eye/EyeOff button to hide/show
- Items wiggle (the `animate-wiggle` CSS keyframe)
- "Done" closes the menu and persists to `settings.json`

Click-outside or Escape while in edit mode exits back to normal mode.

## Test plan

- [x] `electron.customizable-menus.spec.ts` — 5 Playwright e2e tests against isolated `PROSE_USER_DATA_DIR` profile: all pass
  - Toolbar default items + Customize… presence
  - Enter/exit edit mode via Customize… / Done
  - Hide item → reopen → hidden; restore → visible (persistence)
  - Files header "More views" button with Customize…
  - Files header edit mode enter/exit
- [x] `npm run build` — clean build, no type errors
- [x] Smoke test regression: 3/4 pass (1 pre-existing flaky `editor mounts and accepts input` failure unrelated to this PR)

## Notes

- `Close` item in toolbar-more is `pinned: true` — always last, not customizable
- The `…` button in FileListPanel now always appears (was conditional on overflow) to ensure `Customize…` is always reachable regardless of panel width
- ChatPanel's conversation list is NOT customizable; only the static "New Chat" footer item is

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)