### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prose",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prose",
-      "version": "1.6.5",
+      "version": "1.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "description": "A minimal markdown editor with AI chat",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump for the v1.7.0 release (reMarkable typed-text sync, PR #807). Tag `v1.7.0` will be pushed after this merges to trigger the signed+notarized GitHub Release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)