### PR TITLE
Fix stale file path recovery (#727)

### DIFF
--- a/docs/issues/727/plan.md
+++ b/docs/issues/727/plan.md
@@ -1,0 +1,20 @@
+# Issue 727: Stale File Path Recovery
+
+## Summary
+
+Treat missing read/save targets as recoverable stale-path states rather than raw IPC failures. Missing files and missing parent folders should notify the user, prune dead Recents entries, keep unsaved edits dirty, and route manual saves through Save As.
+
+## Implementation Notes
+
+- `file:save` and `file:read` return structured success/failure results from the main process.
+- The preload layer unwraps those results so existing renderer calls can keep using `saveFile()` and `readFile()` with their current signatures.
+- Renderer handling detects `ENOENT`/`ENOTDIR`, shows a toast, removes stale Recents entries, and prevents unhandled promise rejections.
+- Autosave blocks repeated retries for the failed path until the document path changes.
+- Session recovery converts missing saved paths into dirty unsaved tabs using the cached session content.
+
+## Verification
+
+- Build: `npm run build`
+- E2E typecheck: `npm run typecheck:e2e`
+- Targeted E2E: `npm run test:e2e:dev -- e2e/electron.stale-paths.spec.ts --workers=1 --retries=0`
+- Manual QA: open a document, remove its parent folder externally, edit, save, and confirm Save As is offered while edits remain dirty.

--- a/e2e/electron.stale-paths.spec.ts
+++ b/e2e/electron.stale-paths.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression coverage for stale file paths (#727).
+ *
+ * Uses an isolated PROSE_USER_DATA_DIR profile so seeded recents/session state
+ * never touches the developer's real settings or IndexedDB profile.
+ */
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  launchApp,
+  waitForAppReady,
+  waitForEditor,
+  dismissOnboarding,
+  dismissOverlay,
+  executeProseTool,
+  getEditorMarkdown,
+  selectors,
+} from './helpers'
+import { ensureFileListOpen } from './shared'
+
+let app: ElectronApplication
+let page: Page
+let qaUserDataDir: string
+let qaDocsDir: string
+let staleDir: string
+let stalePath: string
+let relocatedPath: string
+let existingRecentPath: string
+let missingRecentPath: string
+let sessionMissingPath: string
+
+function writeSettings(): void {
+  writeFileSync(
+    join(qaUserDataDir, 'settings.json'),
+    JSON.stringify(
+      {
+        appearance: { mode: 'dark', color: 'mono', icon: 'pilcrow', migrationToastShown: true },
+        fileAssociation: { hasBeenPrompted: true },
+        aiConsent: { consented: false, consentedAt: new Date().toISOString(), version: 1 },
+        recovery: { mode: 'silent' },
+        autosave: { mode: 'off', intervalSeconds: 30 },
+        defaultSaveDirectory: qaDocsDir,
+        recentFiles: [missingRecentPath, existingRecentPath],
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+async function launchIsolatedApp(): Promise<void> {
+  const launched = await launchApp({ env: { PROSE_USER_DATA_DIR: qaUserDataDir } })
+  app = launched.app
+  page = launched.page
+  await waitForAppReady(page)
+  await dismissOnboarding(page)
+  await dismissOverlay(page)
+}
+
+async function stubSaveDialog(filePath: string): Promise<void> {
+  await app.evaluate(
+    ({ dialog }, targetPath) => {
+      const globalState = globalThis as typeof globalThis & {
+        __proseOriginalShowSaveDialog?: typeof dialog.showSaveDialog
+      }
+      if (!globalState.__proseOriginalShowSaveDialog) {
+        globalState.__proseOriginalShowSaveDialog = dialog.showSaveDialog
+      }
+      dialog.showSaveDialog = async () => ({ canceled: false, filePath: targetPath })
+    },
+    filePath,
+  )
+}
+
+async function seedSession(session: unknown): Promise<void> {
+  await page.evaluate(async (state) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('prose-db')
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction('drafts', 'readwrite')
+      tx.objectStore('drafts').put(state, 'session')
+      tx.onerror = () => reject(tx.error)
+      tx.oncomplete = () => resolve()
+    })
+
+    db.close()
+  }, session)
+}
+
+async function openRecentView(): Promise<void> {
+  await ensureFileListOpen(page)
+
+  const recentButton = page.getByRole('button', { name: 'Recent files' })
+  if (await recentButton.isVisible({ timeout: 500 }).catch(() => false)) {
+    await recentButton.click()
+    return
+  }
+
+  await page.getByRole('button', { name: 'More views' }).click()
+  await page.getByRole('menuitem', { name: 'Recent files' }).click()
+}
+
+async function setEditorContentWithUpdate(html: string): Promise<void> {
+  await page.evaluate((content) => {
+    const editor = (window as typeof window & {
+      __prose_editor?: { commands: { setContent: (html: string, emitUpdate: boolean) => void } }
+    }).__prose_editor
+    editor?.commands.setContent(content, true)
+  }, html)
+}
+
+test.beforeAll(async () => {
+  test.setTimeout(180_000)
+
+  qaUserDataDir = mkdtempSync(join(tmpdir(), 'prose-qa-profile-'))
+  qaDocsDir = mkdtempSync(join(tmpdir(), 'prose-qa-docs-'))
+  staleDir = join(qaDocsDir, 'stale-parent')
+  stalePath = join(staleDir, 'post.md')
+  relocatedPath = join(qaDocsDir, 'relocated-post.md')
+  existingRecentPath = join(qaDocsDir, 'existing-recent.md')
+  missingRecentPath = join(qaDocsDir, 'missing-recent.md')
+  sessionMissingPath = join(qaDocsDir, 'missing-session.md')
+
+  mkdirSync(staleDir, { recursive: true })
+  writeFileSync(stalePath, '# Original\n\nBefore move.\n')
+  writeFileSync(existingRecentPath, '# Existing recent\n')
+  writeSettings()
+
+  await launchIsolatedApp()
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  rmSync(qaUserDataDir, { recursive: true, force: true })
+  rmSync(qaDocsDir, { recursive: true, force: true })
+})
+
+test.describe('Electron - stale file path recovery', () => {
+  test('prunes missing files from the in-app Recents view', async () => {
+    await openRecentView()
+    const panel = page.locator(selectors.fileListPanel)
+
+    await expect(panel.getByText('existing-recent.md')).toBeVisible({ timeout: 5_000 })
+    await expect(panel.getByText('missing-recent.md')).not.toBeVisible({ timeout: 5_000 })
+
+    await expect.poll(async () => {
+      const settings = await page.evaluate(async () => (window as any).api.loadSettings())
+      return settings.recentFiles ?? []
+    }).toEqual([existingRecentPath])
+  })
+
+  test('manual save to a removed parent folder relocates through Save As', async () => {
+    const opened = await executeProseTool(page, 'open_file', { path: stalePath })
+    expect(opened.success).toBe(true)
+    await waitForEditor(page)
+
+    rmSync(staleDir, { recursive: true, force: true })
+    await stubSaveDialog(relocatedPath)
+
+    await setEditorContentWithUpdate('<h1>Relocated</h1><p>Kept edits.</p>')
+    await expect.poll(() => getEditorMarkdown(page), { timeout: 5_000 }).toContain('Kept edits')
+    await page.waitForTimeout(700)
+    await page.getByRole('button', { name: 'More options' }).click()
+    await page.getByRole('menuitem', { name: 'Save', exact: true }).click()
+
+    await expect.poll(() => existsSync(relocatedPath), { timeout: 5_000 }).toBe(true)
+    expect(readFileSync(relocatedPath, 'utf8')).toContain('Kept edits')
+    expect(existsSync(staleDir)).toBe(false)
+  })
+
+  test('session restore converts a missing saved path into cached unsaved content', async () => {
+    const session = {
+      tabs: [
+        {
+          tabId: 'stale-session-tab',
+          documentId: 'stale-session-doc',
+          path: sessionMissingPath,
+          title: 'missing-session',
+          content: '# Cached Session\n\nRecovered from IndexedDB.\n',
+          isDirty: false,
+          frontmatter: {},
+          cursorPosition: { line: 1, column: 1 },
+          activeChatId: null,
+        },
+      ],
+      activeTabId: 'stale-session-tab',
+      savedAt: Date.now(),
+    }
+
+    await seedSession(session)
+    await app.close()
+
+    await launchIsolatedApp()
+    await waitForEditor(page)
+
+    await expect(page.getByText(/missing-session\.md" no longer exists/i)).toBeVisible({ timeout: 5_000 })
+    await expect.poll(() => getEditorMarkdown(page), { timeout: 5_000 }).toContain('Recovered from IndexedDB')
+  })
+})

--- a/e2e/electron.stale-paths.spec.ts
+++ b/e2e/electron.stale-paths.spec.ts
@@ -167,7 +167,9 @@ test.describe('Electron - stale file path recovery', () => {
 
     await setEditorContentWithUpdate('<h1>Relocated</h1><p>Kept edits.</p>')
     await expect.poll(() => getEditorMarkdown(page), { timeout: 5_000 }).toContain('Kept edits')
-    await page.waitForTimeout(700)
+    // Wait for the dirty indicator to confirm the edit registered before opening the save menu.
+    // Autosave is off in this test profile, so "unsaved" appears in the status bar once isDirty=true.
+    await expect(page.getByText('unsaved')).toBeVisible({ timeout: 5_000 })
     await page.getByRole('button', { name: 'More options' }).click()
     await page.getByRole('menuitem', { name: 'Save', exact: true }).click()
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { getSettingsDir, LEGACY_SETTINGS_DIR } from './paths'
 import { clearRecentFiles } from './recentFiles'
 import { refreshMenu, setReopenClosedTabEnabled } from './menu'
 import { credentialStore } from './credentialStore'
+import { toFileOperationFailure, type ReadFileResult, type SaveFileResult } from '../shared/fileOperationResult'
 
 // Credential store keys
 const LLM_API_KEY = 'llm-api-key'
@@ -195,15 +196,25 @@ export function setupIpcHandlers(): void {
   })
 
   // File: Save content to path
-  ipcMain.handle('file:save', async (_event, path: string, content: string) => {
-    const safePath = validatePath(path)
-    await writeFile(safePath, content, 'utf-8')
+  ipcMain.handle('file:save', async (_event, path: string, content: string): Promise<SaveFileResult> => {
+    try {
+      const safePath = validatePath(path)
+      await writeFile(safePath, content, 'utf-8')
+      return { ok: true }
+    } catch (error) {
+      return toFileOperationFailure(path, error)
+    }
   })
 
   // File: Read file at path
-  ipcMain.handle('file:read', async (_event, path: string) => {
-    const safePath = validatePath(path)
-    return await readFile(safePath, 'utf-8')
+  ipcMain.handle('file:read', async (_event, path: string): Promise<ReadFileResult> => {
+    try {
+      const safePath = validatePath(path)
+      const content = await readFile(safePath, 'utf-8')
+      return { ok: true, content }
+    } catch (error) {
+      return toFileOperationFailure(path, error)
+    }
   })
 
   // File: Read binary file as base64

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { Settings, RemarkableSyncPhase, IconId } from '../renderer/types'
 import type { ToolResult } from '../shared/tools/types'
+import {
+  unwrapReadFileResult,
+  unwrapSaveFileResult,
+  type ReadFileResult,
+  type SaveFileResult
+} from '../shared/fileOperationResult'
 
 export interface FileResult {
   path: string
@@ -349,11 +355,17 @@ export interface RemarkableSyncState {
 
 const api: ElectronAPI = {
   openFile: () => ipcRenderer.invoke('file:open'),
-  saveFile: (path: string, content: string) => ipcRenderer.invoke('file:save', path, content),
+  saveFile: async (path: string, content: string) => {
+    const result = await ipcRenderer.invoke('file:save', path, content) as SaveFileResult
+    unwrapSaveFileResult(result)
+  },
   saveFileAs: (content: string, defaultFilename?: string) => ipcRenderer.invoke('file:saveAs', content, defaultFilename),
   exportTxt: (content: string, defaultFilename?: string) => ipcRenderer.invoke('file:exportTxt', content, defaultFilename),
   exportHtml: (content: string, defaultFilename?: string) => ipcRenderer.invoke('file:exportHtml', content, defaultFilename),
-  readFile: (path: string) => ipcRenderer.invoke('file:read', path),
+  readFile: async (path: string) => {
+    const result = await ipcRenderer.invoke('file:read', path) as ReadFileResult
+    return unwrapReadFileResult(result)
+  },
   readFileBase64: (path: string) => ipcRenderer.invoke('file:readBase64', path),
   loadSettings: () => ipcRenderer.invoke('settings:load'),
   saveSettings: (settings: Settings) => ipcRenderer.invoke('settings:save', settings),

--- a/src/renderer/components/editor/Editor.tsx
+++ b/src/renderer/components/editor/Editor.tsx
@@ -623,7 +623,9 @@ export function Editor() {
       openFile()
     } else if (isMod && e.key === 's' && !e.shiftKey) {
       e.preventDefault()
-      saveFile()
+      saveFile().catch((error) => {
+        console.error('[Editor] Failed to save from shortcut:', error)
+      })
     } else if (isMod && e.key === ',') {
       e.preventDefault()
       setDialogOpen(true)

--- a/src/renderer/components/files/FileListPanel.tsx
+++ b/src/renderer/components/files/FileListPanel.tsx
@@ -44,6 +44,7 @@ import { History, Cloud, Plus, FileText, BookOpen, CloudOff, ChevronUp, ChevronL
 import { useSettings } from '../../hooks/useSettings'
 import { cn } from '../../lib/utils'
 import { getApi } from '../../lib/browserApi'
+import { pruneMissingRecentFiles } from '../../lib/stalePath'
 import { requestBugReport } from '../EnableLoggingDialog'
 import type { RemarkableNotebookMetadata, RemarkableCloudNotebook, GoogleDocEntry } from '../../types'
 import { ProjectsPanel } from './ProjectsPanel'
@@ -614,6 +615,13 @@ export function FileListPanel() {
       }
     }
   }, [viewMode, googleConnected]) // Intentionally exclude googleSync and isGoogleSyncing to only trigger on view change
+
+  useEffect(() => {
+    if (viewMode !== 'recent' || recentFiles.length === 0) return
+    pruneMissingRecentFiles(recentFiles).catch((error) => {
+      console.error('[FileListPanel] Failed to prune missing recent files:', error)
+    })
+  }, [viewMode, recentFiles])
 
   const handleFileClick = async (path: string) => {
     selectFile(path)

--- a/src/renderer/components/layout/App.tsx
+++ b/src/renderer/components/layout/App.tsx
@@ -59,6 +59,7 @@ import {
   deleteConversations
 } from '../../lib/persistence'
 import { extractFirstH1 } from '../../lib/markdown'
+import { handleMissingPath } from '../../lib/stalePath'
 import type { DraftState, SessionState } from '../../lib/persistence'
 import { executeTool } from '../../lib/tools'
 import { useReviewMode, useWasChatOpenBeforeReview, usePreviousChatWidth, useReviewStore, type ReviewMode } from '../../stores/reviewStore'
@@ -242,14 +243,25 @@ export function App() {
       for (let i = 0; i < session.tabs.length; i++) {
         const tabDraft = session.tabs[i]
         const isActiveTab = tabDraft.tabId === session.activeTabId
+        let restoredPath = tabDraft.path
+        let restoredIsDirty = tabDraft.isDirty
+
+        if (tabDraft.path && window.api) {
+          const exists = await window.api.fileExists(tabDraft.path).catch(() => false)
+          if (!exists) {
+            handleMissingPath(tabDraft.path, 'restore')
+            restoredPath = null
+            restoredIsDirty = true
+          }
+        }
 
         addTab({
           id: tabDraft.tabId,
           documentId: tabDraft.documentId,
-          path: tabDraft.path,
+          path: restoredPath,
           title: tabDraft.title,
           baseTitle: tabDraft.baseTitle,
-          isDirty: tabDraft.isDirty,
+          isDirty: restoredIsDirty,
           content: tabDraft.content,
           frontmatter: tabDraft.frontmatter,
           cursorPosition: tabDraft.cursorPosition
@@ -261,10 +273,10 @@ export function App() {
           useEditorStore.setState({
             document: {
               documentId: tabDraft.documentId,
-              path: tabDraft.path,
+              path: restoredPath,
               content: documentContent,
               frontmatter: tabDraft.frontmatter ?? {},
-              isDirty: tabDraft.isDirty
+              isDirty: restoredIsDirty
             }
           })
           setCurrentDocumentId(tabDraft.documentId)
@@ -699,14 +711,20 @@ export function App() {
               if (result) {
                 await openFileInTab(result.path)
               }
+            }).catch((error) => {
+              console.error('[App] Failed to open file from menu:', error)
             })
           }
           break
         case 'save':
-          saveFile()
+          saveFile().catch((error) => {
+            console.error('[App] Failed to save from menu:', error)
+          })
           break
         case 'saveAs':
-          saveFileAs()
+          saveFileAs().catch((error) => {
+            console.error('[App] Failed to save as from menu:', error)
+          })
           break
         case 'exportHtml':
           // Delegate to Toolbar, which owns the export handler
@@ -852,7 +870,9 @@ export function App() {
           // Handle openRecentFile:${path} actions
           if (action.startsWith('openRecentFile:')) {
             const filePath = action.slice('openRecentFile:'.length)
-            openFileInTab(filePath)
+            openFileInTab(filePath).catch((error) => {
+              console.error('[App] Failed to open recent file from menu:', error)
+            })
           }
           break
       }

--- a/src/renderer/hooks/useAutosave.ts
+++ b/src/renderer/hooks/useAutosave.ts
@@ -3,6 +3,7 @@ import { useEditorStore } from '../stores/editorStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useEditorInstanceStore } from '../stores/editorInstanceStore'
 import { serializeMarkdown } from '../lib/markdown'
+import { handleMissingPath, isMissingPathFileError } from '../lib/stalePath'
 
 /**
  * Hook that handles automatic saving of documents.
@@ -14,6 +15,7 @@ import { serializeMarkdown } from '../lib/markdown'
 export function useAutosave() {
   const timerRef = useRef<NodeJS.Timeout | null>(null)
   const isSavingRef = useRef(false)
+  const blockedPathRef = useRef<string | null>(null)
   const editorUnsubscribeRef = useRef<(() => void) | null>(null)
 
   const clearTimer = useCallback(() => {
@@ -30,7 +32,12 @@ export function useAutosave() {
     // - Already saving
     // - No file path (new unsaved document)
     // - Document is not dirty
-    if (isSavingRef.current || !document.path || !document.isDirty) {
+    if (
+      isSavingRef.current ||
+      !document.path ||
+      !document.isDirty ||
+      blockedPathRef.current === document.path
+    ) {
       return
     }
 
@@ -45,12 +52,30 @@ export function useAutosave() {
         new Promise((r) => setTimeout(r, 500))
       ])
       setDirty(false)
+      blockedPathRef.current = null
     } catch (error) {
+      if (isMissingPathFileError(error)) {
+        blockedPathRef.current = document.path
+        clearTimer()
+        handleMissingPath(document.path, 'autosave')
+        return
+      }
       console.error('[Autosave] Failed to save:', error)
     } finally {
       isSavingRef.current = false
       setAutosaving(false)
     }
+  }, [clearTimer])
+
+  useEffect(() => {
+    return useEditorStore.subscribe(
+      (state) => state.document.path,
+      (path) => {
+        if (path !== blockedPathRef.current) {
+          blockedPathRef.current = null
+        }
+      }
+    )
   }, [])
 
   useEffect(() => {

--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -3,8 +3,10 @@ import { useEditorStore } from '../stores/editorStore'
 import { useChatStore, setCurrentDocumentId } from '../stores/chatStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useFileListStore } from '../stores/fileListStore'
+import { useNotificationStore } from '../stores/notificationStore'
 import { parseMarkdown, serializeMarkdown, extractFirstH1, prepareTextContent } from '../lib/markdown'
 import { extractMarkdownFromHtml } from '../lib/htmlExport'
+import { handleMissingPath, isMissingPathFileError } from '../lib/stalePath'
 import {
   generateId,
   generateIdFromPath,
@@ -29,6 +31,10 @@ function buildSaveContent(
     return content
   }
   return serializeMarkdown(content, frontmatter)
+}
+
+function getPathFilename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? 'document.md'
 }
 
 export function useEditor() {
@@ -121,6 +127,9 @@ export function useEditor() {
       const conversations = useChatStore.getState().conversations
       return parsed.content.trim().length > 0 && conversations.length === 0
     } catch (error) {
+      if (isMissingPathFileError(error)) {
+        handleMissingPath(filePath, 'open')
+      }
       console.error('Failed to open file:', error)
       return false
     }
@@ -186,18 +195,10 @@ export function useEditor() {
     return false
   }, [setDocument, document.documentId, saveCurrentConversation, loadForDocument, setEditing])
 
-  const saveFile = useCallback(async () => {
+  const saveContentAs = useCallback(async (content: string, defaultFilename?: string | null) => {
     if (!window.api) return
-    const content = buildSaveContent(document.content, document.frontmatter, document.path)
-
-    if (document.path) {
-      await window.api.saveFile(document.path, content)
-      setDirty(false)
-    } else {
-      // Pre-fill the Save As dialog with the H1 heading (sanitized) if available
-      const h1 = extractFirstH1(document.content)
-      const defaultFilename = h1 ? sanitizeFilename(h1) + '.md' : undefined
-      const path = await window.api.saveFileAs(content, defaultFilename)
+    try {
+      const path = await window.api.saveFileAs(content, defaultFilename ?? undefined)
       if (path) {
         // Migrate chat history to path-based ID
         const newDocumentId = await generateIdFromPath(path)
@@ -230,8 +231,45 @@ export function useEditor() {
         setDirty(false)
         setCurrentDocumentId(newDocumentId)
       }
+    } catch (error) {
+      console.error('Failed to save file as:', error)
+      useNotificationStore.getState().notify({
+        id: 'save-as-failed',
+        message: 'Could not save this document. Choose another location and try again.',
+        durationMs: 0
+      })
     }
-  }, [document, setDirty, setDocument])
+  }, [setDocument, setDirty])
+
+  const saveFile = useCallback(async () => {
+    if (!window.api) return
+    const content = buildSaveContent(document.content, document.frontmatter, document.path)
+
+    if (document.path) {
+      try {
+        await window.api.saveFile(document.path, content)
+        setDirty(false)
+      } catch (error) {
+        if (isMissingPathFileError(error)) {
+          handleMissingPath(document.path, 'save')
+          await saveContentAs(content, getPathFilename(document.path))
+          return
+        }
+
+        console.error('Failed to save file:', error)
+        useNotificationStore.getState().notify({
+          id: `save-failed:${document.path}`,
+          message: `Could not save "${getPathFilename(document.path)}". Use Save As to keep your edits.`,
+          durationMs: 0
+        })
+      }
+    } else {
+      // Pre-fill the Save As dialog with the H1 heading (sanitized) if available
+      const h1 = extractFirstH1(document.content)
+      const defaultFilename = h1 ? sanitizeFilename(h1) + '.md' : undefined
+      await saveContentAs(content, defaultFilename)
+    }
+  }, [document, saveContentAs, setDirty])
 
   const saveFileAs = useCallback(async () => {
     if (!window.api) return
@@ -239,40 +277,8 @@ export function useEditor() {
     // Pre-fill the Save As dialog with the H1 heading (sanitized) if the document is untitled
     const h1 = !document.path ? extractFirstH1(document.content) : null
     const defaultFilename = h1 ? sanitizeFilename(h1) + '.md' : undefined
-    const path = await window.api.saveFileAs(content, defaultFilename)
-    if (path) {
-      // Migrate chat history to path-based ID
-      const newDocumentId = await generateIdFromPath(path)
-      const conversations = useChatStore.getState().conversations
-
-      // Save conversations under new path-based ID
-      if (conversations.length > 0) {
-        const migratedConversations = conversations.map((c) => ({
-          ...c,
-          documentId: newDocumentId
-        }))
-        await saveConversations(newDocumentId, migratedConversations)
-        useChatStore.setState({ conversations: migratedConversations })
-      }
-
-      // Migrate annotations to path-based ID
-      const annotations = useAnnotationStore.getState().annotations
-      if (annotations.length > 0) {
-        const migratedAnnotations = annotations.map((a) => ({
-          ...a,
-          documentId: newDocumentId
-        }))
-        await saveAnnotations(newDocumentId, migratedAnnotations)
-        useAnnotationStore.setState({ annotations: migratedAnnotations, documentId: newDocumentId })
-      } else {
-        useAnnotationStore.getState().setDocumentId(newDocumentId)
-      }
-
-      setDocument({ documentId: newDocumentId, path })
-      setDirty(false)
-      setCurrentDocumentId(newDocumentId)
-    }
-  }, [document, setDocument, setDirty])
+    await saveContentAs(content, defaultFilename)
+  }, [document, saveContentAs])
 
   const newFile = useCallback(async () => {
     // Save current conversations before switching
@@ -352,7 +358,12 @@ export function useEditor() {
       if (isRename && oldPath) {
         // Rename the file: save new content to new path, then delete old file
         await window.api.saveFile(finalPath, content)
-        await window.api.deleteFile(oldPath)
+        try {
+          await window.api.deleteFile(oldPath)
+        } catch (error) {
+          if (!isMissingPathFileError(error)) throw error
+          handleMissingPath(oldPath, 'save')
+        }
       } else {
         // New file or same name: just save
         await window.api.saveFile(finalPath, content)
@@ -393,10 +404,15 @@ export function useEditor() {
 
       return true
     } catch (error) {
+      if (oldPath && isMissingPathFileError(error)) {
+        handleMissingPath(oldPath, 'save')
+        await saveContentAs(content, getPathFilename(oldPath))
+        return !useEditorStore.getState().document.isDirty
+      }
       console.error('Failed to quick save:', error)
       return false
     }
-  }, [document, setDocument, setDirty])
+  }, [document, saveContentAs, setDocument, setDirty])
 
   return {
     document,

--- a/src/renderer/hooks/useTabs.ts
+++ b/src/renderer/hooks/useTabs.ts
@@ -12,6 +12,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useFileListStore } from '../stores/fileListStore'
 import { parseMarkdown, serializeMarkdown, prepareTextContent } from '../lib/markdown'
 import { pipelineLog } from '../lib/aiPipelineLog'
+import { handleMissingPath, isMissingPathFileError } from '../lib/stalePath'
 import {
   generateId,
   generateIdFromPath,
@@ -37,6 +38,14 @@ import type { DraftState } from '../lib/persistence'
 // Track chat panel state before preview mode so we can restore on promote
 let chatPanelStateBeforePreview: boolean | null = null
 
+function restoreAfterPreviewBrowsing(): void {
+  useEditorStore.getState().setPreviewTab(false)
+  if (chatPanelStateBeforePreview !== null) {
+    useChatStore.getState().setPanelOpen(chatPanelStateBeforePreview)
+    chatPanelStateBeforePreview = null
+  }
+}
+
 /**
  * Promote the current preview tab to permanent and restore UI state.
  * Can be called from outside the hook (e.g., Editor mousedown handler).
@@ -46,11 +55,7 @@ export function promoteCurrentPreview(): void {
   if (previewTab) {
     useTabStore.getState().promotePreviewTab(previewTab.id)
   }
-  useEditorStore.getState().setPreviewTab(false)
-  if (chatPanelStateBeforePreview !== null) {
-    useChatStore.getState().setPanelOpen(chatPanelStateBeforePreview)
-    chatPanelStateBeforePreview = null
-  }
+  restoreAfterPreviewBrowsing()
 }
 
 export function useTabs() {
@@ -360,8 +365,21 @@ export function useTabs() {
     useAnnotationStore.getState().setLoadingDocument(true)
 
     // Read file content
-    if (!window.api) return false
-    const rawContent = await window.api.readFile(filePath)
+    if (!window.api) {
+      useAnnotationStore.getState().setLoadingDocument(false)
+      return false
+    }
+    let rawContent: string
+    try {
+      rawContent = await window.api.readFile(filePath)
+    } catch (error) {
+      useAnnotationStore.getState().setLoadingDocument(false)
+      if (isMissingPathFileError(error)) {
+        handleMissingPath(filePath, 'open')
+      }
+      console.error('[useTabs] Failed to open file:', error)
+      return false
+    }
     const isTxt = filePath.endsWith('.txt')
     const parsed = parseMarkdown(isTxt ? prepareTextContent(rawContent) : rawContent)
 
@@ -490,10 +508,21 @@ export function useTabs() {
 
     // Read file content
     if (!window.api) {
-      useEditorStore.getState().setPreviewTab(false)
+      restoreAfterPreviewBrowsing()
       return false
     }
-    const rawContent = await window.api.readFile(filePath)
+    let rawContent: string
+    try {
+      rawContent = await window.api.readFile(filePath)
+    } catch (error) {
+      restoreAfterPreviewBrowsing()
+      useAnnotationStore.getState().setLoadingDocument(false)
+      if (isMissingPathFileError(error)) {
+        handleMissingPath(filePath, 'open')
+      }
+      console.error('[useTabs] Failed to preview file:', error)
+      return false
+    }
     const isTxt = filePath.endsWith('.txt')
     const parsed = parseMarkdown(isTxt ? prepareTextContent(rawContent) : rawContent)
     const newDocumentId = await generateIdFromPath(filePath)

--- a/src/renderer/lib/stalePath.ts
+++ b/src/renderer/lib/stalePath.ts
@@ -1,0 +1,66 @@
+import { isMissingPathFileError } from '../../shared/fileOperationResult'
+import { useNotificationStore } from '../stores/notificationStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { getApi } from './browserApi'
+
+type MissingPathContext = 'open' | 'save' | 'autosave' | 'restore'
+
+function fileName(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path
+}
+
+function missingPathMessage(path: string, context: MissingPathContext): string {
+  const name = fileName(path)
+  if (context === 'save') {
+    return `The folder for "${name}" no longer exists. Choose a new location to save it.`
+  }
+  if (context === 'autosave') {
+    return `Autosave stopped because the folder for "${name}" no longer exists. Use Save As to keep your edits.`
+  }
+  if (context === 'restore') {
+    return `"${name}" no longer exists. Restored its last saved tab content as an unsaved document.`
+  }
+  return `"${name}" no longer exists. It was removed from Recents.`
+}
+
+export { isMissingPathFileError }
+
+export function notifyMissingPath(path: string, context: MissingPathContext): void {
+  useNotificationStore.getState().notify({
+    id: `missing-path:${context}:${path}`,
+    message: missingPathMessage(path, context),
+    durationMs: context === 'autosave' || context === 'restore' ? 0 : undefined
+  })
+}
+
+export function pruneRecentFile(path: string): void {
+  useSettingsStore.getState().removeRecentFile(path)
+}
+
+export function handleMissingPath(path: string, context: MissingPathContext): void {
+  pruneRecentFile(path)
+  notifyMissingPath(path, context)
+}
+
+export async function pruneMissingRecentFiles(paths: string[]): Promise<void> {
+  if (paths.length === 0) return
+  if (!window.api?.fileExists) return
+
+  const api = getApi()
+  const stalePaths: string[] = []
+
+  await Promise.all(
+    paths.map(async (path) => {
+      try {
+        const exists = await api.fileExists(path)
+        if (!exists) stalePaths.push(path)
+      } catch {
+        stalePaths.push(path)
+      }
+    })
+  )
+
+  if (stalePaths.length > 0) {
+    useSettingsStore.getState().pruneRecentFiles(stalePaths)
+  }
+}

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -478,17 +478,21 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
 
   pruneRecentFiles: (paths) => {
     const stale = new Set(paths)
+    let changed = false
     set((state) => {
       const current = state.settings.recentFiles || []
       const filtered = current.filter((p) => !stale.has(p))
       if (filtered.length === current.length) return state
+      changed = true
       return {
         settings: { ...state.settings, recentFiles: filtered }
       }
     })
-    get().saveSettings().then(() => {
-      window.api?.refreshRecentMenu()
-    })
+    if (changed) {
+      get().saveSettings().then(() => {
+        window.api?.refreshRecentMenu()
+      })
+    }
   },
 
   setFeatureFlag: (flag, enabled) => {

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -91,6 +91,7 @@ interface SettingsState {
   toggleAutosaveActive: () => void
   addRecentFile: (path: string) => void
   removeRecentFile: (path: string) => void
+  pruneRecentFiles: (paths: string[]) => void
   setErrorTracking: (enabled: boolean) => void
   setFeatureFlag: (flag: keyof NonNullable<Settings['featureFlags']>, enabled: boolean) => void
   setAIConsent: (consented: boolean) => void
@@ -470,7 +471,24 @@ export const useSettingsStore = create<SettingsState>()(subscribeWithSelector((s
         settings: { ...state.settings, recentFiles: filtered }
       }
     })
-    get().saveSettings()
+    get().saveSettings().then(() => {
+      window.api?.refreshRecentMenu()
+    })
+  },
+
+  pruneRecentFiles: (paths) => {
+    const stale = new Set(paths)
+    set((state) => {
+      const current = state.settings.recentFiles || []
+      const filtered = current.filter((p) => !stale.has(p))
+      if (filtered.length === current.length) return state
+      return {
+        settings: { ...state.settings, recentFiles: filtered }
+      }
+    })
+    get().saveSettings().then(() => {
+      window.api?.refreshRecentMenu()
+    })
   },
 
   setFeatureFlag: (flag, enabled) => {

--- a/src/shared/fileOperationResult.ts
+++ b/src/shared/fileOperationResult.ts
@@ -1,0 +1,70 @@
+export interface FileOperationSuccess {
+  ok: true
+}
+
+export interface FileReadSuccess extends FileOperationSuccess {
+  content: string
+}
+
+export interface FileOperationFailure {
+  ok: false
+  code: string
+  path: string
+  message: string
+}
+
+export type SaveFileResult = FileOperationSuccess | FileOperationFailure
+export type ReadFileResult = FileReadSuccess | FileOperationFailure
+
+function readErrorCode(error: unknown): string {
+  const code = (error as { code?: unknown } | null)?.code
+  return typeof code === 'string' && code.length > 0 ? code : 'UNKNOWN'
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  const message = (error as { message?: unknown } | null)?.message
+  return typeof message === 'string' && message.length > 0
+    ? message
+    : 'File operation failed'
+}
+
+export function toFileOperationFailure(path: string, error: unknown): FileOperationFailure {
+  return {
+    ok: false,
+    code: readErrorCode(error),
+    path,
+    message: readErrorMessage(error)
+  }
+}
+
+export function isFileOperationFailure(error: unknown): error is FileOperationFailure {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { ok?: unknown }).ok === false &&
+    typeof (error as { code?: unknown }).code === 'string' &&
+    typeof (error as { path?: unknown }).path === 'string'
+  )
+}
+
+export function isMissingPathFileError(error: unknown): boolean {
+  if (isFileOperationFailure(error)) {
+    return error.code === 'ENOENT' || error.code === 'ENOTDIR'
+  }
+
+  const code = (error as { code?: unknown } | null)?.code
+  if (code === 'ENOENT' || code === 'ENOTDIR') return true
+
+  const message = readErrorMessage(error).toLowerCase()
+  return message.includes('enoent') || message.includes('no such file or directory')
+}
+
+export function unwrapSaveFileResult(result: SaveFileResult): void {
+  if (!result.ok) throw result
+}
+
+export function unwrapReadFileResult(result: ReadFileResult): string {
+  if (!result.ok) throw result
+  return result.content
+}


### PR DESCRIPTION
## Summary

Treats missing read/save targets as recoverable **stale-path** states instead of raw IPC failures. When a document's file or its parent folder no longer exists, Prose now notifies the user, prunes dead Recents entries, keeps unsaved edits dirty, and routes manual saves through Save As — instead of throwing an uncaught `ENOENT` and silently failing (Closes #727).

## Changes

**Structured file-operation results**
- `file:save` and `file:read` now return structured success/failure results from the main process (`src/shared/fileOperationResult.ts`, `src/main/ipc.ts`).
- The preload layer unwraps those results so existing renderer callers keep using `saveFile()` / `readFile()` with their current signatures (`src/preload/index.ts`).

**Stale read/save failure handling**
- Renderer detects `ENOENT`/`ENOTDIR`, shows a toast, removes the stale Recents entry, and prevents unhandled promise rejections (`src/renderer/lib/stalePath.ts`, `Editor.tsx`, `FileListPanel.tsx`, `useEditor.ts`).
- Manual saves to a missing target are rerouted through Save As while the document stays dirty.

**Recovery paths**
- **Recents**: dead entries are pruned when their target is gone.
- **Session**: restored tabs whose saved path is missing are converted into dirty unsaved tabs from cached session content (`App.tsx`, `useTabs.ts`, `settingsStore.ts`).
- **Autosave**: repeated retries against a failed path are blocked until the document path changes (`useAutosave.ts`).

## Testing

- `npm run build`
- `npm run typecheck:e2e`
- `npm run test:e2e:dev -- e2e/electron.stale-paths.spec.ts --workers=1 --retries=0`
- `npm run test:e2e` — 47 passed, 5 skipped, 2 flaky editor tests passed on retry
- Regression coverage: `e2e/electron.stale-paths.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
