### PR TITLE
feat(editor): add AI provenance for create and paste

### DIFF
--- a/e2e/electron.ai-provenance.spec.ts
+++ b/e2e/electron.ai-provenance.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * AI provenance for content that does not come from normal in-app insert/edit
+ * tool calls (#570): create-from-scratch, MCP-style tool provenance, and paste.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  dismissOnboarding,
+  dismissOverlay,
+  waitForEditor,
+  executeProseTool,
+  getAnnotations,
+  getAnnotationDocId,
+  selectors,
+} from './helpers'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaDocsDir: string
+
+interface DocNode {
+  id: string
+  content?: string
+  children?: DocNode[]
+}
+
+async function nodeIdByText(testPage: Page, text: string): Promise<string> {
+  const result = await executeProseTool(testPage, 'read_document', {})
+  expect(result.success).toBe(true)
+  const flatten = (nodes: DocNode[]): DocNode[] =>
+    nodes.flatMap((node) => [node, ...(node.children ? flatten(node.children) : [])])
+  const match = flatten((result.data as { nodes: DocNode[] }).nodes).find((node) =>
+    (node.content ?? '').includes(text),
+  )
+  expect(match, `node containing "${text}"`).toBeTruthy()
+  return match!.id
+}
+
+async function pasteText(testPage: Page, text: string): Promise<void> {
+  await testPage.click(selectors.editor)
+  await testPage.evaluate((clipboardText) => {
+    const target = document.querySelector('.ProseMirror')
+    if (!target) throw new Error('Editor not found')
+
+    const data = new DataTransfer()
+    data.setData('text/plain', clipboardText)
+    const event = new Event('paste', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'clipboardData', { value: data })
+    target.dispatchEvent(event)
+  }, text)
+}
+
+test.beforeAll(async () => {
+  test.setTimeout(60_000)
+
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaDocsDir = mkdtempSync(join(tmpdir(), 'prose-qa-docs-'))
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', icon: 'default' },
+        defaultSaveDirectory: qaDocsDir,
+        featureFlags: { aiPipelineDebug: true },
+      },
+      null,
+      2,
+    ),
+  )
+
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaDocsDir, { recursive: true, force: true })
+})
+
+test.describe('Electron - AI provenance for create, MCP, and paste', () => {
+  test('create_and_open_file annotates the created document body', async () => {
+    const result = await executeProseTool(
+      page,
+      'create_and_open_file',
+      {
+        filename: 'provenance-create.md',
+        content: '# Generated Draft\n\nThis entire document came from the AI.',
+      },
+      'create',
+      {
+        model: 'Claude Test',
+        conversationId: 'conversation-create',
+        messageId: 'message-create',
+        documentId: 'previous-document',
+      },
+    )
+    expect(result.success).toBe(true)
+    await waitForEditor(page)
+
+    await expect
+      .poll(async () => getAnnotations(page), { timeout: 5_000 })
+      .toHaveLength(1)
+
+    const annotations = await getAnnotations(page)
+    const docId = await getAnnotationDocId(page)
+    expect(annotations[0].documentId).toBe(docId)
+    expect(annotations[0].type).toBe('insertion')
+    expect(annotations[0].from).toBe(0)
+    expect(Number(annotations[0].to)).toBeGreaterThan(0)
+    expect(annotations[0].provenance).toMatchObject({
+      model: 'Claude Test',
+      conversationId: 'conversation-create',
+      messageId: 'message-create',
+    })
+  })
+
+  test('MCP-style edit provenance reaches the annotation path', async () => {
+    const nodeId = await nodeIdByText(page, 'This entire document came from the AI.')
+    const docId = await getAnnotationDocId(page)
+    expect(docId).toBeTruthy()
+
+    const result = await executeProseTool(
+      page,
+      'edit',
+      {
+        nodeId,
+        search: 'This entire document came from the AI.',
+        content: 'This paragraph was revised from Claude Desktop.',
+        comment: 'MCP edit provenance',
+      },
+      'create',
+      {
+        model: 'Claude (MCP)',
+        conversationId: 'mcp-570',
+        messageId: 'mcp-edit-570',
+        documentId: docId!,
+      },
+    )
+    expect(result.success).toBe(true)
+
+    await expect
+      .poll(async () => getAnnotations(page), { timeout: 5_000 })
+      .toContainEqual(
+        expect.objectContaining({
+          provenance: expect.objectContaining({
+            model: 'Claude (MCP)',
+            conversationId: 'mcp-570',
+            messageId: 'mcp-edit-570',
+          }),
+        }),
+      )
+  })
+
+  test('sizable paste prompts and can be marked as externally AI-authored', async () => {
+    const pasted = [
+      'This pasted block came from another AI surface.',
+      '',
+      'It has enough structure to ask for provenance.',
+    ].join('\n')
+
+    await pasteText(page, pasted)
+
+    const dialog = page.getByRole('dialog', { name: 'Mark pasted text as AI-authored?' })
+    await expect(dialog).toBeVisible({ timeout: 5_000 })
+    await page.getByRole('button', { name: 'Mark as AI-authored' }).click()
+
+    await expect
+      .poll(async () => getAnnotations(page), { timeout: 5_000 })
+      .toContainEqual(
+        expect.objectContaining({
+          provenance: expect.objectContaining({
+            model: 'External AI',
+            conversationId: 'paste',
+          }),
+        }),
+      )
+  })
+
+  test('short single-line paste does not prompt', async () => {
+    await pasteText(page, 'short paste')
+
+    await expect(
+      page.getByRole('dialog', { name: 'Mark pasted text as AI-authored?' }),
+    ).toBeHidden({ timeout: 1_000 })
+  })
+})

--- a/e2e/shared.ts
+++ b/e2e/shared.ts
@@ -344,14 +344,15 @@ export async function executeProseTool(
   toolName: string,
   args: Record<string, unknown>,
   mode: 'chat' | 'editor' | 'create' = 'create',
+  provenance?: Record<string, string>,
 ): Promise<ProseToolResult> {
   return page.evaluate(
-    async ({ name, toolArgs, toolMode }) => {
+    async ({ name, toolArgs, toolMode, toolProvenance }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tools = (window as any).__prose_tools
-      return tools.executeTool(name, toolArgs, toolMode)
+      return tools.executeTool(name, toolArgs, toolMode, toolProvenance)
     },
-    { name: toolName, toolArgs: args, toolMode: mode },
+    { name: toolName, toolArgs: args, toolMode: mode, toolProvenance: provenance },
   )
 }
 

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -54,6 +54,15 @@ import { promoteCurrentPreview } from '../../hooks/useTabs'
 import { FindBar } from './FindBar'
 import { SelectionPopover } from './SelectionPopover'
 import { AddCommentDialog } from './AddCommentDialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { Button } from '../ui/button'
 import { EmptyState } from '../layout/EmptyState'
 import { FrontmatterDisplay, hasFrontmatter, getContentWithoutFrontmatter, getFrontmatterRaw } from './FrontmatterDisplay'
 import { FrontmatterEditor, serializeFrontmatter } from './FrontmatterEditor'
@@ -67,6 +76,21 @@ import { useCommentStore } from '../../extensions/comments/store'
 import { LinkPopover } from './LinkPopover'
 import { SourceEditor, SourceEditorHandle } from './SourceEditor'
 import { getApi } from '../../lib/browserApi'
+
+const AI_PASTE_PROMPT_MIN_CHARS = 200
+
+interface PendingPasteAnnotation {
+  documentId: string
+  from: number
+  to: number
+  text: string
+}
+
+function shouldPromptForAIPaste(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed) return false
+  return trimmed.length >= AI_PASTE_PROMPT_MIN_CHARS || trimmed.includes('\n')
+}
 
 // Lowlight instance with a curated set of common languages.
 // Using individual imports (not the full `common` preset) keeps the bundle
@@ -117,6 +141,7 @@ export function Editor() {
     to: number
     text: string
   } | null>(null)
+  const [pendingPasteAnnotation, setPendingPasteAnnotation] = useState<PendingPasteAnnotation | null>(null)
   const { isTransforming, startTransform, completeTransform } = useTransformAnimation()
 
   // Source mode: holds markdown content while CodeMirror is mounted
@@ -246,6 +271,52 @@ export function Editor() {
     editorProps: {
       attributes: {
         class: 'outline-none min-h-full'
+      },
+      handlePaste: (view, event) => {
+        const pastedText = event.clipboardData?.getData('text/plain') ?? ''
+        if (!shouldPromptForAIPaste(pastedText)) return false
+
+        const editorState = useEditorStore.getState()
+        if (
+          editorState.sourceMode ||
+          editorState.isRemarkableReadOnly ||
+          editorState.isPreviewTab ||
+          !editorState.document.documentId
+        ) {
+          return false
+        }
+
+        const documentId = editorState.document.documentId
+        const selectionFrom = view.state.selection.from
+        const selectionTo = view.state.selection.to
+        const replacedSize = selectionTo - selectionFrom
+        const sizeBefore = view.state.doc.content.size
+
+        setTimeout(() => {
+          const activeEditor = useEditorInstanceStore.getState().editor
+          const activeDocumentId = useEditorStore.getState().document.documentId
+          if (!activeEditor || activeDocumentId !== documentId) return
+
+          const sizeAfter = activeEditor.state.doc.content.size
+          const insertedSize = Math.max(0, sizeAfter - sizeBefore + replacedSize)
+          const selectionEnd = activeEditor.state.selection.from
+          const fallbackTo = selectionFrom + insertedSize
+          const annotationTo = Math.min(
+            activeEditor.state.doc.content.size,
+            Math.max(selectionEnd, fallbackTo)
+          )
+
+          if (annotationTo > selectionFrom) {
+            setPendingPasteAnnotation({
+              documentId,
+              from: selectionFrom,
+              to: annotationTo,
+              text: pastedText,
+            })
+          }
+        }, 0)
+
+        return false
       },
       handleDOMEvents: {
         mousedown: () => {
@@ -927,6 +998,40 @@ export function Editor() {
     setContent(currentBody)
   }, [setFrontmatter, setContent, editor])
 
+  const handleConfirmPasteAI = useCallback(() => {
+    if (!pendingPasteAnnotation) return
+
+    const activeDocumentId = useEditorStore.getState().document.documentId
+    const activeEditor = useEditorInstanceStore.getState().editor
+    if (activeDocumentId !== pendingPasteAnnotation.documentId || !activeEditor) {
+      setPendingPasteAnnotation(null)
+      return
+    }
+
+    const annotationTo = Math.min(
+      pendingPasteAnnotation.to,
+      activeEditor.state.doc.content.size
+    )
+    if (annotationTo > pendingPasteAnnotation.from) {
+      const messageId = `paste-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+      useAnnotationStore.getState().addAnnotation({
+        documentId: pendingPasteAnnotation.documentId,
+        type: 'insertion',
+        from: pendingPasteAnnotation.from,
+        to: annotationTo,
+        content: pendingPasteAnnotation.text,
+        provenance: {
+          model: 'External AI',
+          conversationId: 'paste',
+          messageId,
+        },
+        explanation: 'Marked pasted text as AI-authored',
+      })
+    }
+
+    setPendingPasteAnnotation(null)
+  }, [pendingPasteAnnotation])
+
   return (
     <div className="h-full flex flex-col relative">
       {/* Hide FindBar in source mode — CodeMirror has built-in Ctrl+F */}
@@ -1103,6 +1208,29 @@ export function Editor() {
           setPendingCommentSelection(null)
         }}
       />
+      <Dialog
+        open={pendingPasteAnnotation !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingPasteAnnotation(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Mark pasted text as AI-authored?</DialogTitle>
+            <DialogDescription>
+              Save provenance for this pasted block in the document activity.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingPasteAnnotation(null)}>
+              Not now
+            </Button>
+            <Button onClick={handleConfirmPasteAI}>
+              Mark as AI-authored
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       {editor && <AISuggestionPopover editor={editor} />}
       {editor && <CommentPopover editor={editor} />}
       {editor && (

--- a/src/renderer/lib/tools/executors/file.ts
+++ b/src/renderer/lib/tools/executors/file.ts
@@ -500,23 +500,25 @@ export async function executeCreateAndOpenFile(args: {
     if (provenance && content.trim().length > 0) {
       const editorDocument = useEditorStore.getState().document
       const annotationContent = editorDocument.content || content
-      const annotationTo =
-        await waitForEditorDocumentContent(editorDocument.documentId, annotationContent) ??
-        annotationContent.length
+      const annotationTo = await waitForEditorDocumentContent(editorDocument.documentId, annotationContent)
 
-      useAnnotationStore.getState().addAnnotation({
-        documentId: editorDocument.documentId,
-        type: 'insertion',
-        from: 0,
-        to: annotationTo,
-        content: annotationContent,
-        provenance: {
-          model: provenance.model,
-          conversationId: provenance.conversationId,
-          messageId: provenance.messageId,
-        },
-        explanation: `Created ${attemptFilename}`,
-      })
+      // Skip the annotation if the editor isn't ready yet — annotationTo must be a
+      // ProseMirror position (doc.content.size), not a raw character count.
+      if (annotationTo !== null) {
+        useAnnotationStore.getState().addAnnotation({
+          documentId: editorDocument.documentId,
+          type: 'insertion',
+          from: 0,
+          to: annotationTo,
+          content: annotationContent,
+          provenance: {
+            model: provenance.model,
+            conversationId: provenance.conversationId,
+            messageId: provenance.messageId,
+          },
+          explanation: `Created ${attemptFilename}`,
+        })
+      }
     }
 
     return toolSuccess({ path: fullPath, opened: true })

--- a/src/renderer/lib/tools/executors/file.ts
+++ b/src/renderer/lib/tools/executors/file.ts
@@ -6,6 +6,7 @@
 import type { ToolResult, FileItem } from '../../../../shared/tools/types'
 import { toolSuccess, toolError } from '../../../../shared/tools/types'
 import { useEditorStore } from '../../../stores/editorStore'
+import { useEditorInstanceStore } from '../../../stores/editorInstanceStore'
 import { useChatStore, setCurrentDocumentId } from '../../../stores/chatStore'
 import { useSettingsStore } from '../../../stores/settingsStore'
 import { useFileListStore } from '../../../stores/fileListStore'
@@ -21,11 +22,40 @@ import {
 import { useTabStore, generateUntitledTitle } from '../../../stores/tabStore'
 import { useSuggestionStore } from '../../../extensions/ai-suggestions/store'
 
+interface ToolProvenance {
+  model: string
+  conversationId: string
+  messageId: string
+  documentId: string
+}
+
 /**
  * Get the Electron API.
  */
 function getApi() {
   return window.api
+}
+
+async function waitForEditorDocumentContent(documentId: string, markdown: string): Promise<number | null> {
+  const expected = markdown.trim()
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const editor = useEditorInstanceStore.getState().editor
+    const activeDocumentId = useEditorStore.getState().document.documentId
+    const currentMarkdown = editor?.storage.markdown?.getMarkdown?.()
+
+    if (
+      editor &&
+      activeDocumentId === documentId &&
+      (!expected || currentMarkdown?.trim() === expected)
+    ) {
+      return editor.state.doc.content.size
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 16))
+  }
+
+  return null
 }
 
 /**
@@ -418,7 +448,7 @@ export async function executeReadFile(args: {
 export async function executeCreateAndOpenFile(args: {
   filename?: string
   content?: string
-}): Promise<ToolResult<{ path: string; opened: boolean }>> {
+}, provenance?: ToolProvenance): Promise<ToolResult<{ path: string; opened: boolean }>> {
   const api = getApi()
 
   if (!api) {
@@ -465,6 +495,28 @@ export async function executeCreateAndOpenFile(args: {
         `File created at ${fullPath} but failed to open: ${openResult.error}`,
         'OPEN_FAILED'
       )
+    }
+
+    if (provenance && content.trim().length > 0) {
+      const editorDocument = useEditorStore.getState().document
+      const annotationContent = editorDocument.content || content
+      const annotationTo =
+        await waitForEditorDocumentContent(editorDocument.documentId, annotationContent) ??
+        annotationContent.length
+
+      useAnnotationStore.getState().addAnnotation({
+        documentId: editorDocument.documentId,
+        type: 'insertion',
+        from: 0,
+        to: annotationTo,
+        content: annotationContent,
+        provenance: {
+          model: provenance.model,
+          conversationId: provenance.conversationId,
+          messageId: provenance.messageId,
+        },
+        explanation: `Created ${attemptFilename}`,
+      })
     }
 
     return toolSuccess({ path: fullPath, opened: true })

--- a/src/renderer/lib/tools/index.ts
+++ b/src/renderer/lib/tools/index.ts
@@ -145,7 +145,7 @@ export async function executeTool(
       case 'read_file':
         return await executeReadFile(validatedArgs)
       case 'create_and_open_file':
-        return await executeCreateAndOpenFile(validatedArgs)
+        return await executeCreateAndOpenFile(validatedArgs, provenance)
 
       // Tab tools
       case 'list_tabs':


### PR DESCRIPTION
Closes #570

## Summary
- Annotates AI-created documents from create_and_open_file with model, timestamp, and create rationale.
- Carries MCP-style provenance into create/edit paths through the renderer tool dispatcher.
- Adds a paste confirmation dialog for multi-line or 200+ character pasted text so users can mark it as externally AI-authored.

## Verification
1. npm run build
2. npm run test:e2e:dev -- e2e/electron.ai-provenance.spec.ts

## Notes
- Hot-file touch: src/renderer/components/editor/Editor.tsx, limited to paste detection and the provenance confirmation dialog.
- Local npm run typecheck:e2e is blocked in this dirty worktree by an unrelated current-branch error in e2e/electron.file-explorer-qa.spec.ts.
